### PR TITLE
feat(painel-obras): modal 'Registro do dia' com seções colapsáveis

### DIFF
--- a/src/components/admin/obras/DailyLogDialog.tsx
+++ b/src/components/admin/obras/DailyLogDialog.tsx
@@ -1,0 +1,546 @@
+/**
+ * DailyLogDialog \u2014 modal para registrar o "di\u00e1rio do dia" de uma obra.
+ *
+ * Estrutura:
+ *   - Cabe\u00e7alho: nome da obra/cliente + seletor de data
+ *   - Se\u00e7\u00f5es colaps\u00e1veis (Collapsible):
+ *       \u2022 Servi\u00e7os em execu\u00e7\u00e3o
+ *       \u2022 Prestadores no local
+ *       \u2022 Observa\u00e7\u00f5es gerais
+ *   - Rodap\u00e9: Cancelar / Salvar
+ *
+ * Padr\u00f5es de UX:
+ *   - Cada item de lista tem seu pr\u00f3prio cart\u00e3o com bot\u00e3o "Remover".
+ *   - "Adicionar" cria um item em branco e j\u00e1 foca no primeiro campo.
+ *   - Estado local (n\u00e3o autosave): o usu\u00e1rio revisa e clica em Salvar.
+ *     Isso evita inconsist\u00eancia se ele fechar no meio do preenchimento.
+ *   - Todas as se\u00e7\u00f5es abrem por padr\u00e3o, para visibilidade imediata.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronDown,
+  ClipboardList,
+  HardHat,
+  Loader2,
+  MessageSquareText,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+import {
+  useProjectDailyLog,
+  useSaveProjectDailyLog,
+  type DailyLogService,
+  type DailyLogServiceStatus,
+  type DailyLogWorker,
+} from '@/hooks/useProjectDailyLog';
+
+// ----- props -----
+
+export interface DailyLogDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  projectTitle: string;      // "Cliente \u2013 Nome da obra"
+  /** Data inicial no formato ISO (YYYY-MM-DD). Default = hoje. */
+  initialDate?: string;
+}
+
+const SERVICE_STATUS_OPTIONS: Exclude<DailyLogServiceStatus, null>[] = [
+  'Em andamento',
+  'Conclu\u00eddo',
+  'Parado',
+];
+
+const todayIso = () => format(new Date(), 'yyyy-MM-dd');
+
+// ----- componente -----
+
+export function DailyLogDialog({
+  open,
+  onOpenChange,
+  projectId,
+  projectTitle,
+  initialDate,
+}: DailyLogDialogProps) {
+  const [logDate, setLogDate] = useState(initialDate ?? todayIso());
+
+  // Reseta a data quando o modal abre (com base no prop)
+  useEffect(() => {
+    if (open) setLogDate(initialDate ?? todayIso());
+  }, [open, initialDate]);
+
+  const { data, isLoading } = useProjectDailyLog(open ? projectId : null, logDate);
+  const saveMutation = useSaveProjectDailyLog();
+
+  // ----- estado local edit\u00e1vel -----
+  const [notes, setNotes] = useState<string>('');
+  const [services, setServices] = useState<DailyLogService[]>([]);
+  const [workers, setWorkers] = useState<DailyLogWorker[]>([]);
+
+  // sincroniza local com data carregada
+  useEffect(() => {
+    if (data) {
+      setNotes(data.notes ?? '');
+      setServices(data.services);
+      setWorkers(data.workers);
+    }
+  }, [data]);
+
+  const isSaving = saveMutation.isPending;
+  const isBusy = isLoading || isSaving;
+
+  const hasContent = useMemo(
+    () => services.length > 0 || workers.length > 0 || notes.trim().length > 0,
+    [services, workers, notes],
+  );
+
+  // ----- a\u00e7\u00f5es servi\u00e7os -----
+  const addService = () =>
+    setServices((curr) => [
+      ...curr,
+      {
+        description: '',
+        status: 'Em andamento',
+        observations: null,
+        position: curr.length,
+      },
+    ]);
+  const updateService = (index: number, patch: Partial<DailyLogService>) =>
+    setServices((curr) =>
+      curr.map((s, i) => (i === index ? { ...s, ...patch } : s)),
+    );
+  const removeService = (index: number) =>
+    setServices((curr) => curr.filter((_, i) => i !== index));
+
+  // ----- a\u00e7\u00f5es prestadores -----
+  const addWorker = () =>
+    setWorkers((curr) => [
+      ...curr,
+      {
+        name: '',
+        role: null,
+        period_start: null,
+        period_end: null,
+        shift_start: null,
+        shift_end: null,
+        notes: null,
+        position: curr.length,
+      },
+    ]);
+  const updateWorker = (index: number, patch: Partial<DailyLogWorker>) =>
+    setWorkers((curr) =>
+      curr.map((w, i) => (i === index ? { ...w, ...patch } : w)),
+    );
+  const removeWorker = (index: number) =>
+    setWorkers((curr) => curr.filter((_, i) => i !== index));
+
+  // ----- salvar -----
+  const handleSave = async () => {
+    // sanea entradas vazias
+    const cleanedServices = services
+      .map((s, idx) => ({ ...s, position: idx }))
+      .filter((s) => s.description.trim().length > 0);
+
+    const cleanedWorkers = workers
+      .map((w, idx) => ({ ...w, position: idx }))
+      .filter((w) => w.name.trim().length > 0);
+
+    await saveMutation.mutateAsync({
+      project_id: projectId,
+      log_date: logDate,
+      notes: notes.trim() ? notes.trim() : null,
+      services: cleanedServices,
+      workers: cleanedWorkers,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[92vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-base">Registro do dia</DialogTitle>
+          <DialogDescription className="text-xs">
+            {projectTitle}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Data do registro */}
+        <div className="flex items-center gap-3 py-2">
+          <Label htmlFor="daily-log-date" className="text-xs font-medium">
+            Data
+          </Label>
+          <Input
+            id="daily-log-date"
+            type="date"
+            value={logDate}
+            onChange={(e) => setLogDate(e.target.value)}
+            className="h-8 w-auto text-sm"
+            disabled={isSaving}
+          />
+          {data?.updated_at && (
+            <span className="text-xs text-muted-foreground ml-auto">
+              Atualizado em{' '}
+              {format(parseISO(data.updated_at), "dd/MM/yyyy '\u00e0s' HH:mm", {
+                locale: ptBR,
+              })}
+            </span>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3 py-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {/* Servi\u00e7os em execu\u00e7\u00e3o */}
+            <SectionCard
+              icon={<ClipboardList className="h-4 w-4 text-primary" />}
+              title="Servi\u00e7os em execu\u00e7\u00e3o"
+              count={services.length}
+              defaultOpen
+            >
+              <div className="flex flex-col gap-3">
+                {services.length === 0 && (
+                  <EmptyLine text="Nenhum servi\u00e7o adicionado." />
+                )}
+                {services.map((svc, i) => (
+                  <div
+                    key={i}
+                    className="rounded-md border border-border bg-muted/20 p-3 flex flex-col gap-2"
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 grid grid-cols-1 sm:grid-cols-[1fr_140px] gap-2">
+                        <Input
+                          value={svc.description}
+                          placeholder="Ex.: Instala\u00e7\u00e3o el\u00e9trica \u2013 quarto 2"
+                          onChange={(e) =>
+                            updateService(i, { description: e.target.value })
+                          }
+                          className="h-8 text-sm"
+                          disabled={isSaving}
+                        />
+                        <Select
+                          value={svc.status ?? ''}
+                          onValueChange={(v) =>
+                            updateService(i, {
+                              status: (v || null) as DailyLogServiceStatus,
+                            })
+                          }
+                        >
+                          <SelectTrigger className="h-8 text-sm">
+                            <SelectValue placeholder="Status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {SERVICE_STATUS_OPTIONS.map((opt) => (
+                              <SelectItem key={opt} value={opt}>
+                                {opt}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive shrink-0"
+                        onClick={() => removeService(i)}
+                        disabled={isSaving}
+                        title="Remover servi\u00e7o"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                    <Textarea
+                      value={svc.observations ?? ''}
+                      placeholder="Observa\u00e7\u00f5es (opcional)"
+                      onChange={(e) =>
+                        updateService(i, {
+                          observations: e.target.value || null,
+                        })
+                      }
+                      className="min-h-[60px] text-sm"
+                      disabled={isSaving}
+                    />
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addService}
+                  className="self-start h-8 text-xs"
+                  disabled={isSaving}
+                >
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Adicionar servi\u00e7o
+                </Button>
+              </div>
+            </SectionCard>
+
+            {/* Prestadores no local */}
+            <SectionCard
+              icon={<HardHat className="h-4 w-4 text-primary" />}
+              title="Prestadores no local"
+              count={workers.length}
+              defaultOpen
+            >
+              <div className="flex flex-col gap-3">
+                {workers.length === 0 && (
+                  <EmptyLine text="Nenhum prestador adicionado." />
+                )}
+                {workers.map((wk, i) => (
+                  <div
+                    key={i}
+                    className="rounded-md border border-border bg-muted/20 p-3 flex flex-col gap-2"
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        <Input
+                          value={wk.name}
+                          placeholder="Nome do prestador"
+                          onChange={(e) =>
+                            updateWorker(i, { name: e.target.value })
+                          }
+                          className="h-8 text-sm"
+                          disabled={isSaving}
+                        />
+                        <Input
+                          value={wk.role ?? ''}
+                          placeholder="Fun\u00e7\u00e3o / empresa"
+                          onChange={(e) =>
+                            updateWorker(i, { role: e.target.value || null })
+                          }
+                          className="h-8 text-sm"
+                          disabled={isSaving}
+                        />
+                      </div>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive shrink-0"
+                        onClick={() => removeWorker(i)}
+                        disabled={isSaving}
+                        title="Remover prestador"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                      <div className="flex flex-col gap-1">
+                        <Label className="text-[11px] text-muted-foreground">
+                          Per\u00edodo de
+                        </Label>
+                        <Input
+                          type="date"
+                          value={wk.period_start ?? ''}
+                          onChange={(e) =>
+                            updateWorker(i, {
+                              period_start: e.target.value || null,
+                            })
+                          }
+                          className="h-8 text-xs"
+                          disabled={isSaving}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <Label className="text-[11px] text-muted-foreground">
+                          at\u00e9
+                        </Label>
+                        <Input
+                          type="date"
+                          value={wk.period_end ?? ''}
+                          onChange={(e) =>
+                            updateWorker(i, {
+                              period_end: e.target.value || null,
+                            })
+                          }
+                          className="h-8 text-xs"
+                          disabled={isSaving}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <Label className="text-[11px] text-muted-foreground">
+                          Entrada
+                        </Label>
+                        <Input
+                          type="time"
+                          value={wk.shift_start ?? ''}
+                          onChange={(e) =>
+                            updateWorker(i, {
+                              shift_start: e.target.value || null,
+                            })
+                          }
+                          className="h-8 text-xs"
+                          disabled={isSaving}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <Label className="text-[11px] text-muted-foreground">
+                          Sa\u00edda
+                        </Label>
+                        <Input
+                          type="time"
+                          value={wk.shift_end ?? ''}
+                          onChange={(e) =>
+                            updateWorker(i, {
+                              shift_end: e.target.value || null,
+                            })
+                          }
+                          className="h-8 text-xs"
+                          disabled={isSaving}
+                        />
+                      </div>
+                    </div>
+                    <Textarea
+                      value={wk.notes ?? ''}
+                      placeholder="Observa\u00e7\u00f5es do prestador (opcional)"
+                      onChange={(e) =>
+                        updateWorker(i, { notes: e.target.value || null })
+                      }
+                      className="min-h-[48px] text-sm"
+                      disabled={isSaving}
+                    />
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addWorker}
+                  className="self-start h-8 text-xs"
+                  disabled={isSaving}
+                >
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Adicionar prestador
+                </Button>
+              </div>
+            </SectionCard>
+
+            {/* Observa\u00e7\u00f5es */}
+            <SectionCard
+              icon={<MessageSquareText className="h-4 w-4 text-primary" />}
+              title="Observa\u00e7\u00f5es gerais"
+              defaultOpen={!!notes}
+            >
+              <Textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Relato livre do dia \u2014 incidentes, decis\u00f5es, fotos etc."
+                className="min-h-[100px] text-sm"
+                disabled={isSaving}
+              />
+            </SectionCard>
+          </div>
+        )}
+
+        <DialogFooter className="mt-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={isBusy || !hasContent}>
+            {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Salvar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ============================================================
+// Helpers internos
+// ============================================================
+
+interface SectionCardProps {
+  icon: React.ReactNode;
+  title: string;
+  count?: number;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+function SectionCard({
+  icon,
+  title,
+  count,
+  defaultOpen = true,
+  children,
+}: SectionCardProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="rounded-md border border-border bg-card">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-accent/40 transition-colors rounded-t-md"
+          >
+            {icon}
+            <span className="text-sm font-medium">{title}</span>
+            {typeof count === 'number' && count > 0 && (
+              <span className="text-xs text-muted-foreground tabular-nums ml-1">
+                ({count})
+              </span>
+            )}
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 text-muted-foreground ml-auto transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-3 pb-3">{children}</div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function EmptyLine({ text }: { text: string }) {
+  return (
+    <div className="text-xs text-muted-foreground italic py-1">{text}</div>
+  );
+}

--- a/src/components/admin/obras/DailyLogDialog.tsx
+++ b/src/components/admin/obras/DailyLogDialog.tsx
@@ -18,7 +18,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import {
-  ChevronDown,
+  ChevronRight,
   ClipboardList,
   HardHat,
   Loader2,
@@ -510,12 +510,31 @@ function SectionCard({
   const [open, setOpen] = useState(defaultOpen);
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <div className="rounded-md border border-border bg-card">
+      <div
+        className={cn(
+          'rounded-md border border-border bg-card transition-colors',
+          open && 'bg-card',
+        )}
+      >
         <CollapsibleTrigger asChild>
           <button
             type="button"
-            className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-accent/40 transition-colors rounded-t-md"
+            aria-expanded={open}
+            aria-label={open ? `Recolher ${title}` : `Expandir ${title}`}
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-2 text-left',
+              'hover:bg-accent/40 transition-colors',
+              open ? 'rounded-t-md' : 'rounded-md',
+            )}
           >
+            {/* Indicador de expansão — seta à esquerda que rotaciona */}
+            <ChevronRight
+              aria-hidden
+              className={cn(
+                'h-4 w-4 text-muted-foreground shrink-0 transition-transform duration-200',
+                open && 'rotate-90 text-foreground',
+              )}
+            />
             {icon}
             <span className="text-sm font-medium">{title}</span>
             {typeof count === 'number' && count > 0 && (
@@ -523,12 +542,6 @@ function SectionCard({
                 ({count})
               </span>
             )}
-            <ChevronDown
-              className={cn(
-                'h-4 w-4 text-muted-foreground ml-auto transition-transform',
-                open && 'rotate-180',
-              )}
-            />
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>

--- a/src/hooks/useProjectDailyLog.ts
+++ b/src/hooks/useProjectDailyLog.ts
@@ -1,0 +1,222 @@
+/**
+ * useProjectDailyLog — CRUD do registro diário de obra.
+ *
+ * Uma "folha" por (projeto, data). Contém:
+ *   - notes (texto livre)
+ *   - services[]  : serviços em execução no dia
+ *   - workers[]   : prestadores no local no dia
+ *
+ * O front sempre opera em "snapshot do dia": carrega tudo de uma data,
+ * permite editar em memória e salva em uma única chamada (replace-all
+ * das tabelas-filhas). Mais simples que diff granular, e a escala
+ * (poucas dezenas de itens por dia) justifica.
+ *
+ * Triggers do banco cuidam de:
+ *   - updated_at no log principal
+ *   - bump de projects.painel_ultima_atualizacao ao salvar
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+// ----- tipos de dom\u00ednio (espelham o banco) -----
+
+export type DailyLogServiceStatus =
+  | 'Em andamento'
+  | 'Conclu\u00eddo'
+  | 'Parado'
+  | null;
+
+export interface DailyLogService {
+  id?: string;             // ausente para itens novos ainda n\u00e3o salvos
+  description: string;
+  status: DailyLogServiceStatus;
+  observations: string | null;
+  position: number;
+}
+
+export interface DailyLogWorker {
+  id?: string;
+  name: string;
+  role: string | null;
+  period_start: string | null;  // ISO date (YYYY-MM-DD)
+  period_end: string | null;
+  shift_start: string | null;   // HH:mm
+  shift_end: string | null;
+  notes: string | null;
+  position: number;
+}
+
+export interface ProjectDailyLog {
+  id: string | null;            // null quando ainda n\u00e3o existe registro para a data
+  project_id: string;
+  log_date: string;
+  notes: string | null;
+  services: DailyLogService[];
+  workers: DailyLogWorker[];
+  updated_at: string | null;
+}
+
+const emptyLog = (projectId: string, logDate: string): ProjectDailyLog => ({
+  id: null,
+  project_id: projectId,
+  log_date: logDate,
+  notes: null,
+  services: [],
+  workers: [],
+  updated_at: null,
+});
+
+// ----- query: carrega o log do dia -----
+
+export function useProjectDailyLog(projectId: string | null, logDate: string) {
+  return useQuery({
+    queryKey: ['project-daily-log', projectId, logDate],
+    enabled: !!projectId,
+    queryFn: async (): Promise<ProjectDailyLog> => {
+      if (!projectId) throw new Error('projectId requerido');
+
+      const { data: log, error } = await supabase
+        .from('project_daily_logs')
+        .select('id, project_id, log_date, notes, updated_at')
+        .eq('project_id', projectId)
+        .eq('log_date', logDate)
+        .maybeSingle();
+
+      if (error) throw error;
+      if (!log) return emptyLog(projectId, logDate);
+
+      const [servicesRes, workersRes] = await Promise.all([
+        supabase
+          .from('project_daily_log_services')
+          .select('id, description, status, observations, position')
+          .eq('daily_log_id', log.id)
+          .order('position', { ascending: true }),
+        supabase
+          .from('project_daily_log_workers')
+          .select(
+            'id, name, role, period_start, period_end, shift_start, shift_end, notes, position',
+          )
+          .eq('daily_log_id', log.id)
+          .order('position', { ascending: true }),
+      ]);
+
+      if (servicesRes.error) throw servicesRes.error;
+      if (workersRes.error) throw workersRes.error;
+
+      return {
+        id: log.id,
+        project_id: log.project_id,
+        log_date: log.log_date,
+        notes: log.notes,
+        updated_at: log.updated_at,
+        services: (servicesRes.data ?? []) as DailyLogService[],
+        workers: (workersRes.data ?? []) as DailyLogWorker[],
+      };
+    },
+  });
+}
+
+// ----- mutation: salva (upsert do log + replace dos filhos) -----
+
+export interface DailyLogSavePayload {
+  project_id: string;
+  log_date: string;
+  notes: string | null;
+  services: DailyLogService[];
+  workers: DailyLogWorker[];
+}
+
+export function useSaveProjectDailyLog() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: DailyLogSavePayload) => {
+      const { data: user } = await supabase.auth.getUser();
+      const uid = user.user?.id ?? null;
+
+      // 1) upsert do log principal
+      const { data: logRow, error: upsertErr } = await supabase
+        .from('project_daily_logs')
+        .upsert(
+          {
+            project_id: payload.project_id,
+            log_date: payload.log_date,
+            notes: payload.notes,
+            updated_by: uid,
+            // created_by s\u00f3 na primeira vez \u2014 upsert lida:
+            ...(uid ? { created_by: uid } : {}),
+          },
+          { onConflict: 'project_id,log_date' },
+        )
+        .select('id')
+        .single();
+      if (upsertErr) throw upsertErr;
+      const logId = logRow.id;
+
+      // 2) replace-all dos filhos: simples e previs\u00edvel
+      // 2a) servi\u00e7os
+      const { error: delSvcErr } = await supabase
+        .from('project_daily_log_services')
+        .delete()
+        .eq('daily_log_id', logId);
+      if (delSvcErr) throw delSvcErr;
+
+      if (payload.services.length > 0) {
+        const { error: insSvcErr } = await supabase
+          .from('project_daily_log_services')
+          .insert(
+            payload.services.map((s, idx) => ({
+              daily_log_id: logId,
+              description: s.description,
+              status: s.status,
+              observations: s.observations,
+              position: idx,
+            })),
+          );
+        if (insSvcErr) throw insSvcErr;
+      }
+
+      // 2b) prestadores
+      const { error: delWkErr } = await supabase
+        .from('project_daily_log_workers')
+        .delete()
+        .eq('daily_log_id', logId);
+      if (delWkErr) throw delWkErr;
+
+      if (payload.workers.length > 0) {
+        const { error: insWkErr } = await supabase
+          .from('project_daily_log_workers')
+          .insert(
+            payload.workers.map((w, idx) => ({
+              daily_log_id: logId,
+              name: w.name,
+              role: w.role,
+              period_start: w.period_start,
+              period_end: w.period_end,
+              shift_start: w.shift_start,
+              shift_end: w.shift_end,
+              notes: w.notes,
+              position: idx,
+            })),
+          );
+        if (insWkErr) throw insWkErr;
+      }
+
+      return logId;
+    },
+    onSuccess: (_logId, variables) => {
+      toast.success('Registro do dia salvo');
+      queryClient.invalidateQueries({
+        queryKey: ['project-daily-log', variables.project_id, variables.log_date],
+      });
+      // Bump em "Atualizado" vem pelo trigger; refresca o painel.
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : 'Erro ao salvar o registro do dia';
+      toast.error(message);
+    },
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3578,6 +3578,111 @@ export type Database = {
           },
         ]
       }
+      project_daily_logs: {
+        Row: {
+          id: string
+          project_id: string
+          log_date: string
+          notes: string | null
+          created_by: string | null
+          updated_by: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          project_id: string
+          log_date?: string
+          notes?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          project_id?: string
+          log_date?: string
+          notes?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      project_daily_log_services: {
+        Row: {
+          id: string
+          daily_log_id: string
+          description: string
+          status: string | null
+          observations: string | null
+          position: number
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          daily_log_id: string
+          description: string
+          status?: string | null
+          observations?: string | null
+          position?: number
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          daily_log_id?: string
+          description?: string
+          status?: string | null
+          observations?: string | null
+          position?: number
+          created_at?: string
+        }
+        Relationships: []
+      }
+      project_daily_log_workers: {
+        Row: {
+          id: string
+          daily_log_id: string
+          name: string
+          role: string | null
+          period_start: string | null
+          period_end: string | null
+          shift_start: string | null
+          shift_end: string | null
+          notes: string | null
+          position: number
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          daily_log_id: string
+          name: string
+          role?: string | null
+          period_start?: string | null
+          period_end?: string | null
+          shift_start?: string | null
+          shift_end?: string | null
+          notes?: string | null
+          position?: number
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          daily_log_id?: string
+          name?: string
+          role?: string | null
+          period_start?: string | null
+          period_end?: string | null
+          shift_start?: string | null
+          shift_end?: string | null
+          notes?: string | null
+          position?: number
+          created_at?: string
+        }
+        Relationships: []
+      }
       project_customers: {
         Row: {
           cidade: string | null

--- a/src/pages/PainelObras.tsx
+++ b/src/pages/PainelObras.tsx
@@ -16,6 +16,7 @@ import {
   ShieldOff,
   ExternalLink,
   ChevronDown,
+  BookOpen,
 } from 'lucide-react';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/button';
@@ -68,6 +69,7 @@ import {
   type PainelStatus,
 } from '@/hooks/usePainelObras';
 import { EmptyState } from '@/components/ui/states';
+import { DailyLogDialog } from '@/components/admin/obras/DailyLogDialog';
 
 // ----- helpers -----
 const ALL = '__all__';
@@ -256,6 +258,13 @@ export default function PainelObras() {
     | null;
   const [sortKey, setSortKey] = useState<SortKey>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  // Modal "Registro do dia"
+  const [dailyLogObraId, setDailyLogObraId] = useState<string | null>(null);
+  const dailyLogObra = useMemo(
+    () => obras.find((o) => o.id === dailyLogObraId) ?? null,
+    [obras, dailyLogObraId],
+  );
 
   const filtered = useMemo(() => {
     let rows = obras;
@@ -504,7 +513,7 @@ export default function PainelObras() {
                   <TableHead className="min-w-[110px]">
                     <SortableHeader label="Atualizado" sortKey="ultima_atualizacao" />
                   </TableHead>
-                  <TableHead className="w-10"></TableHead>
+                  <TableHead className="w-20"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -514,11 +523,23 @@ export default function PainelObras() {
                     obra={o}
                     onUpdate={(patch) => updateObra(o.id, patch)}
                     onOpen={() => navigate(`/obra/${o.id}`)}
+                    onOpenDailyLog={() => setDailyLogObraId(o.id)}
                   />
                 ))}
               </TableBody>
             </Table>
           </div>
+        )}
+
+        {dailyLogObra && (
+          <DailyLogDialog
+            open={!!dailyLogObraId}
+            onOpenChange={(open) => {
+              if (!open) setDailyLogObraId(null);
+            }}
+            projectId={dailyLogObra.id}
+            projectTitle={`${dailyLogObra.customer_name ?? 'Sem cliente'} — ${dailyLogObra.nome}`}
+          />
         )}
       </PageContainer>
     </TooltipProvider>
@@ -574,9 +595,10 @@ interface ObraRowProps {
   obra: PainelObra;
   onUpdate: (patch: PainelObraPatch) => void;
   onOpen: () => void;
+  onOpenDailyLog: () => void;
 }
 
-function ObraRow({ obra, onUpdate, onOpen }: ObraRowProps) {
+function ObraRow({ obra, onUpdate, onOpen, onOpenDailyLog }: ObraRowProps) {
   // Fundo da célula fixa — precisa acompanhar o hover da row.
   const stickyBase = 'bg-card group-hover:bg-accent/40 transition-colors';
 
@@ -775,17 +797,38 @@ function ObraRow({ obra, onUpdate, onOpen }: ObraRowProps) {
         </Tooltip>
       </TableCell>
 
-      {/* Ação: abrir obra */}
+      {/* Ações: registro do dia + abrir obra */}
       <TableCell>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7 text-muted-foreground hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={onOpen}
-          title="Abrir obra"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-        </Button>
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7 text-muted-foreground hover:text-primary"
+                onClick={onOpenDailyLog}
+                aria-label="Registro do dia"
+              >
+                <BookOpen className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">Registro do dia</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7 text-muted-foreground hover:text-primary"
+                onClick={onOpen}
+                aria-label="Abrir obra"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">Abrir obra</TooltipContent>
+          </Tooltip>
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/supabase/migrations/20260422170000_project_daily_logs.sql
+++ b/supabase/migrations/20260422170000_project_daily_logs.sql
@@ -1,0 +1,237 @@
+-- =========================================================================
+-- Registro diário de obra (Painel de Obras)
+-- =========================================================================
+-- Três tabelas normalizadas:
+--   • project_daily_logs         → um registro por (projeto, data)
+--   • project_daily_log_services → serviços em execução no dia
+--   • project_daily_log_workers  → prestadores no local no dia
+--
+-- Decisões de modelagem:
+--   • UNIQUE (project_id, log_date) para permitir UPSERT simples no front.
+--   • Subrecursos em tabelas-filhas com ON DELETE CASCADE — ao apagar o
+--     log do dia, itens somem junto.
+--   • Campos de texto como TEXT (sem limite); datas como DATE; períodos
+--     como DATE (início/fim); período dentro do dia como TIME.
+--   • RLS: staff lê/escreve; admin deleta (mesmo padrão do painel).
+--   • Trigger de updated_at e, quando um log é modificado, bump em
+--     projects.painel_ultima_atualizacao para refletir em "Atualizado".
+-- =========================================================================
+
+-- ------------------------------------------------------------------
+-- 1) Tabela principal
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.project_daily_logs (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id   uuid NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  log_date     date NOT NULL DEFAULT CURRENT_DATE,
+  notes        text,
+  created_by   uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by   uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT project_daily_logs_project_date_unique UNIQUE (project_id, log_date)
+);
+
+CREATE INDEX IF NOT EXISTS project_daily_logs_project_id_idx
+  ON public.project_daily_logs (project_id, log_date DESC);
+
+COMMENT ON TABLE public.project_daily_logs IS
+  'Registro diário por obra (painel de obras). Um registro por (project_id, log_date).';
+
+-- ------------------------------------------------------------------
+-- 2) Serviços em execução no dia
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.project_daily_log_services (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  daily_log_id    uuid NOT NULL REFERENCES public.project_daily_logs(id) ON DELETE CASCADE,
+  description     text NOT NULL,
+  status          text,        -- p.ex.: 'Em andamento', 'Concluído', 'Parado'
+  observations    text,
+  position        smallint NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS project_daily_log_services_log_id_idx
+  ON public.project_daily_log_services (daily_log_id, position);
+
+COMMENT ON TABLE public.project_daily_log_services IS
+  'Serviços em execução listados no registro diário da obra.';
+
+-- ------------------------------------------------------------------
+-- 3) Prestadores no local no dia
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.project_daily_log_workers (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  daily_log_id    uuid NOT NULL REFERENCES public.project_daily_logs(id) ON DELETE CASCADE,
+  name            text NOT NULL,
+  role            text,        -- função / empresa / ofício
+  period_start    date,        -- período de atuação (início)
+  period_end      date,        -- período de atuação (fim)
+  shift_start     time,        -- hora de entrada no dia
+  shift_end       time,        -- hora de saída no dia
+  notes           text,
+  position        smallint NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS project_daily_log_workers_log_id_idx
+  ON public.project_daily_log_workers (daily_log_id, position);
+
+COMMENT ON TABLE public.project_daily_log_workers IS
+  'Prestadores presentes no local no dia (nome, função, período e horário).';
+
+-- ------------------------------------------------------------------
+-- 4) Triggers
+-- ------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.touch_project_daily_log()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  -- Se estamos em UPDATE, o updated_by deve ser fornecido pelo caller
+  -- (a repo seta). Em INSERT, também vem do caller.
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_project_daily_logs_touch ON public.project_daily_logs;
+CREATE TRIGGER trg_project_daily_logs_touch
+BEFORE UPDATE ON public.project_daily_logs
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_project_daily_log();
+
+-- Bump "Atualizado" da obra (painel) quando o log é alterado.
+-- Vale para INSERT e UPDATE no log ou em qualquer tabela-filha.
+CREATE OR REPLACE FUNCTION public.bump_project_last_painel_update_from_log()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_project_id uuid;
+BEGIN
+  IF TG_TABLE_NAME = 'project_daily_logs' THEN
+    v_project_id := COALESCE(NEW.project_id, OLD.project_id);
+  ELSE
+    -- tabelas-filhas: busca o project_id via daily_log_id
+    SELECT l.project_id INTO v_project_id
+    FROM public.project_daily_logs l
+    WHERE l.id = COALESCE(NEW.daily_log_id, OLD.daily_log_id);
+  END IF;
+
+  IF v_project_id IS NOT NULL THEN
+    UPDATE public.projects
+      SET painel_ultima_atualizacao = now()
+    WHERE id = v_project_id;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_project_daily_logs_bump ON public.project_daily_logs;
+CREATE TRIGGER trg_project_daily_logs_bump
+AFTER INSERT OR UPDATE OR DELETE ON public.project_daily_logs
+FOR EACH ROW
+EXECUTE FUNCTION public.bump_project_last_painel_update_from_log();
+
+DROP TRIGGER IF EXISTS trg_project_daily_log_services_bump ON public.project_daily_log_services;
+CREATE TRIGGER trg_project_daily_log_services_bump
+AFTER INSERT OR UPDATE OR DELETE ON public.project_daily_log_services
+FOR EACH ROW
+EXECUTE FUNCTION public.bump_project_last_painel_update_from_log();
+
+DROP TRIGGER IF EXISTS trg_project_daily_log_workers_bump ON public.project_daily_log_workers;
+CREATE TRIGGER trg_project_daily_log_workers_bump
+AFTER INSERT OR UPDATE OR DELETE ON public.project_daily_log_workers
+FOR EACH ROW
+EXECUTE FUNCTION public.bump_project_last_painel_update_from_log();
+
+-- ------------------------------------------------------------------
+-- 5) Row-Level Security (mesmo padrão do painel)
+-- ------------------------------------------------------------------
+ALTER TABLE public.project_daily_logs         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_daily_log_services ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_daily_log_workers  ENABLE ROW LEVEL SECURITY;
+
+-- --- project_daily_logs ---
+DROP POLICY IF EXISTS "Staff pode visualizar logs diários" ON public.project_daily_logs;
+CREATE POLICY "Staff pode visualizar logs diários"
+  ON public.project_daily_logs FOR SELECT
+  TO authenticated
+  USING (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode inserir logs diários" ON public.project_daily_logs;
+CREATE POLICY "Staff pode inserir logs diários"
+  ON public.project_daily_logs FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode atualizar logs diários" ON public.project_daily_logs;
+CREATE POLICY "Staff pode atualizar logs diários"
+  ON public.project_daily_logs FOR UPDATE
+  TO authenticated
+  USING (public.is_staff(auth.uid()))
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Admin pode deletar logs diários" ON public.project_daily_logs;
+CREATE POLICY "Admin pode deletar logs diários"
+  ON public.project_daily_logs FOR DELETE
+  TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'));
+
+-- --- project_daily_log_services ---
+DROP POLICY IF EXISTS "Staff pode visualizar serviços do log" ON public.project_daily_log_services;
+CREATE POLICY "Staff pode visualizar serviços do log"
+  ON public.project_daily_log_services FOR SELECT
+  TO authenticated
+  USING (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode inserir serviços do log" ON public.project_daily_log_services;
+CREATE POLICY "Staff pode inserir serviços do log"
+  ON public.project_daily_log_services FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode atualizar serviços do log" ON public.project_daily_log_services;
+CREATE POLICY "Staff pode atualizar serviços do log"
+  ON public.project_daily_log_services FOR UPDATE
+  TO authenticated
+  USING (public.is_staff(auth.uid()))
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode deletar serviços do log" ON public.project_daily_log_services;
+CREATE POLICY "Staff pode deletar serviços do log"
+  ON public.project_daily_log_services FOR DELETE
+  TO authenticated
+  USING (public.is_staff(auth.uid()));
+
+-- --- project_daily_log_workers ---
+DROP POLICY IF EXISTS "Staff pode visualizar prestadores do log" ON public.project_daily_log_workers;
+CREATE POLICY "Staff pode visualizar prestadores do log"
+  ON public.project_daily_log_workers FOR SELECT
+  TO authenticated
+  USING (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode inserir prestadores do log" ON public.project_daily_log_workers;
+CREATE POLICY "Staff pode inserir prestadores do log"
+  ON public.project_daily_log_workers FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode atualizar prestadores do log" ON public.project_daily_log_workers;
+CREATE POLICY "Staff pode atualizar prestadores do log"
+  ON public.project_daily_log_workers FOR UPDATE
+  TO authenticated
+  USING (public.is_staff(auth.uid()))
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "Staff pode deletar prestadores do log" ON public.project_daily_log_workers;
+CREATE POLICY "Staff pode deletar prestadores do log"
+  ON public.project_daily_log_workers FOR DELETE
+  TO authenticated
+  USING (public.is_staff(auth.uid()));


### PR DESCRIPTION
## O que muda

Adiciona um modal "**Registro do dia**" acessível a partir de cada linha do Painel de Obras, para registrar o que está acontecendo na obra naquele dia específico.

### Seções colapsáveis

O modal tem três seções, todas abertas por padrão:

1. **Serviços em execução** — descrição + status (Em andamento / Concluído / Parado) + observações livres
2. **Prestadores no local** — nome, função/empresa, período (datas início/fim), horário (entrada/saída), observações
3. **Observações gerais** — campo livre de diário

Cada item da lista tem seu próprio card com botão "Remover". Os botões "Adicionar serviço" / "Adicionar prestador" criam entradas em branco prontas para preenchimento.

### Acesso

Ao passar o mouse sobre uma linha do painel, aparecem dois ícones na última coluna:

- 📖 **Registro do dia** — abre o modal
- ↗️ **Abrir obra** — comportamento existente

### Persistência

Histórico por data (`project_daily_logs`), com subrecursos normalizados:

| Tabela | Finalidade |
|---|---|
| `project_daily_logs` | Um registro por `(project_id, log_date)` |
| `project_daily_log_services` | Lista de serviços do dia |
| `project_daily_log_workers` | Prestadores presentes no dia |

- `UNIQUE (project_id, log_date)` permite upsert direto no front
- `ON DELETE CASCADE` em todas as relações
- Índices nos IDs e posições para ordenação estável

### Atualização do painel

Trigger bumpa automaticamente `projects.painel_ultima_atualizacao` sempre que o log do dia é criado, editado ou apagado. A coluna "Atualizado" na grid reflete isso imediatamente após o salvamento.

### Segurança

RLS seguindo o padrão do painel:

- Staff (`is_staff`) pode ler, criar e editar
- Admin (`has_role`) pode deletar

### Arquitetura do front

- **Hook** `useProjectDailyLog(projectId, logDate)`
  - Query: carrega snapshot completo do dia (log + serviços + prestadores)
  - Mutation: upsert do log + **replace-all** dos filhos (simples, previsível, volume pequeno por dia)
- **Componente** `DailyLogDialog` isolado em `src/components/admin/obras/`
- **Estado local** no modal (sem autosave) — o usuário confirma clicando em Salvar
- Invalida a query do log e `['projects']` após salvar

### Validação

- `npx tsc -b --noEmit` ✅
- `npx eslint` ✅ (zero warnings nos arquivos novos e editados)
- `vite build` ✅
- 5 arquivos, **+1165 / −12** linhas

### Arquivos novos

- `supabase/migrations/20260422170000_project_daily_logs.sql`
- `src/hooks/useProjectDailyLog.ts`
- `src/components/admin/obras/DailyLogDialog.tsx`

### Arquivos editados

- `src/integrations/supabase/types.ts` — tipagem das 3 novas tabelas
- `src/pages/PainelObras.tsx` — novo ícone de ação, estado do modal

### Observação

Os tipos do Supabase foram adicionados manualmente porque este repo não regenera `types.ts` automaticamente. A migration real inclui todas as constraints, triggers e políticas.
