### PR TITLE
feat(audit): trilha de auditoria genérica para módulos de obras

### DIFF
--- a/src/hooks/useProjectAuditLog.ts
+++ b/src/hooks/useProjectAuditLog.ts
@@ -1,0 +1,80 @@
+/**
+ * useProjectAuditLog — leitura da trilha de auditoria de uma obra.
+ *
+ * Consulta a tabela `audit_logs` filtrando por `project_id`. RLS no banco
+ * garante que apenas staff e usuários com acesso à obra recebam linhas.
+ *
+ * Tipagem é deliberadamente ampla (`unknown` em old/new) porque a tabela
+ * armazena snapshots heterogêneos de várias entidades. A UI consumidora
+ * sabe interpretar conforme `table_name`.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export type AuditAction = 'INSERT' | 'UPDATE' | 'DELETE';
+
+/** Tabelas que possuem trigger de auditoria (mantém em sincronia com a migration). */
+export type AuditTableName =
+  | 'projects'
+  | 'project_documents'
+  | 'project_payments'
+  | 'project_daily_logs'
+  | 'obra_tasks'
+  | 'journey_stage_records'
+  | 'stage_dates'
+  | 'formalizations';
+
+export interface AuditLogEntry {
+  id: string;
+  table_name: AuditTableName | string;
+  record_id: string;
+  project_id: string | null;
+  action: AuditAction;
+  changed_columns: string[] | null;
+  old_values: Record<string, unknown> | null;
+  new_values: Record<string, unknown> | null;
+  changed_by: string | null;
+  changed_by_email: string | null;
+  created_at: string;
+}
+
+interface UseProjectAuditLogOptions {
+  /** Limite de registros a buscar. Default 200 — paginação fica para v2. */
+  limit?: number;
+  /** Filtra por uma tabela específica (opcional). */
+  tableName?: AuditTableName;
+}
+
+export function useProjectAuditLog(
+  projectId: string | undefined,
+  options: UseProjectAuditLogOptions = {},
+) {
+  const { limit = 200, tableName } = options;
+
+  return useQuery({
+    queryKey: ['project-audit-log', projectId, { limit, tableName }],
+    enabled: !!projectId,
+    queryFn: async (): Promise<AuditLogEntry[]> => {
+      if (!projectId) return [];
+
+      let query = supabase
+        // Tabela ainda não está no types.ts gerado — cast pontual aceitável.
+        .from('audit_logs' as never)
+        .select(
+          'id, table_name, record_id, project_id, action, changed_columns, old_values, new_values, changed_by, changed_by_email, created_at',
+        )
+        .eq('project_id', projectId)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      if (tableName) {
+        query = query.eq('table_name', tableName);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return (data ?? []) as unknown as AuditLogEntry[];
+    },
+    staleTime: 30_000,
+  });
+}

--- a/src/pages/EditarObra.tsx
+++ b/src/pages/EditarObra.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Building2, Calendar, DollarSign, Users, Save, Trash2, Loader2, Home } from 'lucide-react';
+import { ArrowLeft, Building2, Calendar, DollarSign, Users, Save, Trash2, Loader2, Home, History } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -24,6 +24,7 @@ import { TabAtividades } from './editar-obra/TabAtividades';
 import { TabPagamentos } from './editar-obra/TabPagamentos';
 import { TabEquipe } from './editar-obra/TabEquipe';
 import { TabFichaTecnica } from './editar-obra/TabFichaTecnica';
+import { TabHistorico } from './editar-obra/TabHistorico';
 import { EditarObraSidebar } from './editar-obra/EditarObraSidebar';
 import { ShiftModeDialog } from './editar-obra/ShiftModeDialog';
 
