### PR TITLE
Handle soft-deleted project restoration in sync-project-inbound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Environment variables — NEVER commit real secrets
 .env

--- a/supabase/functions/sync-project-inbound/index.ts
+++ b/supabase/functions/sync-project-inbound/index.ts
@@ -85,15 +85,23 @@ Deno.serve(async (req) => {
     // --- Upsert: check if already linked ---
     const { data: existing } = await db
       .from("projects")
-      .select("id")
+      .select("id, deleted_at")
       .eq("external_id", source_id)
       .eq("external_system", "envision")
       .maybeSingle();
 
     let projectId: string;
     let isNewProject = false;
+    let wasRestored = false;
 
     if (existing) {
+      // If the project was soft-deleted, restore it on re-sync — otherwise the
+      // update would land on a hidden row and the obra would silently "not be created".
+      if (existing.deleted_at) {
+        projectPayload.deleted_at = null;
+        wasRestored = true;
+        console.log(`[sync-project-inbound] Restoring soft-deleted project ${existing.id} for source_id ${source_id}`);
+      }
       const { error: updateErr } = await db.from("projects").update(projectPayload).eq("id", existing.id);
       if (updateErr) {
         console.error("[sync-project-inbound] Update error:", updateErr.message);
@@ -234,7 +242,7 @@ Deno.serve(async (req) => {
       status: "success",
       project_id: projectId,
       orcamento_id: orcamentoId,
-      action: existing ? "updated" : "created",
+      action: existing ? (wasRestored ? "restored" : "updated") : "created",
       ai_enrichment: aiEnrichment ? "completed" : null,
     });
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary
This change adds support for restoring soft-deleted projects when they are re-synced from the external system. Previously, updates to soft-deleted projects would silently fail to create associated records.

## Key Changes
- Added `deleted_at` field to the project query to detect soft-deleted records
- Implemented restoration logic that sets `deleted_at` to null when a soft-deleted project is re-synced
- Added `wasRestored` flag to track whether a project was restored during the sync
- Updated the response action field to distinguish between "restored" and "updated" projects

## Implementation Details
- When an existing project is found with a non-null `deleted_at` value, the sync operation now explicitly restores it by setting `deleted_at` to null in the update payload
- A console log message is emitted when a project is restored for debugging purposes
- The response action is now more granular: "created" for new projects, "restored" for previously soft-deleted projects, and "updated" for existing active projects

https://claude.ai/code/session_01XDPN9jmmgFKbgg86FMJ6pD