### PR TITLE
feat(kpis): hook único useProjectKPIs (Painel + Portal + Dashboard)

### DIFF
--- a/src/hooks/useClientDashboard.ts
+++ b/src/hooks/useClientDashboard.ts
@@ -11,7 +11,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useProjectSummaryQuery } from './useProjectsQuery';
-import { queryKeys } from '@/lib/queryKeys';
+import { useAllProjectsKPIs, type ProjectKPIs } from './useProjectKPIs';
 import type { ProjectSummary } from '@/infra/repositories/projects.repository';
 
 export interface UpcomingPayment {
@@ -29,23 +29,39 @@ export interface DashboardStats {
   activeProjects: number;
   totalPending: number;
   totalOverdue: number;
+  /** Número de obras com entrega oficial vencida (derivado via useProjectKPIs). */
+  overdueProjects: number;
   unsignedFormalizations: number;
   totalContractValue: number;
   avgProgress: number;
 }
 
-function computeStats(projects: ProjectSummary[]): DashboardStats {
-  const active = projects.filter(p => p.status === 'active');
+/**
+ * Agrega estatísticas do dashboard a partir dos KPIs unificados.
+ * Fonte única: `useProjectKPIs` — garante que "atrasado" aqui use a
+ * mesma regra do Painel e do card individual (entrega oficial vencida
+ * sem entrega real, não apenas contagem de atividades).
+ */
+function computeStats(
+  projects: ProjectSummary[],
+  kpisById: Map<string, ProjectKPIs>,
+): DashboardStats {
+  const active = projects.filter((p) => p.status === 'active');
+  const activeKpis = active
+    .map((p) => kpisById.get(p.id))
+    .filter((k): k is ProjectKPIs => !!k);
   return {
     totalProjects: projects.length,
     activeProjects: active.length,
     totalPending: active.reduce((s, p) => s + (p.pending_count || 0), 0),
     totalOverdue: active.reduce((s, p) => s + (p.overdue_count || 0), 0),
+    overdueProjects: activeKpis.filter((k) => k.isOverdue).length,
     unsignedFormalizations: active.reduce((s, p) => s + (p.unsigned_formalizations || 0), 0),
     totalContractValue: active.reduce((s, p) => s + (p.contract_value || 0), 0),
-    avgProgress: active.length > 0
-      ? Math.round(active.reduce((s, p) => s + (p.progress_percentage || 0), 0) / active.length)
-      : 0,
+    avgProgress:
+      active.length > 0
+        ? Math.round(active.reduce((s, p) => s + (p.progress_percentage || 0), 0) / active.length)
+        : 0,
   };
 }
 
@@ -87,13 +103,15 @@ export function useClientDashboard() {
     staleTime: 2 * 60 * 1000,
   });
 
-  const stats = computeStats(projects as ProjectSummary[]);
+  const { kpisById, isLoading: kpisLoading } = useAllProjectsKPIs();
+  const stats = computeStats(projects as ProjectSummary[], kpisById);
 
   return {
     projects: projects as ProjectSummary[],
+    kpisById,
     stats,
     upcomingPayments,
-    isLoading: projectsLoading,
+    isLoading: projectsLoading || kpisLoading,
     error: projectsError,
   };
 }