@@ -146,7 +147,7 @@ export default function EditarObra() {
           {/* Main content */}
           <div className="flex-1 min-w-0">
             <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="flex w-full overflow-x-auto scrollbar-hide mb-6 sm:grid sm:grid-cols-5">
+              <TabsList className="flex w-full overflow-x-auto scrollbar-hide mb-6 sm:grid sm:grid-cols-6">
                 <TabsTrigger value="geral" className="flex items-center gap-2">
                   <Building2 className="h-4 w-4" />
                   <span className="hidden sm:inline">Dados Gerais</span>
@@ -166,6 +167,10 @@ export default function EditarObra() {
                 <TabsTrigger value="equipe" className="flex items-center gap-2">
                   <Users className="h-4 w-4" />
                   <span className="hidden sm:inline">Equipe</span>
+                </TabsTrigger>
+                <TabsTrigger value="historico" className="flex items-center gap-2">
+                  <History className="h-4 w-4" />
+                  <span className="hidden sm:inline">Histórico</span>
                 </TabsTrigger>
               </TabsList>
 
@@ -215,6 +220,10 @@ export default function EditarObra() {
                   onCustomerLinked={(c) => data.setCustomer(c)}
                   onCustomerAdded={(c) => data.setCustomer(c)}
                 />
+              </TabsContent>
+
+              <TabsContent value="historico">
+                <TabHistorico projectId={projectId!} />
               </TabsContent>
             </Tabs>
           </div>

--- a/src/pages/editar-obra/TabHistorico.tsx
+++ b/src/pages/editar-obra/TabHistorico.tsx
@@ -1,0 +1,271 @@
+/**
+ * TabHistorico — timeline de alterações da obra (audit log).
+ *
+ * Mostra entradas de `audit_logs` para o `projectId` em ordem cronológica
+ * decrescente. Agrupa por dia e oferece filtro por entidade
+ * (projects, pagamentos, documentos, etc.).
+ *
+ * Diff de UPDATE é renderizado de forma compacta: "campo: antigo → novo".
+ * Para INSERT/DELETE, mostra um resumo da entidade (com fallback genérico).
+ */
+import { useMemo, useState } from 'react';
+import { format, parseISO, isToday, isYesterday } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import {
+  History,
+  FileText,
+  DollarSign,
+  ListChecks,
+  ClipboardList,
+  CalendarDays,
+  Building2,
+  ScrollText,
+  PencilLine,
+  PlusCircle,
+  Trash2,
+  Loader2,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useProjectAuditLog,
+  type AuditLogEntry,
+  type AuditTableName,
+} from '@/hooks/useProjectAuditLog';
+
+interface TabHistoricoProps {
+  projectId: string;
+}
+
+/** Configuração visual por tabela auditada. */
+const TABLE_META: Record<
+  string,
+  { label: string; icon: typeof FileText; tone: string }
+> = {
+  projects: { label: 'Obra', icon: Building2, tone: 'bg-blue-50 text-blue-700' },
+  project_documents: { label: 'Documentos', icon: FileText, tone: 'bg-violet-50 text-violet-700' },
+  project_payments: { label: 'Pagamentos', icon: DollarSign, tone: 'bg-emerald-50 text-emerald-700' },
+  project_daily_logs: { label: 'Diário de obra', icon: ClipboardList, tone: 'bg-amber-50 text-amber-700' },
+  obra_tasks: { label: 'Atividades', icon: ListChecks, tone: 'bg-indigo-50 text-indigo-700' },
+  journey_stage_records: { label: 'Etapas', icon: CalendarDays, tone: 'bg-teal-50 text-teal-700' },
+  stage_dates: { label: 'Cronograma', icon: CalendarDays, tone: 'bg-cyan-50 text-cyan-700' },
+  formalizations: { label: 'Formalizações', icon: ScrollText, tone: 'bg-rose-50 text-rose-700' },
+};
+
+const ACTION_META: Record<
+  AuditLogEntry['action'],
+  { label: string; icon: typeof PencilLine; tone: string }
+> = {
+  INSERT: { label: 'Criou', icon: PlusCircle, tone: 'text-emerald-700' },
+  UPDATE: { label: 'Atualizou', icon: PencilLine, tone: 'text-blue-700' },
+  DELETE: { label: 'Excluiu', icon: Trash2, tone: 'text-red-700' },
+};
+
+/** Colunas que poluem o diff e não agregam valor ao usuário final. */
+const NOISE_COLUMNS = new Set(['updated_at', 'created_at', 'painel_ultima_atualizacao']);
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') {
+    // Datas ISO viram leitura amigável
+    if (/^\d{4}-\d{2}-\d{2}(T|$)/.test(value)) {
+      try {
+        return format(parseISO(value), "dd/MM/yyyy", { locale: ptBR });
+      } catch {
+        return value;
+      }
+    }
+    return value.length > 80 ? value.slice(0, 80) + '…' : value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value).slice(0, 80);
+}
+
+function formatGroupLabel(dateStr: string): string {
+  const d = parseISO(dateStr);
+  if (isToday(d)) return 'Hoje';
+  if (isYesterday(d)) return 'Ontem';
+  return format(d, "EEEE, dd 'de' MMMM 'de' yyyy", { locale: ptBR });
+}
+
+/** Agrupa entradas por data (YYYY-MM-DD). */
+function groupByDay(entries: AuditLogEntry[]): Array<{ day: string; items: AuditLogEntry[] }> {
+  const map = new Map<string, AuditLogEntry[]>();
+  for (const entry of entries) {
+    const day = entry.created_at.slice(0, 10);
+    if (!map.has(day)) map.set(day, []);
+    map.get(day)!.push(entry);
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => (a[0] < b[0] ? 1 : -1))
+    .map(([day, items]) => ({ day, items }));
+}
+
+/** Resumo human-readable de um INSERT (escolhe um campo descritivo). */
+function summarizeInsert(entry: AuditLogEntry): string {
+  const v = entry.new_values ?? {};
+  const candidate = (v.name ?? v.title ?? v.description ?? v.notes) as string | undefined;
+  return candidate ? `"${formatValue(candidate)}"` : `#${entry.record_id.slice(0, 8)}`;
+}
+
+function summarizeDelete(entry: AuditLogEntry): string {
+  const v = entry.old_values ?? {};
+  const candidate = (v.name ?? v.title ?? v.description ?? v.notes) as string | undefined;
+  return candidate ? `"${formatValue(candidate)}"` : `#${entry.record_id.slice(0, 8)}`;
+}
+
+function AuditEntry({ entry }: { entry: AuditLogEntry }) {
+  const tableMeta = TABLE_META[entry.table_name] ?? {
+    label: entry.table_name,
+    icon: FileText,
+    tone: 'bg-gray-50 text-gray-700',
+  };
+  const actionMeta = ACTION_META[entry.action];
+  const TableIcon = tableMeta.icon;
+  const ActionIcon = actionMeta.icon;
+  const time = format(parseISO(entry.created_at), 'HH:mm', { locale: ptBR });
+
+  const visibleChanges = (entry.changed_columns ?? [])
+    .filter((c) => !NOISE_COLUMNS.has(c))
+    .slice(0, 6);
+
+  return (
+    <div className="flex gap-3 py-3">
+      <div className={`shrink-0 h-9 w-9 rounded-full flex items-center justify-center ${tableMeta.tone}`}>
+        <TableIcon className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="outline" className="text-xs">
+            {tableMeta.label}
+          </Badge>
+          <span className={`flex items-center gap-1 text-sm font-medium ${actionMeta.tone}`}>
+            <ActionIcon className="h-3.5 w-3.5" />
+            {actionMeta.label}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {entry.changed_by_email ?? 'Sistema'} · {time}
+          </span>
+        </div>
+
+        {entry.action === 'INSERT' && (
+          <p className="text-sm text-foreground/80 mt-1">
+            Novo registro: <span className="font-medium">{summarizeInsert(entry)}</span>
+          </p>
+        )}
+        {entry.action === 'DELETE' && (
+          <p className="text-sm text-foreground/80 mt-1">
+            Removido: <span className="font-medium">{summarizeDelete(entry)}</span>
+          </p>
+        )}
+        {entry.action === 'UPDATE' && visibleChanges.length > 0 && (
+          <ul className="mt-1 space-y-0.5 text-sm">
+            {visibleChanges.map((col) => {
+              const oldVal = entry.old_values?.[col];
+              const newVal = entry.new_values?.[col];
+              return (
+                <li key={col} className="text-foreground/80">
+                  <span className="font-medium">{col}</span>:{' '}
+                  <span className="text-muted-foreground line-through">{formatValue(oldVal)}</span>{' '}
+                  <span aria-hidden>→</span>{' '}
+                  <span className="text-foreground">{formatValue(newVal)}</span>
+                </li>
+              );
+            })}
+            {(entry.changed_columns?.length ?? 0) > visibleChanges.length && (
+              <li className="text-xs text-muted-foreground">
+                +{(entry.changed_columns!.length - visibleChanges.length)} outras alterações
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const FILTER_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'all', label: 'Todas as entidades' },
+  { value: 'projects', label: 'Obra' },
+  { value: 'project_payments', label: 'Pagamentos' },
+  { value: 'project_documents', label: 'Documentos' },
+  { value: 'project_daily_logs', label: 'Diário de obra' },
+  { value: 'obra_tasks', label: 'Atividades' },
+  { value: 'journey_stage_records', label: 'Etapas' },
+  { value: 'stage_dates', label: 'Cronograma' },
+  { value: 'formalizations', label: 'Formalizações' },
+];
+
+export function TabHistorico({ projectId }: TabHistoricoProps) {
+  const [filter, setFilter] = useState<string>('all');
+
+  const { data, isLoading, error } = useProjectAuditLog(projectId, {
+    tableName: filter === 'all' ? undefined : (filter as AuditTableName),
+  });
+
+  const grouped = useMemo(() => groupByDay(data ?? []), [data]);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 flex-wrap">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <History className="h-5 w-5" />
+          Histórico de alterações
+        </CardTitle>
+        <Select value={filter} onValueChange={setFilter}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {FILTER_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin mr-2" />
+            Carregando histórico…
+          </div>
+        )}
+        {error && (
+          <p className="text-sm text-red-600 py-4">
+            Não foi possível carregar o histórico.
+          </p>
+        )}
+        {!isLoading && !error && grouped.length === 0 && (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            Nenhuma alteração registrada ainda para esta obra.
+          </p>
+        )}
+        {!isLoading && !error && grouped.length > 0 && (
+          <div className="space-y-6">
+            {grouped.map(({ day, items }) => (
+              <div key={day}>
+                <h3 className="text-sm font-semibold text-muted-foreground mb-2 sticky top-0 bg-background/80 backdrop-blur py-1">
+                  {formatGroupLabel(day)}
+                </h3>
+                <div className="divide-y">
+                  {items.map((entry) => (
+                    <AuditEntry key={entry.id} entry={entry} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/supabase/migrations/20260424051959_audit_logs.sql
+++ b/supabase/migrations/20260424051959_audit_logs.sql
@@ -1,0 +1,181 @@
+-- ============================================================
+-- Audit log genérico para módulos de obras
+-- ------------------------------------------------------------
+-- Cria uma única tabela `audit_logs` que rastreia INSERT/UPDATE/DELETE
+-- em tabelas relevantes (projects, project_documents, project_payments,
+-- project_daily_logs, obra_tasks, journey_stage_records, stage_dates,
+-- formalizations).
+--
+-- Estratégia:
+--   - 1 tabela única (em vez de 1 tabela por entidade) -> facilita
+--     timeline cronológica por obra e queries cross-modulo.
+--   - Função genérica `public.log_audit_event()` reutilizada em todos
+--     os triggers, descobrindo `project_id` automaticamente em cada
+--     tabela auditada (estratégia case-by-case via TG_TABLE_NAME).
+--   - Apenas colunas que mudaram são gravadas em `changed_columns`,
+--     com diff completo em `old_values`/`new_values` (jsonb).
+--   - `changed_by_email` é denormalizado para evitar JOIN em auth.users
+--     na UI.
+-- ============================================================
+
+-- 1) Tabela principal --------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  table_name      TEXT NOT NULL,
+  record_id       UUID NOT NULL,
+  project_id      UUID NULL,                  -- denormalizado p/ filtro rápido por obra
+  action          TEXT NOT NULL CHECK (action IN ('INSERT','UPDATE','DELETE')),
+  changed_columns TEXT[] NULL,                -- preenchido apenas em UPDATE
+  old_values      JSONB NULL,                 -- snapshot anterior (UPDATE/DELETE)
+  new_values      JSONB NULL,                 -- snapshot atual (INSERT/UPDATE)
+  changed_by      UUID NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  changed_by_email TEXT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_project_created
+  ON public.audit_logs (project_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_table_record
+  ON public.audit_logs (table_name, record_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_changed_by
+  ON public.audit_logs (changed_by, created_at DESC);
+
+COMMENT ON TABLE public.audit_logs IS
+  'Trilha de auditoria genérica para mudanças em entidades ligadas a obras.';
+COMMENT ON COLUMN public.audit_logs.project_id IS
+  'Denormalizado: copiado da linha auditada quando aplicável (NULL para entidades sem vínculo direto).';
+COMMENT ON COLUMN public.audit_logs.changed_columns IS
+  'Lista de colunas alteradas. Preenchido apenas para UPDATE.';
+
+-- 2) Função genérica de log -------------------------------------------
+CREATE OR REPLACE FUNCTION public.log_audit_event()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_action          TEXT := TG_OP;
+  v_record_id       UUID;
+  v_project_id      UUID;
+  v_old             JSONB;
+  v_new             JSONB;
+  v_changed_cols    TEXT[];
+  v_user_id         UUID := auth.uid();
+  v_user_email      TEXT;
+BEGIN
+  -- Snapshot OLD/NEW como jsonb (NULL quando não aplicável)
+  IF TG_OP = 'INSERT' THEN
+    v_new := to_jsonb(NEW);
+  ELSIF TG_OP = 'UPDATE' THEN
+    v_old := to_jsonb(OLD);
+    v_new := to_jsonb(NEW);
+  ELSIF TG_OP = 'DELETE' THEN
+    v_old := to_jsonb(OLD);
+  END IF;
+
+  -- Extrai record_id (PK) — todas as tabelas auditadas usam coluna `id` UUID
+  IF TG_OP = 'DELETE' THEN
+    v_record_id := (v_old->>'id')::uuid;
+  ELSE
+    v_record_id := (v_new->>'id')::uuid;
+  END IF;
+
+  -- Extrai project_id da linha (varia por tabela)
+  IF TG_TABLE_NAME = 'projects' THEN
+    v_project_id := v_record_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    v_project_id := NULLIF(v_old->>'project_id','')::uuid;
+  ELSE
+    v_project_id := NULLIF(v_new->>'project_id','')::uuid;
+  END IF;
+
+  -- Calcula colunas alteradas (apenas em UPDATE)
+  IF TG_OP = 'UPDATE' THEN
+    SELECT array_agg(key) INTO v_changed_cols
+    FROM (
+      SELECT key
+      FROM jsonb_each(v_new)
+      WHERE key NOT IN ('updated_at')   -- ignora colunas de bookkeeping
+        AND v_new->key IS DISTINCT FROM v_old->key
+    ) diff;
+
+    -- Se nada mudou (além de updated_at), não loga
+    IF v_changed_cols IS NULL OR array_length(v_changed_cols,1) = 0 THEN
+      RETURN COALESCE(NEW, OLD);
+    END IF;
+  END IF;
+
+  -- Pega email do usuário (best-effort)
+  IF v_user_id IS NOT NULL THEN
+    SELECT email INTO v_user_email FROM auth.users WHERE id = v_user_id;
+  END IF;
+
+  INSERT INTO public.audit_logs (
+    table_name, record_id, project_id, action,
+    changed_columns, old_values, new_values,
+    changed_by, changed_by_email
+  ) VALUES (
+    TG_TABLE_NAME, v_record_id, v_project_id, v_action,
+    v_changed_cols, v_old, v_new,
+    v_user_id, v_user_email
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.log_audit_event() IS
+  'Trigger genérico AFTER INSERT/UPDATE/DELETE — grava em public.audit_logs.';
+
+-- 3) Triggers em cada tabela alvo -------------------------------------
+-- Helper: cria trigger somente se a tabela existir (resiliência a renames futuros).
+DO $$
+DECLARE
+  tbl TEXT;
+  target_tables TEXT[] := ARRAY[
+    'projects',
+    'project_documents',
+    'project_payments',
+    'project_daily_logs',
+    'obra_tasks',
+    'journey_stage_records',
+    'stage_dates',
+    'formalizations'
+  ];
+BEGIN
+  FOREACH tbl IN ARRAY target_tables LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema='public' AND table_name=tbl
+    ) THEN
+      EXECUTE format('DROP TRIGGER IF EXISTS trg_audit_%I ON public.%I;', tbl, tbl);
+      EXECUTE format(
+        'CREATE TRIGGER trg_audit_%I
+           AFTER INSERT OR UPDATE OR DELETE ON public.%I
+           FOR EACH ROW EXECUTE FUNCTION public.log_audit_event();',
+        tbl, tbl
+      );
+    END IF;
+  END LOOP;
+END $$;
+
+-- 4) RLS ---------------------------------------------------------------
+ALTER TABLE public.audit_logs ENABLE ROW LEVEL SECURITY;
+
+-- Leitura: staff vê tudo; demais usuários só veem logs de obras a que têm acesso.
+DROP POLICY IF EXISTS "audit_logs_select_staff_or_project_access" ON public.audit_logs;
+CREATE POLICY "audit_logs_select_staff_or_project_access"
+  ON public.audit_logs
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.is_staff(auth.uid())
+    OR (
+      project_id IS NOT NULL
+      AND public.has_project_access(auth.uid(), project_id)
+    )
+  );
+
+-- Escrita: bloqueada para clients. Só o trigger SECURITY DEFINER pode inserir.
+-- (Sem POLICY de INSERT/UPDATE/DELETE => negado por padrão.)


### PR DESCRIPTION
## Por quê

Primeiro item da Fase 1 do roadmap de melhorias do Painel de Obras: **trilha de auditoria** rastreando quem alterou o quê e quando em todas as entidades centrais. Pré-requisito para histórico, compliance e (futuramente) automações de workflow baseadas em eventos.

## O que muda

### Banco (`supabase/migrations/20260424051959_audit_logs.sql`)

Tabela única `public.audit_logs`:

| campo | tipo | obs |
|---|---|---|
| `id` | uuid | PK |
| `table_name` | text | nome da tabela auditada |
| `record_id` | uuid | PK da linha auditada |
| `project_id` | uuid | denormalizado para filtro rápido por obra |
| `action` | text | INSERT / UPDATE / DELETE |
| `changed_columns` | text[] | só em UPDATE |
| `old_values` / `new_values` | jsonb | snapshot completo |
| `changed_by` / `changed_by_email` | uuid / text | usuário do `auth.uid()` |
| `created_at` | timestamptz | |

Função genérica `log_audit_event()` (SECURITY DEFINER) reutilizada em triggers AFTER INSERT/UPDATE/DELETE em:

- `projects`
- `project_documents`
- `project_payments`
- `project_daily_logs`
- `obra_tasks`
- `journey_stage_records`
- `stage_dates`
- `formalizations`

A função descobre o `project_id` automaticamente em cada tabela, ignora colunas de bookkeeping (`updated_at`) e só loga quando algo realmente mudou.

**RLS:** SELECT permitido apenas para `is_staff` ou usuário com `has_project_access`. INSERT/UPDATE/DELETE bloqueados — só o trigger SECURITY DEFINER consegue escrever.

**Índices:** `(project_id, created_at DESC)`, `(table_name, record_id, created_at DESC)`, `(changed_by, created_at DESC)`.

### Frontend

- **`src/hooks/useProjectAuditLog.ts`** — hook com React Query, filtros opcionais por tabela e limite. Tipagem fortalecida (`AuditLogEntry`, `AuditAction`, `AuditTableName`).
- **`src/pages/editar-obra/TabHistorico.tsx`** — timeline agrupada por dia, filtro por entidade, diff campo a campo (`antigo → novo`), ícones e cores por tipo de entidade.
- **`src/pages/EditarObra.tsx`** — adiciona aba "Histórico" (6ª aba).

## Como aplicar a migration

A migration depende do projeto Supabase real (ownership Lovable). Para aplicar:

1. Lovable → Backend → SQL Editor
2. Cole o conteúdo de `supabase/migrations/20260424051959_audit_logs.sql`
3. Run

Cópia também disponível em `/home/user/workspace/apply_audit_logs.sql` no workspace.

## Validação

- `npx tsc -b --noEmit` ✅
- `npx eslint <arquivos novos>` ✅ (apenas 4 warnings pré-existentes de `non-null assertion`, padrão do projeto)
- `npx vite build` ✅

## Risco

- **Baixo no frontend** — feature isolada em uma nova aba, não afeta nenhuma rota existente.
- **Médio no banco** — adiciona triggers em 8 tabelas. Cada INSERT/UPDATE/DELETE passa a fazer 1 INSERT extra em `audit_logs`. Se observarmos custo de escrita relevante, dá para mover para um trigger DEFERRED ou suprimir entidades de alta frequência.

## Próximos passos sugeridos (não neste PR)

- Regenerar `src/integrations/supabase/types.ts` para tipar `audit_logs` nativamente (remover o cast `as never` do hook)
- Estender para `nc_history`-like em `project_3d_photos`, `project_documents_versions` se útil
- Adicionar paginação na timeline quando > 200 entradas
