### PR TITLE
feat(painel-obras): Prazo como select + novas etapas + status Aguardando

### DIFF
--- a/src/hooks/usePainelObras.ts
+++ b/src/hooks/usePainelObras.ts
@@ -20,11 +20,28 @@ export type PainelEtapa =
   | 'Emissão RRT'
   | 'Condomínio'
   | 'Planejamento'
-  | 'Mobilização';
+  | 'Mobilização'
+  | 'Execução'
+  | 'Vistoria'
+  | 'Vistoria reprovada'
+  | 'Finalizada';
 
-export type PainelStatus = 'Em dia' | 'Atrasado' | 'Paralisada';
+export type PainelStatus = 'Aguardando' | 'Em dia' | 'Atrasado' | 'Paralisada';
 
 export type PainelRelacionamento = 'Normal' | 'Atrito' | 'Insatisfeito' | 'Crítico';
+
+/**
+ * Prazo é armazenado como text livre (painel_prazo) mas editado via select
+ * controlado no painel. Mantemos a lista aqui como fonte única de verdade.
+ */
+export type PainelPrazo = '55 dias' | '60 dias' | '65 dias' | '75 dias';
+
+export const PAINEL_PRAZO_OPTIONS: PainelPrazo[] = [
+  '55 dias',
+  '60 dias',
+  '65 dias',
+  '75 dias',
+];
 
 /** Linha unificada do Painel: dados da obra + campos operacionais + métricas. */
 export interface PainelObra {
@@ -54,6 +71,11 @@ export interface PainelObra {
   overdue_count: number;
 }
 
+/**
+ * Ordem canônica das etapas (reflete o ciclo de vida de uma obra).
+ * A primeira etapa (`Medição`) espelha o início oficial via cronograma;
+ * a última etapa (`Finalizada`) indica entrega consolidada.
+ */
 export const ETAPA_OPTIONS: PainelEtapa[] = [
   'Medição',
   'Executivo',
@@ -61,9 +83,18 @@ export const ETAPA_OPTIONS: PainelEtapa[] = [
   'Condomínio',
   'Planejamento',
   'Mobilização',
+  'Execução',
+  'Vistoria',
+  'Vistoria reprovada',
+  'Finalizada',
 ];
 
-export const STATUS_OPTIONS: PainelStatus[] = ['Em dia', 'Atrasado', 'Paralisada'];
+export const STATUS_OPTIONS: PainelStatus[] = [
+  'Aguardando',
+  'Em dia',
+  'Atrasado',
+  'Paralisada',
+];
 
 export const RELACIONAMENTO_OPTIONS: PainelRelacionamento[] = [
   'Normal',
@@ -174,7 +205,15 @@ export function usePainelObras() {
             if (p.id !== id) return p;
             const next: Record<string, unknown> = { ...p };
             if ('prazo' in patch) next.painel_prazo = patch.prazo;
-            if ('etapa' in patch) next.painel_etapa = patch.etapa;
+            if ('etapa' in patch) {
+              next.painel_etapa = patch.etapa;
+              // Espelha o trigger do banco: ao mudar a etapa, início da
+              // etapa é "hoje" — a menos que o caller tenha enviado um
+              // valor explícito no mesmo patch.
+              if (!('inicio_etapa' in patch)) {
+                next.painel_inicio_etapa = new Date().toISOString().slice(0, 10);
+              }
+            }
             if ('inicio_etapa' in patch) next.painel_inicio_etapa = patch.inicio_etapa;
             if ('previsao_avanco' in patch) next.painel_previsao_avanco = patch.previsao_avanco;
             if ('status' in patch) next.painel_status = patch.status;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6014,12 +6014,16 @@ export type Database = {
         | "Condomínio"
         | "Planejamento"
         | "Mobilização"
+        | "Execução"
+        | "Vistoria"
+        | "Vistoria reprovada"
+        | "Finalizada"
       painel_relacionamento_enum:
         | "Normal"
         | "Atrito"
         | "Insatisfeito"
         | "Crítico"
-      painel_status_enum: "Em dia" | "Atrasado" | "Paralisada"
+      painel_status_enum: "Aguardando" | "Em dia" | "Atrasado" | "Paralisada"
       party_type: "customer" | "company"
       pending_item_status: "pending" | "completed" | "cancelled"
       pending_item_type:
@@ -6278,6 +6282,10 @@ export const Constants = {
         "Condomínio",
         "Planejamento",
         "Mobilização",
+        "Execução",
+        "Vistoria",
+        "Vistoria reprovada",
+        "Finalizada",
       ],
       painel_relacionamento_enum: [
         "Normal",
@@ -6285,7 +6293,7 @@ export const Constants = {
         "Insatisfeito",
         "Crítico",
       ],
-      painel_status_enum: ["Em dia", "Atrasado", "Paralisada"],
+      painel_status_enum: ["Aguardando", "Em dia", "Atrasado", "Paralisada"],
       party_type: ["customer", "company"],
       pending_item_status: ["pending", "completed", "cancelled"],
       pending_item_type: [

--- a/src/pages/PainelObras.tsx
+++ b/src/pages/PainelObras.tsx
@@ -15,13 +15,11 @@ import {
   Table2,
   ShieldOff,
   ExternalLink,
-  Pencil,
   ChevronDown,
 } from 'lucide-react';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
@@ -60,12 +58,14 @@ import { cn } from '@/lib/utils';
 import { useUserRole } from '@/hooks/useUserRole';
 import {
   ETAPA_OPTIONS,
+  PAINEL_PRAZO_OPTIONS,
   RELACIONAMENTO_OPTIONS,
   STATUS_OPTIONS,
   usePainelObras,
   type PainelEtapa,
   type PainelObra,
   type PainelObraPatch,
+  type PainelPrazo,
   type PainelRelacionamento,
   type PainelStatus,
 } from '@/hooks/usePainelObras';
@@ -86,6 +86,8 @@ const toIsoDate = (d: Date | undefined) => (d ? format(d, 'yyyy-MM-dd') : null);
 /** Cor sólida para o "dot" e badge tipo Monday (sem hover ruidoso). */
 const statusDotClass = (s: PainelStatus | null): string => {
   switch (s) {
+    case 'Aguardando':
+      return 'bg-sky-500';
     case 'Em dia':
       return 'bg-emerald-500';
     case 'Atrasado':
@@ -99,6 +101,8 @@ const statusDotClass = (s: PainelStatus | null): string => {
 
 const statusPillClass = (s: PainelStatus | null): string => {
   switch (s) {
+    case 'Aguardando':
+      return 'bg-sky-500/15 text-sky-700 dark:text-sky-400 border border-sky-500/30';
     case 'Em dia':
       return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border border-emerald-500/30';
     case 'Atrasado':
@@ -232,58 +236,6 @@ function DateCell({ value, onChange, confirmEdit, confirmTitle, disabled }: Date
   );
 }
 
-// ----- inline text cell -----
-function TextCell({
-  value,
-  onSave,
-  placeholder,
-}: {
-  value: string | null;
-  onSave: (v: string | null) => void;
-  placeholder?: string;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(value ?? '');
-
-  if (editing) {
-    return (
-      <Input
-        autoFocus
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => {
-          setEditing(false);
-          const next = draft.trim() || null;
-          if (next !== value) onSave(next);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-          if (e.key === 'Escape') {
-            setDraft(value ?? '');
-            setEditing(false);
-          }
-        }}
-        className="h-7 text-sm"
-      />
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => setEditing(true)}
-      className={cn(
-        editableCell,
-        'flex items-center gap-1.5',
-        !value && 'text-muted-foreground italic',
-      )}
-    >
-      <Pencil className="h-3 w-3 shrink-0 opacity-0 group-hover/cell:opacity-60 transition-opacity" />
-      <span className="truncate">{value ?? placeholder ?? '—'}</span>
-    </button>
-  );
-}
-
 // ----- main page -----
 export default function PainelObras() {
   const navigate = useNavigate();
@@ -370,12 +322,13 @@ export default function PainelObras() {
   // Resumo executivo no topo (densidade de informação)
   const summary = useMemo(() => {
     const total = obras.length;
+    const aguardando = obras.filter((o) => o.status === 'Aguardando').length;
     const emDia = obras.filter((o) => o.status === 'Em dia').length;
     const atrasadas = obras.filter((o) => o.status === 'Atrasado').length;
     const paralisadas = obras.filter((o) => o.status === 'Paralisada').length;
     const pendencias = obras.reduce((s, o) => s + o.pending_count, 0);
     const atrasos = obras.reduce((s, o) => s + o.overdue_count, 0);
-    return { total, emDia, atrasadas, paralisadas, pendencias, atrasos };
+    return { total, aguardando, emDia, atrasadas, paralisadas, pendencias, atrasos };
   }, [obras]);
 
   if (roleLoading) {
@@ -434,6 +387,7 @@ export default function PainelObras() {
             </div>
             <div className="flex items-center gap-2 text-xs flex-wrap">
               <KpiPill label="Total" value={summary.total} />
+              <KpiPill label="Aguardando" value={summary.aguardando} dot="bg-sky-500" />
               <KpiPill label="Em dia" value={summary.emDia} dot="bg-emerald-500" />
               <KpiPill label="Atrasadas" value={summary.atrasadas} dot="bg-destructive" />
               <KpiPill label="Paralisadas" value={summary.paralisadas} dot="bg-muted-foreground" />
@@ -723,6 +677,10 @@ function ObraRow({ obra, onUpdate, onOpen }: ObraRowProps) {
             className={cn(
               'h-7 text-xs border-0 shadow-none hover:bg-accent/60 [&>svg]:opacity-40',
               !obra.etapa && 'text-muted-foreground italic',
+              obra.etapa === 'Finalizada' &&
+                'text-emerald-700 dark:text-emerald-400 font-medium',
+              obra.etapa === 'Vistoria reprovada' &&
+                'text-destructive font-medium',
             )}
           >
             <SelectValue placeholder="Definir…" />
@@ -731,7 +689,14 @@ function ObraRow({ obra, onUpdate, onOpen }: ObraRowProps) {
             <SelectItem value={NONE}>(nenhuma)</SelectItem>
             {ETAPA_OPTIONS.map((e) => (
               <SelectItem key={e} value={e}>
-                {e}
+                <span
+                  className={cn(
+                    e === 'Finalizada' && 'text-emerald-700 dark:text-emerald-400 font-medium',
+                    e === 'Vistoria reprovada' && 'text-destructive font-medium',
+                  )}
+                >
+                  {e}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>
@@ -798,9 +763,31 @@ function ObraRow({ obra, onUpdate, onOpen }: ObraRowProps) {
         )}
       </TableCell>
 
-      {/* Prazo - texto livre */}
+      {/* Prazo - select controlado (55/60/65/75 dias) */}
       <TableCell>
-        <TextCell value={obra.prazo} onSave={(v) => onUpdate({ prazo: v })} placeholder="Definir…" />
+        <Select
+          value={obra.prazo ?? NONE}
+          onValueChange={(v) =>
+            onUpdate({ prazo: v === NONE ? null : (v as PainelPrazo) })
+          }
+        >
+          <SelectTrigger
+            className={cn(
+              'h-7 text-xs border-0 shadow-none hover:bg-accent/60 [&>svg]:opacity-40 tabular-nums',
+              !obra.prazo && 'text-muted-foreground italic',
+            )}
+          >
+            <SelectValue placeholder="Definir…" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE}>(nenhum)</SelectItem>
+            {PAINEL_PRAZO_OPTIONS.map((p) => (
+              <SelectItem key={p} value={p} className="tabular-nums">
+                {p}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </TableCell>
 
       {/* Início oficial - exige confirmação */}

--- a/supabase/migrations/20260422145000_painel_obras_novos_campos.sql
+++ b/supabase/migrations/20260422145000_painel_obras_novos_campos.sql
@@ -1,0 +1,109 @@
+-- =========================================================================
+-- Painel de Obras — expansão dos enums e prazo como select controlado
+-- =========================================================================
+-- Contexto:
+--   1. Adicionar novas etapas: Execução, Vistoria, Vistoria reprovada, Finalizada
+--   2. Adicionar novo status "Aguardando" (será o default quando não houver valor)
+--   3. Converter painel_prazo de texto livre para select com opções fixas
+--      (55, 60, 65, 75 dias). Mantido como text para permanecer flexível
+--      caso o negócio precise incluir novas faixas — a validação é feita no
+--      front-end via constante PAINEL_PRAZO_OPTIONS.
+--   4. Trigger: ao mudar painel_etapa, define painel_inicio_etapa = CURRENT_DATE
+--      automaticamente (se o valor não for fornecido na mesma UPDATE).
+-- =========================================================================
+
+-- ------------------------------------------------------------------
+-- 1) Adicionar novas labels ao enum de Etapa
+-- ------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'Execução'
+      AND enumtypid = 'public.painel_etapa_enum'::regtype
+  ) THEN
+    ALTER TYPE public.painel_etapa_enum ADD VALUE 'Execução';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'Vistoria'
+      AND enumtypid = 'public.painel_etapa_enum'::regtype
+  ) THEN
+    ALTER TYPE public.painel_etapa_enum ADD VALUE 'Vistoria';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'Vistoria reprovada'
+      AND enumtypid = 'public.painel_etapa_enum'::regtype
+  ) THEN
+    ALTER TYPE public.painel_etapa_enum ADD VALUE 'Vistoria reprovada';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'Finalizada'
+      AND enumtypid = 'public.painel_etapa_enum'::regtype
+  ) THEN
+    ALTER TYPE public.painel_etapa_enum ADD VALUE 'Finalizada';
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------------
+-- 2) Adicionar novo status "Aguardando"
+-- ------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'Aguardando'
+      AND enumtypid = 'public.painel_status_enum'::regtype
+  ) THEN
+    ALTER TYPE public.painel_status_enum ADD VALUE 'Aguardando' BEFORE 'Em dia';
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------------
+-- 3) Trigger: ao alterar painel_etapa, grava painel_inicio_etapa = hoje
+-- ------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_painel_inicio_etapa_on_etapa_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Só dispara se a etapa mudou E o caller não forneceu inicio_etapa
+  -- explícito na mesma UPDATE (permite override manual).
+  IF NEW.painel_etapa IS DISTINCT FROM OLD.painel_etapa
+     AND NEW.painel_inicio_etapa IS NOT DISTINCT FROM OLD.painel_inicio_etapa
+  THEN
+    NEW.painel_inicio_etapa := CURRENT_DATE;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_projects_painel_inicio_etapa ON public.projects;
+CREATE TRIGGER trg_projects_painel_inicio_etapa
+BEFORE UPDATE OF painel_etapa ON public.projects
+FOR EACH ROW
+EXECUTE FUNCTION public.set_painel_inicio_etapa_on_etapa_change();
+
+-- ------------------------------------------------------------------
+-- 4) (opcional) Comentários documentando o domínio
+-- ------------------------------------------------------------------
+COMMENT ON COLUMN public.projects.painel_prazo IS
+  'Prazo da obra como label livre. Front-end restringe a 55, 60, 65 ou 75 dias (PAINEL_PRAZO_OPTIONS).';
+COMMENT ON COLUMN public.projects.painel_inicio_etapa IS
+  'Data de início da etapa atual. Preenchida automaticamente por trigger ao mudar painel_etapa.';


### PR DESCRIPTION
## O que mudou

Atualização do Painel de Obras (admin) conforme brief.

### Campos do painel

| Coluna | Antes | Depois |
|---|---|---|
| **Cliente / Obra** | Cliente em destaque + nome da obra abaixo em fonte menor | Mantido |
| **Status** | Em dia · Atrasado · Paralisada | **Aguardando** · Em dia · Atrasado · Paralisada |
| **Etapa** | 6 valores | **+ Execução · Vistoria · Vistoria reprovada · Finalizada** |
| **Prazo** | Texto livre (TextCell) | **Select controlado**: 55, 60, 65 ou 75 dias |
| **Início da Etapa** | Data editável | **Preenchido automaticamente** com a data de hoje quando a etapa muda (trigger no banco + optimistic no front) |
| Demais campos de data | — | Mantidos (edição inline com calendário) |

### UX

- **Prazo** agora apresenta opções fixas, evitando divergência entre obras.
- **Etapa 'Finalizada'** ganha destaque verde, e **'Vistoria reprovada'** destaque vermelho — leitura imediata do estado terminal.
- **KPI 'Aguardando'** adicionado no resumo executivo.
- **Hover e ring de foco** preservados; nenhuma regressão no padrão `editableCell`.
- Remoção do componente `TextCell` (não mais necessário) e limpeza de imports.

### Banco (migration inclusa)

Arquivo: `supabase/migrations/20260422145000_painel_obras_novos_campos.sql`

1. `ALTER TYPE painel_etapa_enum ADD VALUE` para as 4 novas etapas.
2. `ALTER TYPE painel_status_enum ADD VALUE 'Aguardando' BEFORE 'Em dia'`.
3. Trigger `set_painel_inicio_etapa_on_etapa_change` em `projects`: ao mudar `painel_etapa` sem fornecer `painel_inicio_etapa`, grava `CURRENT_DATE`.
4. Comentários nas colunas documentando o domínio.

Tipos do Supabase (`src/integrations/supabase/types.ts`) também atualizados para refletir os novos valores.

### Validação

- `npx tsc -b --noEmit` ✅
- `npx eslint` ✅ (sem warnings após remoção do `Badge` não usado)
- `vite build` ✅

### Observações

- A sincronização de **Início Oficial** com a primeira etapa do cronograma e **Entrega Oficial** com a última continua via os campos `planned_start_date` / `planned_end_date` da `projects` (arquitetura existente). Não houve mudança nesse fluxo — as datas já são as mesmas que alimentam o cronograma.
- O `painel_prazo` permanece `text` no banco (em vez de enum) para manter flexibilidade caso o negócio adicione novas faixas. A restrição vem do front via `PAINEL_PRAZO_OPTIONS`.