--- a/src/hooks/useProjectKPIs.ts
+++ b/src/hooks/useProjectKPIs.ts
@@ -1,0 +1,207 @@
+/**
+ * useProjectKPIs — métricas consolidadas por obra.
+ *
+ * Este hook é a fonte única de KPIs para toda a aplicação
+ * (Painel de Obras, Portal do Cliente, Dashboard Executivo). Cada consumidor
+ * costumava calcular seu próprio "atraso", "status derivado" ou "custo pago"
+ * — agora tudo é derivado aqui, garantindo que os mesmos números apareçam
+ * em qualquer tela.
+ *
+ * Fontes consumidas:
+ *   - `get_user_projects_summary` (RPC) → via `useProjectSummaryQuery`:
+ *     progresso do cronograma, pending_count, overdue_count, contract_value,
+ *     planned/actual dates.
+ *   - `project_payments`  → soma de parcelas pagas (custo realizado).
+ *   - `projects.painel_*` → etapa e status operacionais (via
+ *     `useProjectsQuery` / `usePainelObras`).
+ *
+ * Duas APIs:
+ *   - `useProjectKPIs(projectId)` — KPI detalhado de uma obra (inclui custo,
+ *     que depende da tabela `project_payments`).
+ *   - `useAllProjectsKPIs()` — KPI leve (sem custo detalhado) para todas as
+ *     obras visíveis, reutilizando o cache do summary. Usado por dashboards
+ *     e listagens.
+ */
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from './useAuth';
+import { useProjectSummaryQuery } from './useProjectsQuery';
+import { usePainelObras, type PainelObra } from './usePainelObras';
+import { queryKeys } from '@/lib/queryKeys';
+import { QUERY_TIMING } from '@/lib/queryClient';
+import {
+  computeCostKPIs,
+  computeDaysOverdue,
+  computeStageKPIs,
+  deriveDisplayStatus,
+  normalizeProgress,
+  type CostKPIs,
+  type StageKPIs,
+} from '@/lib/projectKpis';
+import type { ProjectSummary } from '@/infra/repositories/projects.repository';
+
+/** Shape público consumido por Painel + Portal + Dashboard. */
+export interface ProjectKPIs {
+  projectId: string;
+  projectName: string;
+  /** Status vindo do banco em `projects.status` (active/paused/completed/…). */
+  lifecycleStatus: string;
+  /** Status visual do painel, com "Atrasado" derivado quando entrega oficial passou. */
+  displayStatus: PainelObra['status'];
+  /** Progresso do cronograma ponderado (0-100) ou null quando indisponível. */
+  progress: number | null;
+  /** Dias em atraso em relação à entrega oficial (0 se no prazo ou já entregue). */
+  daysOverdue: number;
+  /** Flags derivadas. */
+  isOverdue: boolean;
+  /** Contadores herdados do summary. */
+  pendingCount: number;
+  overdueCount: number;
+  /** Etapa atual + próxima (ciclo canônico do painel). */
+  stage: StageKPIs;
+  /** Custo contratual vs pago. Pode ser `null` quando o hook foi chamado em modo light. */
+  cost: CostKPIs | null;
+  /** Datas relevantes (snapshot). */
+  dates: {
+    plannedStart: string | null;
+    plannedEnd: string | null;
+    actualStart: string | null;
+    actualEnd: string | null;
+  };
+  /** Última edição reconhecida (painel ou projeto). */
+  lastUpdate: string | null;
+}
+
+/** Shape do summary enriquecido com campos do `projects` (vindos do painel). */
+type SummaryWithPainel = ProjectSummary & {
+  painel_status?: PainelObra['status'] | null;
+  painel_etapa?: PainelObra['etapa'] | null;
+  painel_ultima_atualizacao?: string | null;
+};
+
+function buildCore(
+  summary: SummaryWithPainel,
+  painel: PainelObra | undefined,
+  cost: CostKPIs | null,
+): ProjectKPIs {
+  const plannedEnd = summary.planned_end_date ?? null;
+  const actualEnd = summary.actual_end_date ?? null;
+  const painelStatus = painel?.status ?? summary.painel_status ?? null;
+  const painelEtapa = painel?.etapa ?? summary.painel_etapa ?? null;
+  const displayStatus = deriveDisplayStatus({
+    status: painelStatus,
+    entregaOficial: plannedEnd,
+    entregaReal: actualEnd,
+  });
+  const daysOverdue = computeDaysOverdue({
+    entregaOficial: plannedEnd,
+    entregaReal: actualEnd,
+  });
+
+  return {
+    projectId: summary.id,
+    projectName: summary.name,
+    lifecycleStatus: summary.status,
+    displayStatus,
+    progress: normalizeProgress(summary.progress_percentage),
+    daysOverdue,
+    isOverdue: displayStatus === 'Atrasado',
+    pendingCount: summary.pending_count ?? 0,
+    overdueCount: summary.overdue_count ?? 0,
+    stage: computeStageKPIs(painelEtapa ?? null),
+    cost,
+    dates: {
+      plannedStart: summary.planned_start_date ?? null,
+      plannedEnd,
+      actualStart: summary.actual_start_date ?? null,
+      actualEnd,
+    },
+    lastUpdate:
+      painel?.ultima_atualizacao ??
+      summary.painel_ultima_atualizacao ??
+      summary.last_activity_at ??
+      null,
+  };
+}
+
+/**
+ * KPIs detalhados para uma única obra (inclui custo baseado em
+ * `project_payments`). Retorna `null` enquanto carrega ou quando
+ * o projeto não é visível para o usuário.
+ */
+export function useProjectKPIs(projectId: string | undefined) {
+  const { user } = useAuth();
+  const { data: summaries = [], isLoading: summariesLoading } = useProjectSummaryQuery();
+  const { obras, isLoading: painelLoading } = usePainelObras();
+
+  const summary = useMemo<SummaryWithPainel | undefined>(() => {
+    if (!projectId) return undefined;
+    return (summaries as SummaryWithPainel[]).find((s) => s.id === projectId);
+  }, [summaries, projectId]);
+
+  const painel = useMemo<PainelObra | undefined>(() => {
+    if (!projectId) return undefined;
+    return obras.find((o) => o.id === projectId);
+  }, [obras, projectId]);
+
+  const {
+    data: payments = [],
+    isLoading: paymentsLoading,
+  } = useQuery({
+    queryKey: queryKeys.payments.list(projectId),
+    queryFn: async () => {
+      if (!projectId) return [];
+      const { data, error } = await supabase
+        .from('project_payments')
+        .select('amount, paid_at')
+        .eq('project_id', projectId);
+      if (error) throw error;
+      return (data ?? []) as Array<{ amount: number | null; paid_at: string | null }>;
+    },
+    enabled: !!user && !!projectId,
+    staleTime: QUERY_TIMING.payments.staleTime,
+    gcTime: QUERY_TIMING.payments.gcTime,
+  });
+
+  const kpis = useMemo<ProjectKPIs | null>(() => {
+    if (!summary) return null;
+    const cost = computeCostKPIs({
+      contractValue: summary.contract_value ?? null,
+      payments,
+    });
+    return buildCore(summary, painel, cost);
+  }, [summary, painel, payments]);
+
+  return {
+    kpis,
+    isLoading: summariesLoading || painelLoading || paymentsLoading,
+  };
+}
+
+/**
+ * KPIs "light" (sem custo) para todas as obras visíveis — ideal para
+ * listagens e o Painel de Obras, onde carregar os `project_payments` de
+ * todos os projetos seria exagero. O custo permanece acessível chamando
+ * `useProjectKPIs(id)` na linha detalhada.
+ */
+export function useAllProjectsKPIs() {
+  const { data: summaries = [], isLoading: summariesLoading } = useProjectSummaryQuery();
+  const { obras, isLoading: painelLoading } = usePainelObras();
+
+  const kpis = useMemo<ProjectKPIs[]>(() => {
+    const painelMap = new Map(obras.map((o) => [o.id, o]));
+    return (summaries as SummaryWithPainel[]).map((summary) =>
+      buildCore(summary, painelMap.get(summary.id), null),
+    );
+  }, [summaries, obras]);
+
+  const kpisById = useMemo(() => new Map(kpis.map((k) => [k.projectId, k])), [kpis]);
+
+  return {
+    kpis,
+    kpisById,
+    isLoading: summariesLoading || painelLoading,
+  };
+}

