### PR TITLE
Adicionar pré-visualização e corrigir download de anexos de formalização

### DIFF
--- a/src/components/formalizacao/FormalizacaoEvidence.tsx
+++ b/src/components/formalizacao/FormalizacaoEvidence.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { Upload, Link2, Trash2, File, Image, FileText, ExternalLink, Plus } from 'lucide-react';
+import { Upload, File, Image, FileText, ExternalLink, Plus, Eye, Download, Link2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -16,6 +16,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import { DocumentViewer } from '@/components/DocumentViewer';
 import { 
   uploadFormalizationAttachment, 
   getAttachmentUrl, 
@@ -61,6 +62,10 @@ export function FormalizacaoEvidence({
   const [uploading, setUploading] = useState(false);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [newLink, setNewLink] = useState({ kind: 'other' as EvidenceLinkKind, url: '', description: '' });
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewingId, setPreviewingId] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewFile, setPreviewFile] = useState<{ name: string; mimeType: string; storagePath: string } | null>(null);
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -103,7 +108,10 @@ export function FormalizacaoEvidence({
 
   const handleDownload = async (storagePath: string, filename: string) => {
     try {
-      await downloadAttachment(storagePath, filename);
+      const downloaded = await downloadAttachment(storagePath, filename);
+      if (!downloaded) {
+        throw new Error('Falha ao gerar URL de download');
+      }
     } catch (error) {
       toast({
         title: 'Erro',
@@ -111,6 +119,28 @@ export function FormalizacaoEvidence({
         variant: 'destructive',
       });
     }
+  };
+
+  const handlePreview = async (attachmentId: string, storagePath: string, filename: string, mimeType: string) => {
+    setPreviewOpen(true);
+    setPreviewingId(attachmentId);
+    setPreviewUrl(null);
+    setPreviewFile({ name: filename, mimeType, storagePath });
+
+    const url = await getAttachmentUrl(storagePath);
+    if (!url) {
+      toast({
+        title: 'Erro',
+        description: 'Não foi possível carregar a pré-visualização do anexo.',
+        variant: 'destructive',
+      });
+      setPreviewingId(null);
+      setPreviewOpen(false);
+      return;
+    }
+
+    setPreviewUrl(url);
+    setPreviewingId(null);
   };
 
   const handleAddLink = async () => {
@@ -210,9 +240,24 @@ export function FormalizacaoEvidence({
                   <Button
                     variant="ghost"
                     size="sm"
+                    onClick={() => handlePreview(
+                      attachment.id,
+                      attachment.storage_path,
+                      attachment.original_filename,
+                      attachment.mime_type
+                    )}
+                    aria-label={`Pré-visualizar ${attachment.original_filename}`}
+                  >
+                    <Eye className="h-4 w-4 mr-2" />
+                    Ver
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => handleDownload(attachment.storage_path, attachment.original_filename)}
                     aria-label={`Baixar ${attachment.original_filename}`}
                   >
+                    <Download className="h-4 w-4 mr-2" />
                     Baixar
                   </Button>
                 </div>
@@ -221,6 +266,50 @@ export function FormalizacaoEvidence({
           )}
         </CardContent>
       </Card>
+
+      <Dialog
+        open={previewOpen}
+        onOpenChange={(open) => {
+          setPreviewOpen(open);
+          if (!open) {
+            setPreviewUrl(null);
+            setPreviewFile(null);
+            setPreviewingId(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-4xl w-[95vw] h-[90dvh] max-h-[95dvh] p-0 flex flex-col">
+          <DialogHeader className="p-4 border-b border-border">
+            <DialogTitle className="text-base truncate">
+              {previewFile?.name ?? 'Pré-visualização do anexo'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 overflow-hidden">
+            {previewingId ? (
+              <div className="h-full flex items-center justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+              </div>
+            ) : previewUrl && previewFile ? (
+              <DocumentViewer
+                url={previewUrl}
+                title={previewFile.name}
+                mimeType={previewFile.mimeType}
+                className="h-full rounded-none border-0"
+              />
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center text-muted-foreground gap-4 px-6 text-center">
+                <p>Não foi possível carregar a pré-visualização.</p>
+                {previewFile && (
+                  <Button onClick={() => handleDownload(previewFile.storagePath, previewFile.name)} variant="outline">
+                    <Download className="h-4 w-4 mr-2" />
+                    Baixar arquivo
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Evidence Links */}
       <Card>


### PR DESCRIPTION
### Motivation
- Usuários não conseguiam visualizar nem sempre baixar anexos na aba de evidências de formalizações; o objetivo é habilitar preview inline e tornar o download mais robusto.

### Description
- Implementa pré-visualização de anexos em `src/components/formalizacao/FormalizacaoEvidence.tsx` usando um modal com `DocumentViewer` e novos estados `previewOpen`, `previewUrl`, `previewFile` e `previewingId`.
- Adiciona a ação `Ver` que chama a nova função `handlePreview` e obtém a URL assinada via `getAttachmentUrl`, e separa a ação `Baixar` que usa `handleDownload`.
- Melhora o tratamento de erro no download validando o retorno de `downloadAttachment` e exibindo um `toast` em caso de falha.
- Mantém invalidação de cache após upload chamando `queryClient.invalidateQueries({ queryKey: ['formalizacao', formalizationId] })` para atualizar a lista de anexos.

### Testing
- Tentativa de lint com `npm run lint -- src/components/formalizacao/FormalizacaoEvidence.tsx` falhou devido a dependência de ambiente ausente (`@eslint/js`).
- Tentativa de instalar dependências com `npm ci` falhou porque `package-lock.json` está fora de sincronia com `package.json` (erro de lockfile). 
- Tentativa alternativa `npm install --package-lock=false` falhou com erro 403 ao acessar o registry (restrição do ambiente).
- Tentativa de executar `npm run dev` falhou porque `vite` não está disponível sem instalação das dependências.
- Nenhum teste automatizado foi executado com sucesso no ambiente devido às limitações acima.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999d45f4df083248198f8aa6f368645)