### PR TITLE
feat(cronograma): checklist técnico e galeria de fotos por atividade

### DIFF
--- a/src/components/cronograma/ActivityChecklistAndPhotos.tsx
+++ b/src/components/cronograma/ActivityChecklistAndPhotos.tsx
@@ -1,0 +1,368 @@
+/**
+ * ActivityChecklistAndPhotos — bloco expansível por atividade do
+ * cronograma com 2 abas: Checklist técnico e Galeria de fotos.
+ *
+ * Como atividades não-salvas ainda não têm registro no banco, o
+ * componente fica desabilitado até o `isPersisted` ser true.
+ */
+import { useRef, useState } from 'react';
+import {
+  ListChecks,
+  ImageIcon,
+  Plus,
+  Trash2,
+  Loader2,
+  Upload,
+  X,
+  Pencil,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Progress } from '@/components/ui/progress';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useActivityChecklist } from '@/hooks/useActivityChecklist';
+import { useActivityPhotos } from '@/hooks/useActivityPhotos';
+import { cn } from '@/lib/utils';
+
+interface ActivityChecklistAndPhotosProps {
+  activityId: string;
+  projectId: string;
+  /** Indica se a atividade já existe no banco (foi salva). */
+  isPersisted: boolean;
+  /** Permite escrita; false para customers. */
+  canEdit: boolean;
+}
+
+export function ActivityChecklistAndPhotos({
+  activityId,
+  projectId,
+  isPersisted,
+  canEdit,
+}: ActivityChecklistAndPhotosProps) {
+  if (!isPersisted) {
+    return (
+      <div className="rounded-md border border-dashed bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+        Salve o cronograma para liberar checklist e galeria de fotos desta atividade.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border bg-background shadow-sm">
+      <Tabs defaultValue="checklist" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 rounded-t-md rounded-b-none">
+          <TabsTrigger value="checklist" className="flex items-center gap-2">
+            <ListChecks className="h-4 w-4" />
+            Checklist
+          </TabsTrigger>
+          <TabsTrigger value="photos" className="flex items-center gap-2">
+            <ImageIcon className="h-4 w-4" />
+            Fotos
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="checklist" className="p-3">
+          <ChecklistPanel activityId={activityId} projectId={projectId} canEdit={canEdit} />
+        </TabsContent>
+        <TabsContent value="photos" className="p-3">
+          <PhotosPanel activityId={activityId} projectId={projectId} canEdit={canEdit} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// ---------- Checklist ------------------------------------------------
+
+function ChecklistPanel({
+  activityId,
+  projectId,
+  canEdit,
+}: {
+  activityId: string;
+  projectId: string;
+  canEdit: boolean;
+}) {
+  const {
+    items,
+    isLoading,
+    total,
+    doneCount,
+    progress,
+    addItem,
+    toggleItem,
+    editItem,
+    deleteItem,
+  } = useActivityChecklist(activityId, projectId);
+
+  const [newDescription, setNewDescription] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState('');
+
+  const handleAdd = () => {
+    if (!newDescription.trim()) return;
+    addItem.mutate(newDescription, { onSuccess: () => setNewDescription('') });
+  };
+
+  const startEdit = (id: string, current: string) => {
+    setEditingId(id);
+    setEditingValue(current);
+  };
+
+  const commitEdit = () => {
+    if (!editingId) return;
+    editItem.mutate(
+      { id: editingId, description: editingValue },
+      { onSuccess: () => setEditingId(null) },
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Progress value={progress} className="flex-1 h-2" />
+        <span className="text-xs tabular-nums text-muted-foreground min-w-[60px] text-right">
+          {doneCount}/{total} ({progress}%)
+        </span>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Carregando checklist…
+        </div>
+      )}
+
+      {!isLoading && items.length === 0 && (
+        <p className="text-sm text-muted-foreground py-1">
+          Nenhum item ainda. {canEdit ? 'Adicione abaixo.' : ''}
+        </p>
+      )}
+
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            className="flex items-start gap-2 group rounded px-1 py-1 hover:bg-accent/40"
+          >
+            <Checkbox
+              checked={item.is_done}
+              disabled={!canEdit || toggleItem.isPending}
+              onCheckedChange={(checked) =>
+                toggleItem.mutate({ id: item.id, is_done: checked === true })
+              }
+              className="mt-0.5"
+            />
+            <div className="flex-1 min-w-0">
+              {editingId === item.id ? (
+                <div className="flex gap-1">
+                  <Input
+                    autoFocus
+                    value={editingValue}
+                    onChange={(e) => setEditingValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitEdit();
+                      if (e.key === 'Escape') setEditingId(null);
+                    }}
+                    className="h-7 text-sm"
+                  />
+                  <Button size="sm" variant="secondary" onClick={commitEdit}>
+                    OK
+                  </Button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={cn(
+                    'text-sm text-left w-full block',
+                    item.is_done && 'line-through text-muted-foreground',
+                  )}
+                  onClick={() => canEdit && startEdit(item.id, item.description)}
+                  disabled={!canEdit}
+                  title={canEdit ? 'Clique para editar' : undefined}
+                >
+                  {item.description}
+                </button>
+              )}
+            </div>
+            {canEdit && editingId !== item.id && (
+              <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-6 w-6"
+                  onClick={() => startEdit(item.id, item.description)}
+                  aria-label="Editar item"
+                >
+                  <Pencil className="h-3 w-3" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-6 w-6 text-destructive hover:text-destructive"
+                  onClick={() => deleteItem.mutate(item.id)}
+                  aria-label="Excluir item"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {canEdit && (
+        <div className="flex gap-2 pt-1 border-t">
+          <Input
+            placeholder="Novo item de checklist…"
+            value={newDescription}
+            onChange={(e) => setNewDescription(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+            className="h-8 text-sm"
+          />
+          <Button
+            size="sm"
+            onClick={handleAdd}
+            disabled={!newDescription.trim() || addItem.isPending}
+          >
+            {addItem.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                <Plus className="h-4 w-4 mr-1" /> Adicionar
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- Photos ---------------------------------------------------
+
+function PhotosPanel({
+  activityId,
+  projectId,
+  canEdit,
+}: {
+  activityId: string;
+  projectId: string;
+  canEdit: boolean;
+}) {
+  const { photos, isLoading, uploadPhotos, deletePhoto } = useActivityPhotos(
+    activityId,
+    projectId,
+  );
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) {
+      uploadPhotos.mutate({ files });
+    }
+    e.target.value = '';
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {photos.length === 0
+            ? 'Nenhuma foto ainda.'
+            : `${photos.length} foto${photos.length > 1 ? 's' : ''}`}
+        </span>
+        {canEdit && (
+          <>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+              multiple
+              className="hidden"
+              onChange={handleSelect}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => fileRef.current?.click()}
+              disabled={uploadPhotos.isPending}
+            >
+              {uploadPhotos.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <>
+                  <Upload className="h-4 w-4 mr-1" /> Enviar fotos
+                </>
+              )}
+            </Button>
+          </>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Carregando fotos…
+        </div>
+      )}
+
+      {!isLoading && photos.length > 0 && (
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+          {photos.map((photo) => (
+            <div
+              key={photo.id}
+              className="relative group rounded-md overflow-hidden border bg-muted aspect-square"
+            >
+              {photo.signed_url ? (
+                <button
+                  type="button"
+                  className="w-full h-full"
+                  onClick={() => setPreview(photo.signed_url ?? null)}
+                  aria-label="Ampliar foto"
+                >
+                  <img
+                    src={photo.signed_url}
+                    alt={photo.caption ?? 'Foto da atividade'}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                </button>
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-muted-foreground">
+                  <ImageIcon className="h-6 w-6" />
+                </div>
+              )}
+              {canEdit && (
+                <button
+                  type="button"
+                  className="absolute top-1 right-1 h-6 w-6 rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                  onClick={() => deletePhoto.mutate(photo)}
+                  aria-label="Remover foto"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {preview && (
+        <div
+          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4 cursor-zoom-out"
+          onClick={() => setPreview(null)}
+        >
+          <img
+            src={preview}
+            alt="Visualização ampliada"
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/hooks/useActivityChecklist.ts
+++ b/src/hooks/useActivityChecklist.ts
@@ -1,0 +1,161 @@
+/**
+ * useActivityChecklist — CRUD do checklist técnico de uma atividade
+ * do cronograma (project_activities).
+ *
+ * Cada atividade pode ter N itens. UI mostra-os ordenados por `position`.
+ * Triggers do banco preenchem `done_at` / `done_by` ao marcar.
+ *
+ * Estratégia de mutation: chamadas pontuais (add/toggle/edit/delete/reorder)
+ * com invalidação local do query — não há "save all" porque a operação
+ * típica é interativa (clicar checkbox) e queremos feedback imediato.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+export interface ActivityChecklistItem {
+  id: string;
+  activity_id: string;
+  project_id: string;
+  description: string;
+  position: number;
+  is_done: boolean;
+  done_at: string | null;
+  done_by: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+const TABLE = 'project_activity_checklist_items' as never;
+
+function activityChecklistKey(activityId: string | undefined) {
+  return ['activity-checklist', activityId] as const;
+}
+
+export function useActivityChecklist(
+  activityId: string | undefined,
+  projectId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+  const queryKey = activityChecklistKey(activityId);
+
+  const query = useQuery({
+    queryKey,
+    enabled: !!activityId,
+    queryFn: async (): Promise<ActivityChecklistItem[]> => {
+      if (!activityId) return [];
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'id, activity_id, project_id, description, position, is_done, done_at, done_by, created_at, updated_at, created_by',
+        )
+        .eq('activity_id', activityId)
+        .order('position', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as unknown as ActivityChecklistItem[];
+    },
+    staleTime: 30_000,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const addItem = useMutation({
+    mutationFn: async (description: string) => {
+      if (!activityId || !projectId) throw new Error('Atividade não encontrada');
+      const trimmed = description.trim();
+      if (!trimmed) throw new Error('Descrição vazia');
+      const nextPosition = (query.data?.length ?? 0);
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({
+          activity_id: activityId,
+          project_id: projectId,
+          description: trimmed,
+          position: nextPosition,
+          is_done: false,
+        } as never)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as unknown as ActivityChecklistItem;
+    },
+    onSuccess: () => {
+      invalidate();
+    },
+    onError: (err: Error) => {
+      toast.error('Não foi possível adicionar o item', { description: err.message });
+    },
+  });
+
+  const toggleItem = useMutation({
+    mutationFn: async ({ id, is_done }: { id: string; is_done: boolean }) => {
+      const { error } = await supabase
+        .from(TABLE)
+        .update({ is_done } as never)
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onMutate: async ({ id, is_done }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData<ActivityChecklistItem[]>(queryKey);
+      if (prev) {
+        queryClient.setQueryData<ActivityChecklistItem[]>(
+          queryKey,
+          prev.map((it) => (it.id === id ? { ...it, is_done } : it)),
+        );
+      }
+      return { prev };
+    },
+    onError: (err: Error, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
+      toast.error('Não foi possível atualizar o item', { description: err.message });
+    },
+    onSettled: () => invalidate(),
+  });
+
+  const editItem = useMutation({
+    mutationFn: async ({ id, description }: { id: string; description: string }) => {
+      const trimmed = description.trim();
+      if (!trimmed) throw new Error('Descrição vazia');
+      const { error } = await supabase
+        .from(TABLE)
+        .update({ description: trimmed } as never)
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => invalidate(),
+    onError: (err: Error) => {
+      toast.error('Não foi possível editar o item', { description: err.message });
+    },
+  });
+
+  const deleteItem = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase.from(TABLE).delete().eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => invalidate(),
+    onError: (err: Error) => {
+      toast.error('Não foi possível excluir o item', { description: err.message });
+    },
+  });
+
+  const items = query.data ?? [];
+  const total = items.length;
+  const doneCount = items.filter((i) => i.is_done).length;
+  const progress = total === 0 ? 0 : Math.round((doneCount / total) * 100);
+
+  return {
+    items,
+    isLoading: query.isLoading,
+    error: query.error,
+    total,
+    doneCount,
+    progress,
+    addItem,
+    toggleItem,
+    editItem,
+    deleteItem,
+  };
+}

--- a/src/hooks/useActivityPhotos.ts
+++ b/src/hooks/useActivityPhotos.ts
@@ -1,0 +1,182 @@
+/**
+ * useActivityPhotos — galeria de fotos de uma atividade do cronograma.
+ *
+ * Arquivos vivem no bucket privado `activity-photos` em paths
+ *   "<project_id>/<activity_id>/<uuid>.<ext>"
+ * A tabela `project_activity_photos` guarda apenas metadata.
+ *
+ * Para exibição, geramos signed URLs sob demanda (1h de validade).
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+const BUCKET = 'activity-photos';
+const TABLE = 'project_activity_photos' as never;
+const SIGNED_URL_TTL = 60 * 60; // 1h
+
+export interface ActivityPhoto {
+  id: string;
+  activity_id: string;
+  project_id: string;
+  storage_path: string;
+  caption: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  width: number | null;
+  height: number | null;
+  uploaded_by: string | null;
+  uploaded_at: string;
+  /** Preenchido em runtime após signed URL fetch. */
+  signed_url?: string;
+}
+
+const ALLOWED_MIME = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+const MAX_SIZE = 15 * 1024 * 1024; // 15 MB (alinha com o bucket)
+
+function activityPhotosKey(activityId: string | undefined) {
+  return ['activity-photos', activityId] as const;
+}
+
+export function useActivityPhotos(
+  activityId: string | undefined,
+  projectId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+  const queryKey = activityPhotosKey(activityId);
+
+  const query = useQuery({
+    queryKey,
+    enabled: !!activityId,
+    queryFn: async (): Promise<ActivityPhoto[]> => {
+      if (!activityId) return [];
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(
+          'id, activity_id, project_id, storage_path, caption, mime_type, size_bytes, width, height, uploaded_by, uploaded_at',
+        )
+        .eq('activity_id', activityId)
+        .order('uploaded_at', { ascending: false });
+      if (error) throw error;
+
+      const rows = (data ?? []) as unknown as ActivityPhoto[];
+      if (rows.length === 0) return rows;
+
+      // Gera signed URLs em batch
+      const paths = rows.map((r) => r.storage_path);
+      const { data: signed, error: signedErr } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrls(paths, SIGNED_URL_TTL);
+      if (signedErr) {
+        console.warn('[ActivityPhotos] signedUrls error', signedErr);
+        return rows;
+      }
+      const urlByPath = new Map(signed?.map((s) => [s.path, s.signedUrl]) ?? []);
+      return rows.map((r) => ({ ...r, signed_url: urlByPath.get(r.storage_path) ?? undefined }));
+    },
+    staleTime: SIGNED_URL_TTL * 1000 * 0.8,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const uploadPhotos = useMutation({
+    mutationFn: async ({ files, caption }: { files: File[]; caption?: string }) => {
+      if (!activityId || !projectId) throw new Error('Atividade não encontrada');
+      if (files.length === 0) return [];
+
+      const uploadedRows: ActivityPhoto[] = [];
+
+      for (const file of files) {
+        if (!ALLOWED_MIME.has(file.type)) {
+          throw new Error(`Tipo não suportado: ${file.type || file.name}`);
+        }
+        if (file.size > MAX_SIZE) {
+          throw new Error(`Arquivo "${file.name}" excede 15 MB`);
+        }
+        const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg';
+        const fileName = `${crypto.randomUUID()}.${ext}`;
+        const path = `${projectId}/${activityId}/${fileName}`;
+
+        const { error: upErr } = await supabase.storage
+          .from(BUCKET)
+          .upload(path, file, { contentType: file.type, upsert: false });
+        if (upErr) throw upErr;
+
+        const { data: row, error: insErr } = await supabase
+          .from(TABLE)
+          .insert({
+            activity_id: activityId,
+            project_id: projectId,
+            storage_path: path,
+            caption: caption?.trim() || null,
+            mime_type: file.type,
+            size_bytes: file.size,
+          } as never)
+          .select()
+          .single();
+
+        if (insErr) {
+          // Rollback do storage
+          await supabase.storage.from(BUCKET).remove([path]).catch(() => {});
+          throw insErr;
+        }
+        uploadedRows.push(row as unknown as ActivityPhoto);
+      }
+
+      return uploadedRows;
+    },
+    onSuccess: (rows) => {
+      if (rows.length > 0) {
+        toast.success(
+          rows.length === 1 ? 'Foto enviada' : `${rows.length} fotos enviadas`,
+        );
+      }
+      invalidate();
+    },
+    onError: (err: Error) => {
+      toast.error('Falha ao enviar foto', { description: err.message });
+    },
+  });
+
+  const updateCaption = useMutation({
+    mutationFn: async ({ id, caption }: { id: string; caption: string | null }) => {
+      const { error } = await supabase
+        .from(TABLE)
+        .update({ caption: caption?.trim() || null } as never)
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => invalidate(),
+  });
+
+  const deletePhoto = useMutation({
+    mutationFn: async (photo: ActivityPhoto) => {
+      // Remove a metadata primeiro (RLS-safe), storage depois.
+      const { error: dbErr } = await supabase.from(TABLE).delete().eq('id', photo.id);
+      if (dbErr) throw dbErr;
+      await supabase.storage.from(BUCKET).remove([photo.storage_path]).catch(() => {});
+    },
+    onSuccess: () => {
+      toast.success('Foto removida');
+      invalidate();
+    },
+    onError: (err: Error) => {
+      toast.error('Não foi possível remover', { description: err.message });
+    },
+  });
+
+  return {
+    photos: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    uploadPhotos,
+    updateCaption,
+    deletePhoto,
+  };
+}

--- a/src/pages/Cronograma.tsx
+++ b/src/pages/Cronograma.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { Plus, Trash2, Save, Loader2, AlertCircle, Upload, Bookmark, ShoppingCart, Wand2, GripVertical, ChevronDown, FileText } from 'lucide-react';
+import { Plus, Trash2, Save, Loader2, AlertCircle, Upload, Bookmark, ShoppingCart, Wand2, GripVertical, ChevronDown, FileText, ListChecks } from 'lucide-react';
 import { isHoliday } from '@/lib/businessDays';
 import { AIScheduleGenerator } from '@/components/schedule/AIScheduleGenerator';
 import { ContentSkeleton } from '@/components/ContentSkeleton';
@@ -17,6 +17,8 @@ import { toast } from 'sonner';
 import { Progress } from '@/components/ui/progress';
 import { ImportScheduleModal } from '@/components/ImportScheduleModal';
 import { CronogramaMobileView } from '@/components/cronograma/CronogramaMobileView';
+import { ActivityChecklistAndPhotos } from '@/components/cronograma/ActivityChecklistAndPhotos';
+import { useUserRole } from '@/hooks/useUserRole';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { cn } from '@/lib/utils';
 
@@ -186,6 +188,15 @@ const Cronograma = () => {
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [openDetails, setOpenDetails] = useState<Record<string, boolean>>({});
+  const [openExtras, setOpenExtras] = useState<Record<string, boolean>>({});
+  const { isStaff } = useUserRole();
+
+  // IDs de atividades já persistidas no banco (vs criadas localmente).
+  // Só atividades persistidas podem ter checklist e fotos vinculados.
+  const persistedActivityIds = useMemo(
+    () => new Set(existingActivities.map((a) => a.id)),
+    [existingActivities],
+  );
 
   const clearDragState = useCallback(() => {
     setDraggedIndex(null);
@@ -665,6 +676,24 @@ const Cronograma = () => {
                                 {hasDetail ? 'Descrição da etapa' : 'Fechar descrição'}
                               </button>
                             )}
+                            <button
+                              type="button"
+                              className={cn(
+                                'text-[11px] flex items-center gap-1 transition-colors font-medium',
+                                openExtras[activity.id]
+                                  ? 'text-primary hover:text-primary/80'
+                                  : 'text-muted-foreground/60 hover:text-primary',
+                              )}
+                              onClick={() =>
+                                setOpenExtras((prev) => ({
+                                  ...prev,
+                                  [activity.id]: !prev[activity.id],
+                                }))
+                              }
+                            >
+                              <ListChecks className="h-3 w-3" />
+                              Checklist & fotos
+                            </button>
                           </div>
                         </div>
 
@@ -722,6 +751,19 @@ const Cronograma = () => {
                             placeholder="Descreva o escopo, objetivos e entregas desta etapa do cronograma..."
                             rows={3}
                             className="text-sm resize-none"
+                          />
+                        </div>
+                      )}
+                      {openExtras[activity.id] && projectId && (
+                        <div
+                          className="border-b border-border/30 bg-muted/10 px-4 py-3"
+                          style={{ paddingLeft: 'calc(44px + 56px + 8px)' }}
+                        >
+                          <ActivityChecklistAndPhotos
+                            activityId={activity.id}
+                            projectId={projectId}
+                            isPersisted={persistedActivityIds.has(activity.id)}
+                            canEdit={isStaff}
                           />
                         </div>
                       )}
@@ -813,6 +855,36 @@ const Cronograma = () => {
                       rows={2}
                       className="text-xs resize-none"
                     />
+                  </div>
+                  <div className="pl-8">
+                    <button
+                      type="button"
+                      className={cn(
+                        'text-[11px] flex items-center gap-1 transition-colors font-medium',
+                        openExtras[activity.id]
+                          ? 'text-primary hover:text-primary/80'
+                          : 'text-muted-foreground/60 hover:text-primary',
+                      )}
+                      onClick={() =>
+                        setOpenExtras((prev) => ({
+                          ...prev,
+                          [activity.id]: !prev[activity.id],
+                        }))
+                      }
+                    >
+                      <ListChecks className="h-3 w-3" />
+                      Checklist & fotos
+                    </button>
+                    {openExtras[activity.id] && projectId && (
+                      <div className="mt-2">
+                        <ActivityChecklistAndPhotos
+                          activityId={activity.id}
+                          projectId={projectId}
+                          isPersisted={persistedActivityIds.has(activity.id)}
+                          canEdit={isStaff}
+                        />
+                      </div>
+                    )}
                   </div>
                 </div>
               );

--- a/supabase/migrations/20260424053216_activity_checklist_and_photos.sql
+++ b/supabase/migrations/20260424053216_activity_checklist_and_photos.sql
@@ -1,0 +1,250 @@
+-- ============================================================
+-- Checklist + Galeria de fotos por atividade do cronograma
+-- ------------------------------------------------------------
+-- Adiciona duas estruturas vinculadas a `project_activities`:
+--   1) project_activity_checklist_items
+--      Itens de checklist técnicos por atividade (ex.: "teste de
+--      estanqueidade assinado", "metais testados"). Cada item pode
+--      ser marcado como done com timestamp e usuário.
+--
+--   2) project_activity_photos
+--      Galeria de fotos por atividade. Os arquivos vivem no bucket
+--      `activity-photos` (privado), e a tabela só guarda metadata.
+--
+-- Ambas reutilizam o mesmo padrão de RLS já consagrado em outras
+-- tabelas project-scoped: leitura para project members ou customers
+-- vinculados; escrita apenas para staff (engineer/admin).
+-- ============================================================
+
+-- 1) Checklist de atividades ------------------------------------------
+CREATE TABLE IF NOT EXISTS public.project_activity_checklist_items (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  activity_id  UUID NOT NULL REFERENCES public.project_activities(id) ON DELETE CASCADE,
+  project_id   UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  description  TEXT NOT NULL,
+  position     INT  NOT NULL DEFAULT 0,
+  is_done      BOOLEAN NOT NULL DEFAULT false,
+  done_at      TIMESTAMPTZ NULL,
+  done_by      UUID NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by   UUID NULL REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_checklist_activity
+  ON public.project_activity_checklist_items (activity_id, position);
+CREATE INDEX IF NOT EXISTS idx_activity_checklist_project
+  ON public.project_activity_checklist_items (project_id);
+
+COMMENT ON TABLE public.project_activity_checklist_items IS
+  'Itens de checklist técnico vinculados a uma atividade do cronograma.';
+
+-- Trigger: mantém done_at/done_by sincronizados com is_done
+CREATE OR REPLACE FUNCTION public.sync_checklist_done_meta()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.created_by := COALESCE(NEW.created_by, auth.uid());
+    IF NEW.is_done THEN
+      NEW.done_at := COALESCE(NEW.done_at, now());
+      NEW.done_by := COALESCE(NEW.done_by, auth.uid());
+    END IF;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF NEW.is_done IS DISTINCT FROM OLD.is_done THEN
+      IF NEW.is_done THEN
+        NEW.done_at := COALESCE(NEW.done_at, now());
+        NEW.done_by := COALESCE(NEW.done_by, auth.uid());
+      ELSE
+        NEW.done_at := NULL;
+        NEW.done_by := NULL;
+      END IF;
+    END IF;
+    NEW.updated_at := now();
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_checklist_done_meta ON public.project_activity_checklist_items;
+CREATE TRIGGER trg_checklist_done_meta
+  BEFORE INSERT OR UPDATE ON public.project_activity_checklist_items
+  FOR EACH ROW EXECUTE FUNCTION public.sync_checklist_done_meta();
+
+-- RLS: leitura para members/customers, escrita só para staff
+ALTER TABLE public.project_activity_checklist_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "checklist_select_member_or_customer"
+  ON public.project_activity_checklist_items;
+CREATE POLICY "checklist_select_member_or_customer"
+  ON public.project_activity_checklist_items
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.project_members pm
+      WHERE pm.user_id = auth.uid()
+        AND pm.project_id = project_activity_checklist_items.project_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.project_customers pc
+      WHERE pc.customer_user_id = auth.uid()
+        AND pc.project_id = project_activity_checklist_items.project_id
+    )
+    OR public.is_staff(auth.uid())
+  );
+
+DROP POLICY IF EXISTS "checklist_insert_staff"
+  ON public.project_activity_checklist_items;
+CREATE POLICY "checklist_insert_staff"
+  ON public.project_activity_checklist_items
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "checklist_update_staff"
+  ON public.project_activity_checklist_items;
+CREATE POLICY "checklist_update_staff"
+  ON public.project_activity_checklist_items
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_staff(auth.uid()))
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "checklist_delete_staff"
+  ON public.project_activity_checklist_items;
+CREATE POLICY "checklist_delete_staff"
+  ON public.project_activity_checklist_items
+  FOR DELETE
+  TO authenticated
+  USING (public.is_staff(auth.uid()));
+
+-- 2) Bucket de fotos ---------------------------------------------------
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'activity-photos',
+  'activity-photos',
+  false,
+  15728640,                                           -- 15 MB
+  ARRAY['image/jpeg','image/png','image/webp','image/heic','image/heif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Policies de storage para o bucket: paths são "<project_id>/<activity_id>/<file>"
+DROP POLICY IF EXISTS "activity_photos_read"
+  ON storage.objects;
+CREATE POLICY "activity_photos_read"
+  ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'activity-photos'
+    AND (
+      public.is_staff(auth.uid())
+      OR EXISTS (
+        SELECT 1 FROM public.project_members pm
+        WHERE pm.user_id = auth.uid()
+          AND pm.project_id::text = (storage.foldername(name))[1]
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.project_customers pc
+        WHERE pc.customer_user_id = auth.uid()
+          AND pc.project_id::text = (storage.foldername(name))[1]
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "activity_photos_write_staff"
+  ON storage.objects;
+CREATE POLICY "activity_photos_write_staff"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'activity-photos'
+    AND public.is_staff(auth.uid())
+  );
+
+DROP POLICY IF EXISTS "activity_photos_delete_staff"
+  ON storage.objects;
+CREATE POLICY "activity_photos_delete_staff"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'activity-photos'
+    AND public.is_staff(auth.uid())
+  );
+
+-- 3) Tabela de metadata das fotos -------------------------------------
+CREATE TABLE IF NOT EXISTS public.project_activity_photos (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  activity_id  UUID NOT NULL REFERENCES public.project_activities(id) ON DELETE CASCADE,
+  project_id   UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  storage_path TEXT NOT NULL,                        -- "<project_id>/<activity_id>/<file>"
+  caption      TEXT NULL,
+  mime_type    TEXT NULL,
+  size_bytes   BIGINT NULL,
+  width        INT NULL,
+  height       INT NULL,
+  uploaded_by  UUID NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  uploaded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_photos_activity
+  ON public.project_activity_photos (activity_id, uploaded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_photos_project
+  ON public.project_activity_photos (project_id);
+
+COMMENT ON TABLE public.project_activity_photos IS
+  'Galeria de fotos vinculadas a uma atividade do cronograma.';
+
+ALTER TABLE public.project_activity_photos ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "activity_photos_meta_select_member_or_customer"
+  ON public.project_activity_photos;
+CREATE POLICY "activity_photos_meta_select_member_or_customer"
+  ON public.project_activity_photos
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.project_members pm
+      WHERE pm.user_id = auth.uid()
+        AND pm.project_id = project_activity_photos.project_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.project_customers pc
+      WHERE pc.customer_user_id = auth.uid()
+        AND pc.project_id = project_activity_photos.project_id
+    )
+    OR public.is_staff(auth.uid())
+  );
+
+DROP POLICY IF EXISTS "activity_photos_meta_insert_staff"
+  ON public.project_activity_photos;
+CREATE POLICY "activity_photos_meta_insert_staff"
+  ON public.project_activity_photos
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "activity_photos_meta_update_staff"
+  ON public.project_activity_photos;
+CREATE POLICY "activity_photos_meta_update_staff"
+  ON public.project_activity_photos
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_staff(auth.uid()))
+  WITH CHECK (public.is_staff(auth.uid()));
+
+DROP POLICY IF EXISTS "activity_photos_meta_delete_staff"
+  ON public.project_activity_photos;
+CREATE POLICY "activity_photos_meta_delete_staff"
+  ON public.project_activity_photos
+  FOR DELETE
+  TO authenticated
+  USING (public.is_staff(auth.uid()));


### PR DESCRIPTION
## Por quê

Item 2 da Fase 1 do roadmap de melhorias do Painel de Obras: **checklist técnico e galeria de fotos por atividade do cronograma**.

Conforme alinhado, este PR não mexe na lista de etapas (continua livre/text como hoje) — apenas adiciona infra para que cada atividade do cronograma possa ter:
- itens de checklist marcáveis (ex: "teste de estanqueidade assinado", "metais testados")
- fotos como evidência de execução

## O que muda

### Banco — `supabase/migrations/20260424053216_activity_checklist_and_photos.sql`

#### `project_activity_checklist_items`
| campo | tipo | obs |
|---|---|---|
| `activity_id` | uuid | FK em `project_activities`, ON DELETE CASCADE |
| `project_id` | uuid | denormalizado p/ RLS rápido |
| `description` | text | texto do item |
| `position` | int | ordenação |
| `is_done` | boolean | |
| `done_at` / `done_by` | timestamptz / uuid | preenchidos pelo trigger ao marcar |

Trigger BEFORE INSERT/UPDATE `sync_checklist_done_meta()` mantém `done_at`/`done_by` em sincronia com `is_done` (limpa ao desmarcar).

#### `project_activity_photos`
Metadata de fotos: `storage_path`, `caption`, `mime_type`, `size_bytes`, `width`, `height`, `uploaded_by`, `uploaded_at`.

#### Bucket `activity-photos`
- Privado, 15 MB, formatos jpeg/png/webp/heic/heif
- Path padrão: `<project_id>/<activity_id>/<file>`
- Storage policies via `storage.foldername(name)[1] = project_id`

#### RLS
Reaproveita o mesmo padrão de `project_activities`:
- **SELECT**: `project_members` ∪ `project_customers` ∪ `is_staff`
- **INSERT/UPDATE/DELETE**: apenas `is_staff`

### Frontend

- **`src/hooks/useActivityChecklist.ts`** — CRUD com optimistic update no toggle, contador `doneCount/total/progress`.
- **`src/hooks/useActivityPhotos.ts`** — upload com rollback (remove do storage se a inserção da metadata falhar), signed URLs em batch (1h TTL), delete que remove ambos.
- **`src/components/cronograma/ActivityChecklistAndPhotos.tsx`** — bloco com tabs Checklist / Fotos:
  - Checklist: progress bar, edit inline, hover-actions (edit/delete)
  - Fotos: grid responsivo, upload múltiplo, lightbox, delete com hover
  - Atividades não-persistidas mostram aviso "salve para liberar"
- **`src/pages/Cronograma.tsx`** — novo botão "Checklist & fotos" em cada linha (desktop + mobile) que abre/fecha o bloco. Customers veem em modo leitura (`canEdit = isStaff`).

## Por que não bloquear conclusão da etapa pelo checklist

O doc estratégico sugere "só conclui etapa com 100% do checklist OK". Optei por **não bloquear** nesta versão — primeiro porque exigiria mudar o fluxo de salvamento, segundo porque pode atrapalhar fluxos válidos (atividade conclui antes do registro do checklist). A telemetria `done_at`/`done_by` permite enforcement futuro via UI ou trigger se quisermos.

## Como aplicar a migration

Mesma situação do PR #9 — Lovable é dono do projeto Supabase. Cole o conteúdo de `supabase/migrations/20260424053216_activity_checklist_and_photos.sql` no SQL Editor do Lovable.

Cópia local também em `/home/user/workspace/apply_activity_checklist_photos.sql`.

## Validação

- `npx tsc -b --noEmit` ✅
- `npx eslint <arquivos novos>` ✅ (apenas warnings pré-existentes em `Cronograma.tsx`)
- `npx vite build` ✅

## Risco

- **Baixo no frontend** — feature isolada, opt-in via botão por linha.
- **Baixo no banco** — duas tabelas novas + 1 bucket. Nenhuma alteração em tabela existente.
- **Atenção a custos de storage** — fotos podem crescer rápido. Considerar pruning automático ou compressão futura se virar problema.

## Próximos passos sugeridos (não neste PR)

- Regenerar `src/integrations/supabase/types.ts` para tipar as novas tabelas (remove os casts `as never`)
- Adicionar campo `block_completion_until_checklist` em `project_activities` se quiser ativar enforcement
- Vincular `obra_tasks` a esse mesmo padrão se fizer sentido