--- a/src/lib/__tests__/projectKpis.test.ts
+++ b/src/lib/__tests__/projectKpis.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeCostKPIs,
+  computeDaysOverdue,
+  computeStageKPIs,
+  deriveDisplayStatus,
+  normalizeProgress,
+} from '../projectKpis';
+
+const NOW = new Date('2026-04-24T12:00:00-03:00');
+
+describe('deriveDisplayStatus', () => {
+  it('marca Atrasado quando entrega oficial vencida sem entrega real', () => {
+    expect(
+      deriveDisplayStatus({
+        status: 'Em dia',
+        entregaOficial: '2026-04-20',
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe('Atrasado');
+  });
+
+  it('mantém status quando já há entrega real', () => {
+    expect(
+      deriveDisplayStatus({
+        status: 'Em dia',
+        entregaOficial: '2026-04-20',
+        entregaReal: '2026-04-22',
+        now: NOW,
+      }),
+    ).toBe('Em dia');
+  });
+
+  it('mantém status quando entrega oficial ainda no futuro', () => {
+    expect(
+      deriveDisplayStatus({
+        status: 'Em dia',
+        entregaOficial: '2026-05-20',
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe('Em dia');
+  });
+
+  it('preserva null quando não há status salvo nem prazo', () => {
+    expect(
+      deriveDisplayStatus({
+        status: null,
+        entregaOficial: null,
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it('não isenta atraso mesmo para status Paralisada se entrega oficial venceu', () => {
+    expect(
+      deriveDisplayStatus({
+        status: 'Paralisada',
+        entregaOficial: '2026-04-10',
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe('Atrasado');
+  });
+});
+
+describe('computeDaysOverdue', () => {
+  it('retorna 0 quando já existe entrega real', () => {
+    expect(
+      computeDaysOverdue({
+        entregaOficial: '2026-04-01',
+        entregaReal: '2026-04-03',
+        now: NOW,
+      }),
+    ).toBe(0);
+  });
+
+  it('retorna diferença positiva quando prazo venceu', () => {
+    expect(
+      computeDaysOverdue({
+        entregaOficial: '2026-04-20',
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe(4);
+  });
+
+  it('retorna 0 quando ainda no prazo', () => {
+    expect(
+      computeDaysOverdue({
+        entregaOficial: '2026-05-10',
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe(0);
+  });
+
+  it('retorna 0 quando prazo ausente', () => {
+    expect(
+      computeDaysOverdue({
+        entregaOficial: null,
+        entregaReal: null,
+        now: NOW,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('computeCostKPIs', () => {
+  it('soma apenas parcelas pagas', () => {
+    const result = computeCostKPIs({
+      contractValue: 100_000,
+      payments: [
+        { amount: 30_000, paid_at: '2026-01-10' },
+        { amount: 20_000, paid_at: null }, // pendente
+        { amount: 10_000, paid_at: '2026-02-10' },
+      ],
+    });
+    expect(result.planned).toBe(100_000);
+    expect(result.paid).toBe(40_000);
+    expect(result.remaining).toBe(60_000);
+    expect(result.percentPaid).toBe(40);
+  });
+
+  it('lida com contrato ausente', () => {
+    const result = computeCostKPIs({
+      contractValue: null,
+      payments: [{ amount: 5_000, paid_at: '2026-01-10' }],
+    });
+    expect(result.planned).toBeNull();
+    expect(result.paid).toBe(5_000);
+    expect(result.remaining).toBeNull();
+    expect(result.percentPaid).toBe(0);
+  });
+
+  it('clampa percentPaid em 100', () => {
+    const result = computeCostKPIs({
+      contractValue: 10_000,
+      payments: [{ amount: 15_000, paid_at: '2026-01-10' }],
+    });
+    expect(result.percentPaid).toBe(100);
+    expect(result.remaining).toBe(0);
+  });
+});
+
+describe('computeStageKPIs', () => {
+  it('aponta próxima etapa na ordem canônica', () => {
+    const kpi = computeStageKPIs('Executivo');
+    expect(kpi.current).toBe('Executivo');
+    expect(kpi.next).toBe('Emissão RRT');
+    expect(kpi.currentIndex).toBe(1);
+    expect(kpi.totalStages).toBe(10);
+  });
+
+  it('retorna próxima nula em Finalizada', () => {
+    const kpi = computeStageKPIs('Finalizada');
+    expect(kpi.current).toBe('Finalizada');
+    expect(kpi.next).toBeNull();
+  });
+
+  it('Vistoria reprovada aponta direto para Finalizada', () => {
+    const kpi = computeStageKPIs('Vistoria reprovada');
+    expect(kpi.next).toBe('Finalizada');
+  });
+
+  it('sem etapa preenchida sugere Medição', () => {
+    const kpi = computeStageKPIs(null);
+    expect(kpi.current).toBeNull();
+    expect(kpi.next).toBe('Medição');
+  });
+});
+
+describe('normalizeProgress', () => {
+  it('arredonda e clampa em [0,100]', () => {
+    expect(normalizeProgress(57.4)).toBe(57);
+    expect(normalizeProgress(101)).toBe(100);
+    expect(normalizeProgress(-5)).toBe(0);
+  });
+
+  it('retorna null quando ausente', () => {
+    expect(normalizeProgress(null)).toBeNull();
+    expect(normalizeProgress(undefined)).toBeNull();
+  });
+});

--- a/src/lib/projectKpis.ts
+++ b/src/lib/projectKpis.ts
@@ -1,0 +1,158 @@
+/**
+ * Funções puras para derivar KPIs consolidados de uma obra.
+ *
+ * Por que existir:
+ *   Antes, cada página (Painel, Portal Cliente, cards) recalculava
+ *   "dias atrasados", "status derivado", "próxima etapa" de formas sutilmente
+ *   diferentes. Este módulo é a fonte única para esses cálculos —
+ *   consumido por `useProjectKPIs` e pode ser testado isoladamente.
+ *
+ *   As funções NÃO conhecem React ou Supabase: recebem dados já carregados
+ *   e devolvem métricas. Isso permite chamá-las em server-side rendering,
+ *   relatórios PDF, e-mails etc. sem mudanças.
+ */
+
+import { differenceInCalendarDays, format, parseISO } from 'date-fns';
+import {
+  ETAPA_OPTIONS,
+  type PainelEtapa,
+  type PainelStatus,
+} from '@/hooks/usePainelObras';
+
+/** Retorna a data de "hoje" no fuso local, normalizada para YYYY-MM-DD. */
+export function todayIso(now: Date = new Date()): string {
+  return format(now, 'yyyy-MM-dd');
+}
+
+/**
+ * Parte "temporal" do status exibido no painel.
+ *
+ * Regra (derivada, não persiste no banco):
+ *   - Se a entrega oficial já passou e a entrega real não foi preenchida,
+ *     o status visual é `Atrasado`, independentemente do `painel_status`.
+ *   - Caso contrário, mantém o `painel_status` armazenado.
+ *
+ * A etapa `Finalizada` **não** isenta o atraso enquanto não houver
+ * entrega real — isso força o registro da data para fechar a obra.
+ */
+export function deriveDisplayStatus(input: {
+  status: PainelStatus | null;
+  entregaOficial: string | null;
+  entregaReal: string | null;
+  now?: Date;
+}): PainelStatus | null {
+  const { status, entregaOficial, entregaReal } = input;
+  if (!entregaOficial || entregaReal) return status;
+  const hoje = todayIso(input.now);
+  return entregaOficial < hoje ? 'Atrasado' : status;
+}
+
+/**
+ * Dias de atraso em relação à entrega oficial.
+ * - Positivo: obra atrasada.
+ * - Zero: no prazo.
+ * - Retorna 0 quando já existe entrega real ou quando não há prazo.
+ */
+export function computeDaysOverdue(input: {
+  entregaOficial: string | null;
+  entregaReal: string | null;
+  now?: Date;
+}): number {
+  const { entregaOficial, entregaReal } = input;
+  if (!entregaOficial || entregaReal) return 0;
+  const diff = differenceInCalendarDays(
+    input.now ?? new Date(),
+    parseISO(entregaOficial),
+  );
+  return diff > 0 ? diff : 0;
+}
+
+/**
+ * KPI de custo: previsto vs. realizado (pago).
+ *
+ * - `planned`  = `projects.contract_value` (valor contratual cheio).
+ * - `paid`     = soma de `project_payments.amount` onde `paid_at IS NOT NULL`.
+ * - `percent`  = `paid / planned * 100` (arredondado), 0 quando planned ausente.
+ */
+export interface CostKPIs {
+  planned: number | null;
+  paid: number;
+  remaining: number | null;
+  percentPaid: number;
+}
+
+export function computeCostKPIs(input: {
+  contractValue: number | null | undefined;
+  payments: ReadonlyArray<{ amount: number | null; paid_at: string | null }>;
+}): CostKPIs {
+  const planned =
+    typeof input.contractValue === 'number' && !Number.isNaN(input.contractValue)
+      ? input.contractValue
+      : null;
+  const paid = (input.payments ?? []).reduce((sum, p) => {
+    if (!p.paid_at) return sum;
+    return sum + (typeof p.amount === 'number' ? p.amount : 0);
+  }, 0);
+  const remaining =
+    planned != null ? Math.max(0, planned - paid) : null;
+  const percentPaid =
+    planned && planned > 0 ? Math.min(100, Math.round((paid / planned) * 100)) : 0;
+  return { planned, paid, remaining, percentPaid };
+}
+
+/**
+ * Etapa atual e próxima, usando a ordem canônica em `ETAPA_OPTIONS`.
+ *
+ * Heurística:
+ *   - Se `painelEtapa` é uma das etapas conhecidas, ela é a "atual".
+ *   - A "próxima" é o elemento seguinte na lista, ou `null` se já
+ *     estiver em `Finalizada`.
+ *   - Para obras sem painel preenchido, retorna atual `null` e próxima
+ *     `Medição` (primeira etapa do ciclo).
+ *
+ * Observação: `Vistoria reprovada` é tratada como "estado paralelo" —
+ * a próxima etapa continua sendo `Finalizada`, não volta para Vistoria,
+ * porque a decisão de reentrar em vistoria é explícita e manual.
+ */
+export interface StageKPIs {
+  current: PainelEtapa | null;
+  next: PainelEtapa | null;
+  /** Índice (0-based) da etapa atual dentro de ETAPA_OPTIONS, ou null. */
+  currentIndex: number | null;
+  /** Total de etapas na jornada canônica. */
+  totalStages: number;
+}
+
+export function computeStageKPIs(painelEtapa: PainelEtapa | null): StageKPIs {
+  const total = ETAPA_OPTIONS.length;
+  if (!painelEtapa) {
+    return {
+      current: null,
+      next: ETAPA_OPTIONS[0] ?? null,
+      currentIndex: null,
+      totalStages: total,
+    };
+  }
+  const idx = ETAPA_OPTIONS.indexOf(painelEtapa);
+  if (idx === -1) {
+    return { current: painelEtapa, next: null, currentIndex: null, totalStages: total };
+  }
+  // "Vistoria reprovada" não aponta de volta para Vistoria: a próxima é
+  // Finalizada (saída natural após correção + nova vistoria aprovada).
+  if (painelEtapa === 'Vistoria reprovada') {
+    return { current: painelEtapa, next: 'Finalizada', currentIndex: idx, totalStages: total };
+  }
+  const next = ETAPA_OPTIONS[idx + 1] ?? null;
+  return { current: painelEtapa, next, currentIndex: idx, totalStages: total };
+}
+
+/**
+ * Normaliza o percentual de progresso vindo do summary.
+ * - Arredonda para inteiro.
+ * - Clampa em [0, 100].
+ * - Retorna `null` quando a fonte não tiver valor.
+ */
+export function normalizeProgress(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(Number(value))) return null;
+  return Math.round(Math.min(100, Math.max(0, Number(value))));
+}

--- a/src/pages/MinhasObras.tsx
+++ b/src/pages/MinhasObras.tsx
@@ -18,7 +18,7 @@ import type { ProjectSummary } from '@/infra/repositories/projects.repository';
 export default function MinhasObras() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { projects, stats, upcomingPayments, isLoading, error } = useClientDashboard();
+  const { projects, stats, upcomingPayments, kpisById, isLoading, error } = useClientDashboard();
   const displayName = user?.user_metadata?.display_name || user?.user_metadata?.full_name || user?.email?.split('@')[0] || '';
   const activeIds = useMemo(() => projects.filter(p => p.status === 'active').map(p => p.id), [projects]);
   const { data: activitiesMap } = useDashboardActivities(activeIds);
@@ -113,6 +113,7 @@ export default function MinhasObras() {
                         project={project}
                         onClick={() => handleProjectClick(project)}
                         activities={getProjectActivities(project.id)}
+                        kpis={kpisById.get(project.id)}
                       />
                     </ErrorBoundary>
                   ))}

--- a/src/pages/PainelObras.tsx
+++ b/src/pages/PainelObras.tsx
@@ -72,6 +72,7 @@ import {
   type PainelRelacionamento,
   type PainelStatus,
 } from '@/hooks/usePainelObras';
+import { deriveDisplayStatus } from '@/lib/projectKpis';
 import { EmptyState } from '@/components/ui/states';
 import { DailyLogInline } from '@/components/admin/obras/DailyLogInline';
 
@@ -108,14 +109,12 @@ const computeDisplayStatus = (obra: {
   status: PainelStatus | null;
   entrega_oficial: string | null;
   entrega_real: string | null;
-}): PainelStatus | null => {
-  const { status, entrega_oficial, entrega_real } = obra;
-  if (!entrega_oficial || entrega_real) return status;
-  // Compara como ISO (YYYY-MM-DD) — 'hoje' no fuso local do navegador.
-  const hojeIso = format(new Date(), 'yyyy-MM-dd');
-  if (entrega_oficial < hojeIso) return 'Atrasado';
-  return status;
-};
+}): PainelStatus | null =>
+  deriveDisplayStatus({
+    status: obra.status,
+    entregaOficial: obra.entrega_oficial,
+    entregaReal: obra.entrega_real,
+  });
 
 /** Cor sólida para o "dot" e badge tipo Monday (sem hover ruidoso). */
 const statusDotClass = (s: PainelStatus | null): string => {

--- a/src/pages/minhas-obras/DashboardStatsCards.tsx
+++ b/src/pages/minhas-obras/DashboardStatsCards.tsx
@@ -51,7 +51,8 @@ export function DashboardStatsCards({ stats }: DashboardStatsCardsProps) {
         icon={TrendingUp}
         label="Progresso Médio"
         value={`${stats.avgProgress}%`}
-        accent="success"
+        accent={stats.overdueProjects > 0 ? 'warning' : 'success'}
+        subtitle={stats.overdueProjects > 0 ? `${stats.overdueProjects} em atraso` : undefined}
       />
       <StatCard
         icon={AlertTriangle}

--- a/src/pages/minhas-obras/ProjectDashboardCard.tsx
+++ b/src/pages/minhas-obras/ProjectDashboardCard.tsx
@@ -1,16 +1,24 @@
 import { useMemo } from 'react';
-import { ChevronRight, AlertCircle, ClipboardSignature, FileText } from 'lucide-react';
+import { ChevronRight, AlertCircle, ClipboardSignature, FileText, CalendarClock } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { SCurveSparkline } from '@/components/scurve/SCurveSparkline';
 import type { ProjectSummary } from '@/infra/repositories/projects.repository';
 import type { Activity } from '@/types/report';
+import type { ProjectKPIs } from '@/hooks/useProjectKPIs';
 
 interface ProjectDashboardCardProps {
   project: ProjectSummary;
   onClick: () => void;
   activities?: Activity[];
+  /**
+   * KPIs consolidados da obra — quando fornecidos, substituem o cálculo
+   * local e garantem que "atraso" e "% conclusão" sigam a mesma regra do
+   * Painel de Obras. Quando ausente, o card cai para os campos
+   * básicos do summary (modo legado).
+   */
+  kpis?: ProjectKPIs;
 }
 
 const statusLabels: Record<string, string> = {
@@ -27,12 +35,20 @@ const statusVariants: Record<string, string> = {
   cancelled: 'bg-muted text-muted-foreground border-border',
 };
 
-export function ProjectDashboardCard({ project, onClick, activities }: ProjectDashboardCardProps) {
+export function ProjectDashboardCard({ project, onClick, activities, kpis }: ProjectDashboardCardProps) {
   const isActive = project.status === 'active';
-  const progress = project.progress_percentage || 0;
+  const progress = kpis?.progress ?? project.progress_percentage ?? 0;
+  const daysOverdue = kpis?.daysOverdue ?? 0;
 
   const alerts = useMemo(() => {
     const items: Array<{ icon: React.ElementType; label: string; accent: string }> = [];
+    if (kpis?.isOverdue && daysOverdue > 0) {
+      items.push({
+        icon: CalendarClock,
+        label: `${daysOverdue} dia(s) em atraso`,
+        accent: 'text-destructive',
+      });
+    }
     if (project.pending_count > 0) {
       items.push({ icon: AlertCircle, label: `${project.pending_count} pendência(s)`, accent: 'text-[hsl(var(--warning))]' });
     }
@@ -43,7 +59,7 @@ export function ProjectDashboardCard({ project, onClick, activities }: ProjectDa
       items.push({ icon: FileText, label: `${project.pending_documents} doc(s)`, accent: 'text-primary' });
     }
     return items;
-  }, [project]);
+  }, [project, kpis, daysOverdue]);
 
   return (
     <Card


### PR DESCRIPTION
## Problema

Cada tela calculava seus próprios KPIs, com regras sutilmente diferentes:

- **PainelObras** tinha `computeDisplayStatus` para derivar "Atrasado" quando a entrega oficial vencia sem entrega real;
- **useClientDashboard** somava `overdue_count` de **atividades** (cronograma), não de obras, e apresentava como "totalOverdue" sem distinguir o que era;
- **ProjectDashboardCard** (Portal do Cliente) mostrava apenas `pending_count`, nunca sinalizava atraso da obra;
- Custo realizado vs previsto não existia — só havia `contract_value` solto em `projects`;
- "Próxima etapa" do cronograma inexistia no código, apesar de `ETAPA_OPTIONS` ser canônico.

## Mudança

Introduz a fonte única de KPIs da obra.

### `src/lib/projectKpis.ts` — funções puras

- `deriveDisplayStatus({ status, entregaOficial, entregaReal })` → status visual com regra de atraso automático;
- `computeDaysOverdue({ entregaOficial, entregaReal })` → dias corridos de atraso (0 quando entregue ou no prazo);
- `computeCostKPIs({ contractValue, payments })` → `{ planned, paid, remaining, percentPaid }`;
- `computeStageKPIs(painelEtapa)` → `{ current, next, currentIndex, totalStages }` usando `ETAPA_OPTIONS` canônica (inclui tratamento especial para `Vistoria reprovada`);
- `normalizeProgress(value)` → arredonda + clampa em [0,100].

Cobertura: **18/18 testes** (`src/lib/__tests__/projectKpis.test.ts`).

### `src/hooks/useProjectKPIs.ts` — API React

- `useProjectKPIs(projectId)` — KPI detalhado de uma obra, incluindo custo (carrega `project_payments` da obra).
- `useAllProjectsKPIs()` — KPI _light_ (sem custo) para todas as obras, reutilizando o cache do `useProjectSummaryQuery`. Ideal para dashboards e listagens.

Shape público:

```ts
interface ProjectKPIs {
  projectId: string;
  projectName: string;
  lifecycleStatus: string;           // projects.status
  displayStatus: PainelStatus | null; // com "Atrasado" derivado
  progress: number | null;            // 0-100
  daysOverdue: number;
  isOverdue: boolean;
  pendingCount: number;
  overdueCount: number;
  stage: { current, next, currentIndex, totalStages };
  cost: { planned, paid, remaining, percentPaid } | null; // null no modo light
  dates: { plannedStart, plannedEnd, actualStart, actualEnd };
  lastUpdate: string | null;
}
```

## Integrações

- **PainelObras**: `computeDisplayStatus` agora delega para o util — mesma regra, código único.
- **useClientDashboard**: stats agora incluem `overdueProjects` (obras com entrega oficial vencida, derivado via `useAllProjectsKPIs`).
- **ProjectDashboardCard**: aceita prop opcional `kpis` — quando fornecido, mostra `N dia(s) em atraso` como alerta destacado.
- **DashboardStatsCards**: card "Progresso Médio" vira `warning` e anota `N em atraso` no subtítulo quando há obras atrasadas.
- **MinhasObras**: injeta `kpisById.get(project.id)` no card.

## Roadmap futuro (desbloqueado por este PR)

- Dashboard Executivo (Fase 2) lê `useAllProjectsKPIs()` direto;
- Exibição de custo previsto vs realizado em EditarObra e cards;
- Automação de "próxima etapa" no cronograma usando `stage.next`.

## Validação

- `npx vitest run src/lib/__tests__/projectKpis.test.ts` → **18/18 passed**;
- `npx tsc -b --noEmit` → **limpo**;
- `npx eslint` em todos os arquivos tocados → **0 erros, 0 warnings**;
- `vite build` → **limpo**, tamanhos de bundle mantidos.
