### PR TITLE
feat: repositório único de documentos + módulo Marcenaria

### DIFF
--- a/src/components/tabs/DocumentosContent.tsx
+++ b/src/components/tabs/DocumentosContent.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback, useMemo, memo } from "react";
-import { Download, FileText, Box, Ruler, Award, ClipboardList, Receipt, Shield, Building, CheckSquare, FilePlus, Loader2, History, ShieldCheck, Plus, ChevronRight, Trash2 } from "lucide-react";
+import { Download, FileText, Box, Ruler, Award, ClipboardList, Receipt, Shield, Building, CheckSquare, FilePlus, Loader2, History, ShieldCheck, Plus, ChevronRight, Trash2, Hammer, Barcode, BadgeCheck, Camera, File, Search, X } from "lucide-react";
 import { toast } from "sonner";
 import { useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ContentSkeleton } from "@/components/ContentSkeleton";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -32,6 +33,11 @@ const categoryIcons: Record<DocumentCategory, React.ReactNode> = {
   garantia: <Shield className="w-5 h-5" />,
   as_built: <Building className="w-5 h-5" />,
   termo_entrega: <CheckSquare className="w-5 h-5" />,
+  marcenaria: <Hammer className="w-5 h-5" />,
+  boleto: <Barcode className="w-5 h-5" />,
+  comprovante: <BadgeCheck className="w-5 h-5" />,
+  foto_obra: <Camera className="w-5 h-5" />,
+  outro: <File className="w-5 h-5" />,
 };
 
 const DocumentCard = ({ 
@@ -214,6 +220,8 @@ const DocumentosContent = () => {
   const deleteDocMutation = useDeleteDocumentMutation();
   const [selectedTab, setSelectedTab] = useState<string>("all");
   const [historyDocId, setHistoryDocId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [categoryFilters, setCategoryFilters] = useState<DocumentCategory[]>([]);
 
   const canUpload = can('documents:upload');
   const canDelete = can('documents:delete');
@@ -235,12 +243,45 @@ const DocumentosContent = () => {
 
   const historyDocs = historyDocId ? getVersionHistory(historyDocId) : [];
 
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+
+  const filterDocsBySearch = useCallback(
+    (docs: ProjectDocument[]) => {
+      if (!normalizedQuery) return docs;
+      return docs.filter(
+        d =>
+          d.name.toLowerCase().includes(normalizedQuery) ||
+          (d.description?.toLowerCase().includes(normalizedQuery) ?? false)
+      );
+    },
+    [normalizedQuery]
+  );
+
+  const toggleCategoryFilter = (cat: DocumentCategory) => {
+    setCategoryFilters(prev =>
+      prev.includes(cat) ? prev.filter(c => c !== cat) : [...prev, cat]
+    );
+  };
+
+  const clearFilters = () => {
+    setSearchQuery("");
+    setCategoryFilters([]);
+  };
+
   if (projectLoading || loading) {
     return <ContentSkeleton variant="cards" rows={6} />;
   }
 
   const categories = Object.keys(DOCUMENT_CATEGORIES) as DocumentCategory[];
   const categoriesWithDocs = categories.filter(cat => getLatestByCategoryMerged(cat).length > 0);
+
+  // Se há filtros multi-categoria ativos, intersectamos com categorias que têm docs
+  const effectiveCategories: DocumentCategory[] =
+    categoryFilters.length > 0
+      ? categoryFilters.filter(cat => categoriesWithDocs.includes(cat))
+      : categoriesWithDocs;
+
+  const hasActiveFilters = normalizedQuery.length > 0 || categoryFilters.length > 0;
 
   return (
     <div>
@@ -265,6 +306,64 @@ const DocumentosContent = () => {
           {canUpload && projectId && <DocumentUpload projectId={projectId} onSuccess={refetch} />}
         </EmptyState>
       ) : (
+        <>
+        {/* Barra de busca + chips de categoria */}
+        <div className="space-y-3 mb-6">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <Input
+              type="search"
+              placeholder="Buscar documentos por nome ou descrição..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9 pr-9 h-11"
+              aria-label="Buscar documentos"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded hover:bg-muted text-muted-foreground"
+                aria-label="Limpar busca"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          {categoriesWithDocs.length > 1 && (
+            <div className="flex flex-wrap gap-2 items-center">
+              <span className="text-xs text-muted-foreground mr-1">Filtrar por categoria:</span>
+              {categoriesWithDocs.map(cat => {
+                const active = categoryFilters.includes(cat);
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => toggleCategoryFilter(cat)}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-[32px] ${
+                      active
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "bg-background border-border hover:bg-muted"
+                    }`}
+                    aria-pressed={active}
+                  >
+                    {DOCUMENT_CATEGORIES[cat].label}
+                  </button>
+                );
+              })}
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 ml-1"
+                >
+                  Limpar filtros
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
         <Tabs value={selectedTab} onValueChange={setSelectedTab} className="space-y-6">
           <TabsList className="w-full overflow-x-auto flex-nowrap justify-start h-auto min-h-[44px] p-1 bg-muted/50 scrollbar-none">
             <TabsTrigger value="all" className="shrink-0 whitespace-nowrap min-h-[36px]">Todos ({documents.length})</TabsTrigger>
@@ -274,22 +373,50 @@ const DocumentosContent = () => {
           </TabsList>
 
           <TabsContent value="all" className="space-y-8 mt-6">
-            {categoriesWithDocs.map(cat => (
-              <CategorySection key={cat} category={cat} documents={getLatestByCategoryMerged(cat)}
-                onViewHistory={setHistoryDocId} onVersionUploaded={refetch} isStaff={isStaff} canDelete={canDelete} onRequestDelete={handleRequestDelete} />
-            ))}
+            {effectiveCategories.length === 0 ? (
+              <div className="text-center py-12 text-muted-foreground text-sm">
+                Nenhum documento corresponde aos filtros atuais.
+              </div>
+            ) : (
+              effectiveCategories.map(cat => {
+                const docs = filterDocsBySearch(getLatestByCategoryMerged(cat));
+                if (docs.length === 0) return null;
+                return (
+                  <CategorySection key={cat} category={cat} documents={docs}
+                    onViewHistory={setHistoryDocId} onVersionUploaded={refetch} isStaff={isStaff} canDelete={canDelete} onRequestDelete={handleRequestDelete} />
+                );
+              })
+            )}
+            {effectiveCategories.length > 0 &&
+              effectiveCategories.every(cat => filterDocsBySearch(getLatestByCategoryMerged(cat)).length === 0) && (
+                <div className="text-center py-12 text-muted-foreground text-sm">
+                  Nenhum documento corresponde à busca &quot;{searchQuery}&quot;.
+                </div>
+              )}
           </TabsContent>
 
-          {categoriesWithDocs.map(cat => (
-            <TabsContent key={cat} value={cat} className="mt-6">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {getLatestByCategoryMerged(cat).map(doc => (
-                  <DocumentCard key={doc.id} doc={doc} onViewHistory={setHistoryDocId} onVersionUploaded={refetch} isStaff={isStaff} canDelete={canDelete} onRequestDelete={handleRequestDelete} />
-                ))}
-              </div>
-            </TabsContent>
-          ))}
+          {categoriesWithDocs.map(cat => {
+            const docs = filterDocsBySearch(getLatestByCategoryMerged(cat));
+            return (
+              <TabsContent key={cat} value={cat} className="mt-6">
+                {docs.length === 0 ? (
+                  <div className="text-center py-12 text-muted-foreground text-sm">
+                    {normalizedQuery
+                      ? `Nenhum documento corresponde à busca "${searchQuery}".`
+                      : "Nenhum documento nesta categoria."}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    {docs.map(doc => (
+                      <DocumentCard key={doc.id} doc={doc} onViewHistory={setHistoryDocId} onVersionUploaded={refetch} isStaff={isStaff} canDelete={canDelete} onRequestDelete={handleRequestDelete} />
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+            );
+          })}
         </Tabs>
+        </>
       )}
 
       {/* Version History Dialog */}

--- a/src/hooks/useDocuments.ts
+++ b/src/hooks/useDocuments.ts
@@ -22,6 +22,12 @@ export const DOCUMENT_CATEGORIES = {
   garantia: { label: 'Garantias', icon: 'Shield' },
   as_built: { label: 'As Built', icon: 'Building' },
   termo_entrega: { label: 'Termo de Entrega', icon: 'CheckSquare' },
+  // Categorias adicionadas no repositório único de documentos
+  marcenaria: { label: 'Marcenaria', icon: 'Hammer' },
+  boleto: { label: 'Boletos', icon: 'Barcode' },
+  comprovante: { label: 'Comprovantes', icon: 'BadgeCheck' },
+  foto_obra: { label: 'Fotos da Obra', icon: 'Camera' },
+  outro: { label: 'Outros', icon: 'File' },
 } as const;
 
 export type DocumentCategory = keyof typeof DOCUMENT_CATEGORIES;

--- a/src/hooks/useMarcenaria.ts
+++ b/src/hooks/useMarcenaria.ts
@@ -1,0 +1,175 @@
+/**
+ * Hook do módulo de Marcenaria
+ * -----------------------------------------------------------
+ * Gerencia itens de marcenaria de uma obra — armários, painéis,
+ * móveis sob medida. Cada item tem status, valores e um
+ * mini-cronograma com datas planejadas vs reais para as 4
+ * etapas do processo: aprovação, produção, entrega e instalação.
+ *
+ * RLS da tabela `marcenaria_items`:
+ *   - SELECT: project_members ∪ project_customers ∪ is_staff
+ *   - INSERT/UPDATE/DELETE: apenas is_staff
+ */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+
+export const MARCENARIA_STATUS = [
+  "orcamento",
+  "aprovado",
+  "producao",
+  "entregue",
+  "instalado",
+] as const;
+
+export type MarcenariaStatus = (typeof MARCENARIA_STATUS)[number];
+
+export const MARCENARIA_STATUS_LABELS: Record<MarcenariaStatus, string> = {
+  orcamento: "Orçamento",
+  aprovado: "Aprovado",
+  producao: "Produção",
+  entregue: "Entregue",
+  instalado: "Instalado",
+};
+
+export interface MarcenariaItem {
+  id: string;
+  project_id: string;
+  name: string;
+  supplier: string | null;
+  status: MarcenariaStatus;
+  valor_orcado: number | null;
+  valor_aprovado: number | null;
+  observacoes: string | null;
+  planned_approval_date: string | null;
+  actual_approval_date: string | null;
+  planned_production_start: string | null;
+  actual_production_start: string | null;
+  planned_delivery_date: string | null;
+  actual_delivery_date: string | null;
+  planned_installation_date: string | null;
+  actual_installation_date: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+export type MarcenariaItemInput = Partial<
+  Omit<MarcenariaItem, "id" | "created_at" | "updated_at" | "created_by">
+> & {
+  name: string;
+  project_id: string;
+};
+
+export type MarcenariaItemUpdate = Partial<
+  Omit<MarcenariaItem, "id" | "project_id" | "created_at" | "updated_at" | "created_by">
+>;
+
+const TABLE = "marcenaria_items";
+
+export function marcenariaKey(projectId: string | undefined) {
+  return ["marcenaria-items", projectId] as const;
+}
+
+export function useMarcenaria(projectId: string | undefined) {
+  const qc = useQueryClient();
+  const queryKey = marcenariaKey(projectId);
+
+  const { data: items = [], isLoading, error, refetch } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<MarcenariaItem[]> => {
+      if (!projectId) return [];
+      const { data, error } = await supabase
+        // Tipos ainda não regenerados; cast defensivo para evitar erro de typing.
+        .from(TABLE as never)
+        .select("*")
+        .eq("project_id", projectId)
+        .order("created_at", { ascending: false });
+
+      if (error) throw error;
+      return (data ?? []) as unknown as MarcenariaItem[];
+    },
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: MarcenariaItemInput): Promise<MarcenariaItem> => {
+      const { data, error } = await supabase
+        .from(TABLE as never)
+        .insert(payload as never)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as unknown as MarcenariaItem;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Item de marcenaria criado");
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : "Erro ao criar item";
+      toast.error(message);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({
+      id,
+      patch,
+    }: {
+      id: string;
+      patch: MarcenariaItemUpdate;
+    }): Promise<MarcenariaItem> => {
+      const { data, error } = await supabase
+        .from(TABLE as never)
+        .update(patch as never)
+        .eq("id", id)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as unknown as MarcenariaItem;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Item atualizado");
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : "Erro ao atualizar item";
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from(TABLE as never)
+        .delete()
+        .eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Item removido");
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : "Erro ao remover item";
+      toast.error(message);
+    },
+  });
+
+  return {
+    items,
+    isLoading,
+    error: error ? (error as Error).message : null,
+    refetch,
+    create: createMutation.mutateAsync,
+    isCreating: createMutation.isPending,
+    update: updateMutation.mutateAsync,
+    isUpdating: updateMutation.isPending,
+    remove: deleteMutation.mutateAsync,
+    isDeleting: deleteMutation.isPending,
+  };
+}

--- a/src/hooks/useMarcenariaAttachments.ts
+++ b/src/hooks/useMarcenariaAttachments.ts
@@ -1,0 +1,183 @@
+/**
+ * Hook de anexos de itens de marcenaria
+ * -----------------------------------------------------------
+ * Anexos são arquivos (projeto executivo em PDF, orçamentos,
+ * imagens de referência, DWGs) vinculados a um `marcenaria_items`.
+ *
+ * - Bucket privado: `marcenaria-attachments`
+ * - Path: `<project_id>/<item_id>/<uuid>.<ext>`
+ * - URLs assinadas por 1 hora, com fallback para URL pública.
+ */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+
+export interface MarcenariaAttachment {
+  id: string;
+  item_id: string;
+  project_id: string;
+  storage_path: string;
+  caption: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  uploaded_by: string | null;
+  uploaded_at: string;
+  url?: string;
+}
+
+const BUCKET = "marcenaria-attachments";
+const TABLE = "marcenaria_attachments";
+
+export function marcenariaAttachmentsKey(itemId: string | undefined) {
+  return ["marcenaria-attachments", itemId] as const;
+}
+
+export function useMarcenariaAttachments(
+  itemId: string | undefined,
+  projectId: string | undefined
+) {
+  const qc = useQueryClient();
+  const queryKey = marcenariaAttachmentsKey(itemId);
+
+  const { data: attachments = [], isLoading } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<MarcenariaAttachment[]> => {
+      if (!itemId) return [];
+
+      const { data, error } = await supabase
+        .from(TABLE as never)
+        .select("*")
+        .eq("item_id", itemId)
+        .order("uploaded_at", { ascending: false });
+
+      if (error) throw error;
+
+      const rows = (data ?? []) as unknown as MarcenariaAttachment[];
+
+      // URLs assinadas em paralelo (1h) com fallback para URL pública
+      const results = await Promise.allSettled(
+        rows.map(async (att) => {
+          try {
+            const { data: signed, error: signedErr } = await supabase.storage
+              .from(BUCKET)
+              .createSignedUrl(att.storage_path, 3600);
+
+            let url = signed?.signedUrl;
+
+            if (!url || signedErr) {
+              const { data: pub } = supabase.storage
+                .from(BUCKET)
+                .getPublicUrl(att.storage_path);
+              url = pub?.publicUrl || undefined;
+            }
+
+            return { ...att, url } as MarcenariaAttachment;
+          } catch {
+            const { data: pub } = supabase.storage
+              .from(BUCKET)
+              .getPublicUrl(att.storage_path);
+            return {
+              ...att,
+              url: pub?.publicUrl || undefined,
+            } as MarcenariaAttachment;
+          }
+        })
+      );
+
+      return results
+        .filter(
+          (r): r is PromiseFulfilledResult<MarcenariaAttachment> =>
+            r.status === "fulfilled"
+        )
+        .map((r) => r.value);
+    },
+    enabled: !!itemId,
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: async (files: File[]) => {
+      if (!itemId || !projectId) {
+        throw new Error("Item ou projeto não identificado");
+      }
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Não autenticado");
+
+      const uploaded: MarcenariaAttachment[] = [];
+      for (const file of files) {
+        const ext = file.name.includes(".")
+          ? file.name.split(".").pop()
+          : "bin";
+        const path = `${projectId}/${itemId}/${crypto.randomUUID()}.${ext}`;
+
+        const { error: uploadError } = await supabase.storage
+          .from(BUCKET)
+          .upload(path, file, {
+            contentType: file.type || "application/octet-stream",
+            upsert: false,
+          });
+        if (uploadError) throw uploadError;
+
+        const { data: row, error: insertError } = await supabase
+          .from(TABLE as never)
+          .insert({
+            item_id: itemId,
+            project_id: projectId,
+            storage_path: path,
+            caption: file.name,
+            mime_type: file.type || null,
+            size_bytes: file.size,
+            uploaded_by: user.id,
+          } as never)
+          .select()
+          .single();
+
+        if (insertError) throw insertError;
+        uploaded.push(row as unknown as MarcenariaAttachment);
+      }
+      return uploaded;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Anexo enviado");
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : "Erro ao enviar anexo";
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (att: MarcenariaAttachment) => {
+      // Remove do storage (best-effort) e depois do metadata
+      await supabase.storage.from(BUCKET).remove([att.storage_path]);
+      const { error } = await supabase
+        .from(TABLE as never)
+        .delete()
+        .eq("id", att.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success("Anexo removido");
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : "Erro ao remover anexo";
+      toast.error(message);
+    },
+  });
+
+  return {
+    attachments,
+    isLoading,
+    upload: uploadMutation.mutateAsync,
+    isUploading: uploadMutation.isPending,
+    remove: deleteMutation.mutateAsync,
+    isDeleting: deleteMutation.isPending,
+  };
+}

--- a/src/pages/Documentos.tsx
+++ b/src/pages/Documentos.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, memo } from "react";
-import { ArrowLeft, Download, FileText, Box, Ruler, Award, ClipboardList, Receipt, Shield, Building, CheckSquare, FilePlus, Loader2, History, ShieldCheck, Plus, MessageSquare, ChevronRight, Share2, ExternalLink } from "lucide-react";
+import { ArrowLeft, Download, FileText, Box, Ruler, Award, ClipboardList, Receipt, Shield, Building, CheckSquare, FilePlus, Loader2, History, ShieldCheck, Plus, MessageSquare, ChevronRight, Share2, ExternalLink, Hammer, Barcode, BadgeCheck, Camera, File } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ContentSkeleton } from "@/components/ContentSkeleton";
@@ -40,6 +40,11 @@ const categoryIcons: Record<DocumentCategory, React.ReactNode> = {
   garantia: <Shield className="w-5 h-5" />,
   as_built: <Building className="w-5 h-5" />,
   termo_entrega: <CheckSquare className="w-5 h-5" />,
+  marcenaria: <Hammer className="w-5 h-5" />,
+  boleto: <Barcode className="w-5 h-5" />,
+  comprovante: <BadgeCheck className="w-5 h-5" />,
+  foto_obra: <Camera className="w-5 h-5" />,
+  outro: <File className="w-5 h-5" />,
 };
 
 const DocumentCard = ({ 

--- a/src/pages/EditarObra.tsx
+++ b/src/pages/EditarObra.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Building2, Calendar, DollarSign, Users, Save, Trash2, Loader2, Home } from 'lucide-react';
+import { ArrowLeft, Building2, Calendar, DollarSign, Users, Save, Trash2, Loader2, Home, Hammer } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -24,6 +24,7 @@ import { TabAtividades } from './editar-obra/TabAtividades';
 import { TabPagamentos } from './editar-obra/TabPagamentos';
 import { TabEquipe } from './editar-obra/TabEquipe';
 import { TabFichaTecnica } from './editar-obra/TabFichaTecnica';
+import { TabMarcenaria } from './editar-obra/TabMarcenaria';
 import { EditarObraSidebar } from './editar-obra/EditarObraSidebar';
 import { ShiftModeDialog } from './editar-obra/ShiftModeDialog';
 
@@ -146,7 +147,7 @@ export default function EditarObra() {
           {/* Main content */}
           <div className="flex-1 min-w-0">
             <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="flex w-full overflow-x-auto scrollbar-hide mb-6 sm:grid sm:grid-cols-5">
+              <TabsList className="flex w-full overflow-x-auto scrollbar-hide mb-6 sm:grid sm:grid-cols-6">
                 <TabsTrigger value="geral" className="flex items-center gap-2">
                   <Building2 className="h-4 w-4" />
                   <span className="hidden sm:inline">Dados Gerais</span>
@@ -166,6 +167,10 @@ export default function EditarObra() {
                 <TabsTrigger value="equipe" className="flex items-center gap-2">
                   <Users className="h-4 w-4" />
                   <span className="hidden sm:inline">Equipe</span>
+                </TabsTrigger>
+                <TabsTrigger value="marcenaria" className="flex items-center gap-2">
+                  <Hammer className="h-4 w-4" />
+                  <span className="hidden sm:inline">Marcenaria</span>
                 </TabsTrigger>
               </TabsList>
 
@@ -205,6 +210,10 @@ export default function EditarObra() {
                   onDelete={data.deletePayment}
                   onRefresh={data.refetchAll}
                 />
+              </TabsContent>
+
+              <TabsContent value="marcenaria">
+                <TabMarcenaria projectId={projectId!} />
               </TabsContent>
 
               <TabsContent value="equipe">

--- a/src/pages/editar-obra/TabMarcenaria.tsx
+++ b/src/pages/editar-obra/TabMarcenaria.tsx
@@ -1,0 +1,931 @@
+import { useState, useMemo } from "react";
+import {
+  Plus,
+  Hammer,
+  Paperclip,
+  Trash2,
+  Download,
+  Upload,
+  Loader2,
+  FileText,
+  Calendar,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { EmptyState } from "@/components/EmptyState";
+import {
+  useMarcenaria,
+  MarcenariaItem,
+  MarcenariaItemInput,
+  MarcenariaStatus,
+  MARCENARIA_STATUS,
+  MARCENARIA_STATUS_LABELS,
+} from "@/hooks/useMarcenaria";
+import {
+  useMarcenariaAttachments,
+  MarcenariaAttachment,
+} from "@/hooks/useMarcenariaAttachments";
+import { useUserRole } from "@/hooks/useUserRole";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+
+interface TabMarcenariaProps {
+  projectId: string;
+}
+
+const statusBadgeVariant: Record<MarcenariaStatus, string> = {
+  orcamento: "bg-muted text-muted-foreground border-border",
+  aprovado: "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-900",
+  producao: "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:border-amber-900",
+  entregue: "bg-indigo-100 text-indigo-800 border-indigo-200 dark:bg-indigo-950 dark:text-indigo-200 dark:border-indigo-900",
+  instalado: "bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-200 dark:border-emerald-900",
+};
+
+function formatCurrency(value: number | null): string {
+  if (value === null || value === undefined) return "—";
+  return value.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  try {
+    return format(new Date(value), "dd/MM/yyyy", { locale: ptBR });
+  } catch {
+    return value;
+  }
+}
+
+interface ItemFormState {
+  name: string;
+  supplier: string;
+  status: MarcenariaStatus;
+  valor_orcado: string;
+  valor_aprovado: string;
+  observacoes: string;
+  planned_approval_date: string;
+  actual_approval_date: string;
+  planned_production_start: string;
+  actual_production_start: string;
+  planned_delivery_date: string;
+  actual_delivery_date: string;
+  planned_installation_date: string;
+  actual_installation_date: string;
+}
+
+function emptyFormState(): ItemFormState {
+  return {
+    name: "",
+    supplier: "",
+    status: "orcamento",
+    valor_orcado: "",
+    valor_aprovado: "",
+    observacoes: "",
+    planned_approval_date: "",
+    actual_approval_date: "",
+    planned_production_start: "",
+    actual_production_start: "",
+    planned_delivery_date: "",
+    actual_delivery_date: "",
+    planned_installation_date: "",
+    actual_installation_date: "",
+  };
+}
+
+function itemToFormState(item: MarcenariaItem): ItemFormState {
+  return {
+    name: item.name,
+    supplier: item.supplier ?? "",
+    status: item.status,
+    valor_orcado: item.valor_orcado != null ? String(item.valor_orcado) : "",
+    valor_aprovado:
+      item.valor_aprovado != null ? String(item.valor_aprovado) : "",
+    observacoes: item.observacoes ?? "",
+    planned_approval_date: item.planned_approval_date ?? "",
+    actual_approval_date: item.actual_approval_date ?? "",
+    planned_production_start: item.planned_production_start ?? "",
+    actual_production_start: item.actual_production_start ?? "",
+    planned_delivery_date: item.planned_delivery_date ?? "",
+    actual_delivery_date: item.actual_delivery_date ?? "",
+    planned_installation_date: item.planned_installation_date ?? "",
+    actual_installation_date: item.actual_installation_date ?? "",
+  };
+}
+
+function parseNumber(raw: string): number | null {
+  if (!raw.trim()) return null;
+  const normalized = raw.replace(",", ".");
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseDate(raw: string): string | null {
+  return raw.trim() ? raw : null;
+}
+
+function formStateToPayload(
+  state: ItemFormState,
+  projectId: string
+): MarcenariaItemInput {
+  return {
+    project_id: projectId,
+    name: state.name.trim(),
+    supplier: state.supplier.trim() || null,
+    status: state.status,
+    valor_orcado: parseNumber(state.valor_orcado),
+    valor_aprovado: parseNumber(state.valor_aprovado),
+    observacoes: state.observacoes.trim() || null,
+    planned_approval_date: parseDate(state.planned_approval_date),
+    actual_approval_date: parseDate(state.actual_approval_date),
+    planned_production_start: parseDate(state.planned_production_start),
+    actual_production_start: parseDate(state.actual_production_start),
+    planned_delivery_date: parseDate(state.planned_delivery_date),
+    actual_delivery_date: parseDate(state.actual_delivery_date),
+    planned_installation_date: parseDate(state.planned_installation_date),
+    actual_installation_date: parseDate(state.actual_installation_date),
+  };
+}
+
+function ItemFormDialog({
+  projectId,
+  mode,
+  initialItem,
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting,
+}: {
+  projectId: string;
+  mode: "create" | "edit";
+  initialItem?: MarcenariaItem;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: MarcenariaItemInput) => Promise<void>;
+  isSubmitting: boolean;
+}) {
+  const [form, setForm] = useState<ItemFormState>(
+    initialItem ? itemToFormState(initialItem) : emptyFormState()
+  );
+
+  // Reset form quando o dialog abrir com um item diferente
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setForm(initialItem ? itemToFormState(initialItem) : emptyFormState());
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    const payload = formStateToPayload(form, projectId);
+    await onSubmit(payload);
+  };
+
+  const update = <K extends keyof ItemFormState>(
+    key: K,
+    value: ItemFormState[K]
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl w-[95vw] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? "Novo item de marcenaria" : "Editar item"}
+          </DialogTitle>
+          <DialogDescription>
+            Cadastre armários, painéis e móveis sob medida com fornecedor, status e mini-cronograma.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="sm:col-span-2">
+              <Label htmlFor="marc-name">Nome *</Label>
+              <Input
+                id="marc-name"
+                value={form.name}
+                onChange={(e) => update("name", e.target.value)}
+                placeholder="Ex.: Armário da cozinha"
+                required
+                maxLength={200}
+              />
+            </div>
+            <div>
+              <Label htmlFor="marc-supplier">Fornecedor</Label>
+              <Input
+                id="marc-supplier"
+                value={form.supplier}
+                onChange={(e) => update("supplier", e.target.value)}
+                placeholder="Nome do marceneiro"
+                maxLength={200}
+              />
+            </div>
+            <div>
+              <Label htmlFor="marc-status">Status</Label>
+              <Select
+                value={form.status}
+                onValueChange={(v) => update("status", v as MarcenariaStatus)}
+              >
+                <SelectTrigger id="marc-status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MARCENARIA_STATUS.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {MARCENARIA_STATUS_LABELS[s]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="marc-valor-orcado">Valor orçado (R$)</Label>
+              <Input
+                id="marc-valor-orcado"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.valor_orcado}
+                onChange={(e) => update("valor_orcado", e.target.value)}
+                placeholder="0,00"
+              />
+            </div>
+            <div>
+              <Label htmlFor="marc-valor-aprovado">Valor aprovado (R$)</Label>
+              <Input
+                id="marc-valor-aprovado"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.valor_aprovado}
+                onChange={(e) => update("valor_aprovado", e.target.value)}
+                placeholder="0,00"
+              />
+            </div>
+          </div>
+
+          {/* Mini-cronograma */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4 text-muted-foreground" />
+              <h3 className="text-sm font-semibold">Mini-cronograma</h3>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 rounded-lg border border-border bg-muted/30 p-3">
+              <DateStageGroup
+                label="Aprovação"
+                plannedId="plan-approval"
+                actualId="actual-approval"
+                plannedValue={form.planned_approval_date}
+                actualValue={form.actual_approval_date}
+                onPlannedChange={(v) => update("planned_approval_date", v)}
+                onActualChange={(v) => update("actual_approval_date", v)}
+              />
+              <DateStageGroup
+                label="Produção"
+                plannedId="plan-prod"
+                actualId="actual-prod"
+                plannedValue={form.planned_production_start}
+                actualValue={form.actual_production_start}
+                onPlannedChange={(v) => update("planned_production_start", v)}
+                onActualChange={(v) => update("actual_production_start", v)}
+              />
+              <DateStageGroup
+                label="Entrega"
+                plannedId="plan-delivery"
+                actualId="actual-delivery"
+                plannedValue={form.planned_delivery_date}
+                actualValue={form.actual_delivery_date}
+                onPlannedChange={(v) => update("planned_delivery_date", v)}
+                onActualChange={(v) => update("actual_delivery_date", v)}
+              />
+              <DateStageGroup
+                label="Instalação"
+                plannedId="plan-install"
+                actualId="actual-install"
+                plannedValue={form.planned_installation_date}
+                actualValue={form.actual_installation_date}
+                onPlannedChange={(v) => update("planned_installation_date", v)}
+                onActualChange={(v) => update("actual_installation_date", v)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="marc-obs">Observações</Label>
+            <Textarea
+              id="marc-obs"
+              value={form.observacoes}
+              onChange={(e) => update("observacoes", e.target.value)}
+              placeholder="Dimensões, acabamentos, material..."
+              rows={3}
+              maxLength={2000}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={!form.name.trim() || isSubmitting}>
+              {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {mode === "create" ? "Criar item" : "Salvar alterações"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DateStageGroup({
+  label,
+  plannedId,
+  actualId,
+  plannedValue,
+  actualValue,
+  onPlannedChange,
+  onActualChange,
+}: {
+  label: string;
+  plannedId: string;
+  actualId: string;
+  plannedValue: string;
+  actualValue: string;
+  onPlannedChange: (v: string) => void;
+  onActualChange: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        {label}
+      </h4>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label htmlFor={plannedId} className="text-xs">
+            Planejado
+          </Label>
+          <Input
+            id={plannedId}
+            type="date"
+            value={plannedValue}
+            onChange={(e) => onPlannedChange(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor={actualId} className="text-xs">
+            Real
+          </Label>
+          <Input
+            id={actualId}
+            type="date"
+            value={actualValue}
+            onChange={(e) => onActualChange(e.target.value)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AttachmentsPanel({
+  item,
+  projectId,
+  canEdit,
+}: {
+  item: MarcenariaItem;
+  projectId: string;
+  canEdit: boolean;
+}) {
+  const { attachments, isLoading, upload, isUploading, remove } =
+    useMarcenariaAttachments(item.id, projectId);
+  const [pendingDelete, setPendingDelete] = useState<MarcenariaAttachment | null>(
+    null
+  );
+
+  const handleFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    await upload(Array.from(files));
+    e.target.value = "";
+  };
+
+  const handleDownload = async (att: MarcenariaAttachment) => {
+    if (!att.url) return;
+    try {
+      const resp = await fetch(att.url);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = att.caption || `anexo-${att.id}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      window.open(att.url, "_blank");
+    }
+  };
+
+  return (
+    <div className="space-y-3 border-t border-border pt-3 mt-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold flex items-center gap-2">
+          <Paperclip className="w-4 h-4" />
+          Anexos
+          <Badge variant="outline" className="ml-1">
+            {attachments.length}
+          </Badge>
+        </h4>
+        {canEdit && (
+          <label className="inline-flex items-center gap-2 text-sm cursor-pointer bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-3 py-1.5 min-h-[36px]">
+            {isUploading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Upload className="w-4 h-4" />
+            )}
+            <span>Enviar arquivo</span>
+            <input
+              type="file"
+              className="sr-only"
+              multiple
+              disabled={isUploading}
+              accept=".pdf,.jpg,.jpeg,.png,.webp,.heic,.heif,.dwg,.dxf"
+              onChange={handleFiles}
+            />
+          </label>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" /> Carregando anexos...
+        </div>
+      ) : attachments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhum anexo. {canEdit && "Envie o projeto executivo em PDF, orçamentos ou fotos de referência."}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {attachments.map((att) => (
+            <li
+              key={att.id}
+              className="flex items-center gap-3 rounded-md border border-border bg-background p-2"
+            >
+              <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">
+                  {att.caption || "Arquivo"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {format(new Date(att.uploaded_at), "dd/MM/yyyy HH:mm", {
+                    locale: ptBR,
+                  })}
+                  {att.size_bytes != null &&
+                    ` • ${(att.size_bytes / 1024).toFixed(0)} KB`}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleDownload(att)}
+                disabled={!att.url}
+              >
+                <Download className="w-4 h-4" />
+              </Button>
+              {canEdit && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setPendingDelete(att)}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AlertDialog
+        open={!!pendingDelete}
+        onOpenChange={(o) => !o && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover anexo</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tem certeza que deseja remover &quot;{pendingDelete?.caption}&quot;?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (pendingDelete) await remove(pendingDelete);
+                setPendingDelete(null);
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function MarcenariaItemCard({
+  item,
+  projectId,
+  canEdit,
+  onEdit,
+  onDelete,
+}: {
+  item: MarcenariaItem;
+  projectId: string;
+  canEdit: boolean;
+  onEdit: (item: MarcenariaItem) => void;
+  onDelete: (item: MarcenariaItem) => void;
+}) {
+  const [showAttachments, setShowAttachments] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-base">{item.name}</CardTitle>
+            {item.supplier && (
+              <CardDescription className="mt-1">
+                Fornecedor: {item.supplier}
+              </CardDescription>
+            )}
+          </div>
+          <Badge
+            variant="outline"
+            className={statusBadgeVariant[item.status]}
+          >
+            {MARCENARIA_STATUS_LABELS[item.status]}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Valores */}
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-xs text-muted-foreground">Valor orçado</p>
+            <p className="font-medium">{formatCurrency(item.valor_orcado)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Valor aprovado</p>
+            <p className="font-medium">{formatCurrency(item.valor_aprovado)}</p>
+          </div>
+        </div>
+
+        {/* Mini-cronograma compacto */}
+        <div className="rounded-md border border-border bg-muted/30 p-2 text-xs space-y-1">
+          <MiniScheduleRow
+            label="Aprovação"
+            planned={item.planned_approval_date}
+            actual={item.actual_approval_date}
+          />
+          <MiniScheduleRow
+            label="Produção"
+            planned={item.planned_production_start}
+            actual={item.actual_production_start}
+          />
+          <MiniScheduleRow
+            label="Entrega"
+            planned={item.planned_delivery_date}
+            actual={item.actual_delivery_date}
+          />
+          <MiniScheduleRow
+            label="Instalação"
+            planned={item.planned_installation_date}
+            actual={item.actual_installation_date}
+          />
+        </div>
+
+        {item.observacoes && (
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+            {item.observacoes}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowAttachments((v) => !v)}
+            className="gap-2"
+          >
+            <Paperclip className="w-4 h-4" />
+            {showAttachments ? "Ocultar anexos" : "Ver anexos"}
+          </Button>
+          {canEdit && (
+            <div className="flex gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => onEdit(item)}
+              >
+                Editar
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => onDelete(item)}
+                className="text-destructive hover:text-destructive"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {showAttachments && (
+          <AttachmentsPanel
+            item={item}
+            projectId={projectId}
+            canEdit={canEdit}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MiniScheduleRow({
+  label,
+  planned,
+  actual,
+}: {
+  label: string;
+  planned: string | null;
+  actual: string | null;
+}) {
+  const hasPlanned = !!planned;
+  const hasActual = !!actual;
+  const isLate =
+    hasPlanned &&
+    !hasActual &&
+    new Date(planned as string).getTime() < new Date().setHours(0, 0, 0, 0);
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="font-medium text-muted-foreground w-20 shrink-0">
+        {label}
+      </span>
+      <div className="flex items-center gap-3 text-right">
+        <span
+          className={isLate ? "text-destructive font-medium" : ""}
+          title="Planejado"
+        >
+          P: {formatDate(planned)}
+        </span>
+        <span
+          className={hasActual ? "text-emerald-700 dark:text-emerald-400" : "text-muted-foreground"}
+          title="Real"
+        >
+          R: {formatDate(actual)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function TabMarcenaria({ projectId }: TabMarcenariaProps) {
+  const { isStaff } = useUserRole();
+  const {
+    items,
+    isLoading,
+    create,
+    isCreating,
+    update,
+    isUpdating,
+    remove,
+  } = useMarcenaria(projectId);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editItem, setEditItem] = useState<MarcenariaItem | null>(null);
+  const [deleteItem, setDeleteItem] = useState<MarcenariaItem | null>(null);
+
+  // Agrupa itens por status para visão de board-like
+  const grouped = useMemo(() => {
+    const map = new Map<MarcenariaStatus, MarcenariaItem[]>();
+    for (const s of MARCENARIA_STATUS) map.set(s, []);
+    for (const it of items) {
+      const list = map.get(it.status);
+      if (list) list.push(it);
+    }
+    return map;
+  }, [items]);
+
+  const handleCreate = async (payload: MarcenariaItemInput) => {
+    await create(payload);
+    setCreateOpen(false);
+  };
+
+  const handleUpdate = async (payload: MarcenariaItemInput) => {
+    if (!editItem) return;
+    const { project_id: _ignored, ...patch } = payload;
+    void _ignored;
+    await update({ id: editItem.id, patch });
+    setEditItem(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteItem) return;
+    await remove(deleteItem.id);
+    setDeleteItem(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Hammer className="w-5 h-5" />
+            Marcenaria
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Armários, painéis e móveis sob medida com fornecedor, status e mini-cronograma.
+          </p>
+        </div>
+        {isStaff && (
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogTrigger asChild>
+              <Button className="gap-2">
+                <Plus className="w-4 h-4" />
+                Novo item
+              </Button>
+            </DialogTrigger>
+            <ItemFormDialog
+              projectId={projectId}
+              mode="create"
+              open={createOpen}
+              onOpenChange={setCreateOpen}
+              onSubmit={handleCreate}
+              isSubmitting={isCreating}
+            />
+          </Dialog>
+        )}
+      </div>
+
+      {items.length === 0 ? (
+        <EmptyState
+          variant="documents"
+          title="Nenhum item de marcenaria"
+          description={
+            isStaff
+              ? "Cadastre o primeiro item para acompanhar fornecedor, status e cronograma."
+              : "Assim que a equipe técnica cadastrar itens de marcenaria, eles aparecerão aqui."
+          }
+        >
+          {isStaff && (
+            <Button onClick={() => setCreateOpen(true)} className="gap-2">
+              <Plus className="w-4 h-4" />
+              Cadastrar item
+            </Button>
+          )}
+        </EmptyState>
+      ) : (
+        <div className="space-y-6">
+          {MARCENARIA_STATUS.map((status) => {
+            const list = grouped.get(status) ?? [];
+            if (list.length === 0) return null;
+            return (
+              <section key={status} className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={statusBadgeVariant[status]}
+                  >
+                    {MARCENARIA_STATUS_LABELS[status]}
+                  </Badge>
+                  <span className="text-sm text-muted-foreground">
+                    {list.length} {list.length === 1 ? "item" : "itens"}
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  {list.map((item) => (
+                    <MarcenariaItemCard
+                      key={item.id}
+                      item={item}
+                      projectId={projectId}
+                      canEdit={isStaff}
+                      onEdit={setEditItem}
+                      onDelete={setDeleteItem}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Dialog de edição */}
+      {editItem && (
+        <ItemFormDialog
+          projectId={projectId}
+          mode="edit"
+          initialItem={editItem}
+          open={!!editItem}
+          onOpenChange={(o) => !o && setEditItem(null)}
+          onSubmit={handleUpdate}
+          isSubmitting={isUpdating}
+        />
+      )}
+
+      {/* Confirmação de exclusão */}
+      <AlertDialog
+        open={!!deleteItem}
+        onOpenChange={(o) => !o && setDeleteItem(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover item</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tem certeza que deseja remover &quot;{deleteItem?.name}&quot;? Todos os anexos vinculados também serão excluídos.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export default TabMarcenaria;


### PR DESCRIPTION
## Resumo

Entrega combinada dos itens 4 e 5 da Fase 2 do roadmap:

1. **Documentos como repositório único** — busca + filtro multi-categoria + 5 novas categorias.
2. **Marcenaria como módulo dedicado** — tabela, mini-cronograma e anexos por item.

PR único conforme alinhado.

---

## 1. Documentos (repositório único)

### Banco de dados

Migração: [`apply_docs_enum_and_marcenaria.sql`](../blob/feat/docs-enum-marcenaria/apply_docs_enum_and_marcenaria.sql) (aplicar manualmente no SQL Editor do Lovable).

- Amplia o `CHECK` em `project_documents.document_type` de 10 para 15 valores aceitos, sem invalidar linhas existentes.
- Novas chaves: `marcenaria`, `boleto`, `comprovante`, `foto_obra`, `outro`.

### Frontend

- `DOCUMENT_CATEGORIES` estendido em [`useDocuments.ts`](../blob/feat/docs-enum-marcenaria/src/hooks/useDocuments.ts).
- `DocumentosContent.tsx` e `Documentos.tsx`:
  - Barra de busca (nome e descrição).
  - Chips de filtro multi-categoria combináveis com a busca.
  - Ícones para as 5 novas categorias.
  - Tabs + histórico de versões mantidos intactos.
- `DocumentUpload` já itera sobre o objeto de categorias — reconhece as novas automaticamente.

---

## 2. Marcenaria (módulo dedicado)

### Banco de dados (mesmo arquivo SQL)

- Tabela `marcenaria_items`:
  - Status (`orcamento` → `aprovado` → `producao` → `entregue` → `instalado`).
  - `valor_orcado`, `valor_aprovado`, `observacoes`.
  - Mini-cronograma: `planned_*` e `actual_*` para aprovação, produção, entrega e instalação.
- Tabela `marcenaria_attachments` vinculada a `marcenaria_items` via `ON DELETE CASCADE`.
- Bucket privado `marcenaria-attachments` (20MB), aceita PDF, imagens e DWG.
- RLS padrão project-scoped:
  - **SELECT**: `project_members` ∪ `project_customers` ∪ `is_staff`.
  - **INSERT/UPDATE/DELETE**: apenas `is_staff`.
- Policies de storage seguem o mesmo padrão (`storage.foldername(name)[1] = project_id`).

### Frontend

- [`useMarcenaria.ts`](../blob/feat/docs-enum-marcenaria/src/hooks/useMarcenaria.ts) — listagem + mutações CRUD com React Query.
- [`useMarcenariaAttachments.ts`](../blob/feat/docs-enum-marcenaria/src/hooks/useMarcenariaAttachments.ts) — upload/delete + URLs assinadas (1h) com fallback público.
- [`TabMarcenaria.tsx`](../blob/feat/docs-enum-marcenaria/src/pages/editar-obra/TabMarcenaria.tsx):
  - Agrupamento por status tipo kanban.
  - Cards com valores, observações e mini-cronograma compacto (planejado × real).
  - Destaque em vermelho para etapas atrasadas (planejado passou, real vazio) e verde para concluídas.
  - Painel expansível por item para upload de projeto executivo, orçamentos, fotos.
  - Modal de formulário único para criar e editar.
- Registrada como 6ª aba em [`EditarObra.tsx`](../blob/feat/docs-enum-marcenaria/src/pages/EditarObra.tsx) com ícone `Hammer`.

---

## Checklist de aplicação

1. ✅ Merge deste PR.
2. ⚠️ **Aplicar migração manualmente** no SQL Editor do Lovable: copiar e colar o conteúdo de `apply_docs_enum_and_marcenaria.sql`.
3. Regenerar tipos Supabase (`npx supabase gen types typescript ...`) — os casts `as never` no código dos hooks podem ser removidos depois.

---

## Validação

| Etapa | Resultado |
|---|---|
| `npx tsc -b --noEmit` | ✅ 0 errors |
| ESLint nos arquivos editados | ✅ 0 errors (23 warnings pré-existentes) |
| `vite build` | ✅ 21s |
| `vitest run src/hooks/__tests__/useBoletoUpload.test.ts` | ✅ 7/7 passando |

> Nota: os 6 testes que falham em `permissions.test.ts` também falham sem este PR aplicado (reproduzido com `git stash`). Falhas pré-existentes na base, não introduzidas aqui.

---

## Dependência

- Nada bloqueia. Este PR é independente do [#11](../pull/11).
- A migração é aditiva: não remove colunas, enum nem constraints existentes.
