### PR TITLE
Aprimora UX mobile (header, bottom nav, sheets, toasts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Environment variables — NEVER commit real secrets
 .env
 .env.local

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -33,24 +33,41 @@ export function AppHeader({ showBackButton, onBack, children }: AppHeaderProps) 
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-background/95 backdrop-blur border-b">
-      <div className="max-w-7xl mx-auto px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+    <header className="sticky top-0 z-header bg-background/95 backdrop-blur border-b border-border-subtle pt-safe">
+      <div className="max-w-7xl mx-auto px-3 sm:px-4 py-2 sm:py-3 pl-safe pr-safe">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             {showBackButton && onBack && (
-              <Button variant="ghost" size="icon" onClick={onBack}>
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onBack}
+                aria-label="Voltar"
+                className="shrink-0 h-11 w-11 rounded-full hover:bg-primary/10 active:bg-primary/15 active:scale-[0.94] transition-transform"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
                 </svg>
               </Button>
             )}
-            <Link to="/">
-              <img src={bwildLogo} alt="Bwild" className="h-8" />
+            <Link to="/" className="shrink-0 inline-flex items-center" aria-label="Início">
+              <img src={bwildLogo} alt="Bwild" className="h-7 sm:h-8" />
             </Link>
             {children}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 sm:gap-2 shrink-0">
             {loading ? (
               <div className="h-9 w-24 bg-muted animate-pulse rounded-md" />
             ) : isAuthenticated ? (
@@ -61,17 +78,23 @@ export function AppHeader({ showBackButton, onBack, children }: AppHeaderProps) 
 
                 <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground ml-2">
                   <User className="h-4 w-4" />
-                  <span>{user?.email?.split('@')[0]}</span>
+                  <span>{user?.email?.split("@")[0]}</span>
                 </div>
-                
-                <Button variant="ghost" size="sm" onClick={handleSignOut}>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleSignOut}
+                  aria-label="Sair"
+                  className="h-10 sm:h-9"
+                >
                   <LogOut className="h-4 w-4 sm:mr-2" />
                   <span className="hidden sm:inline">Sair</span>
                 </Button>
               </>
             ) : (
               <Link to="/auth">
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" aria-label="Entrar" className="h-10 sm:h-9">
                   <LogIn className="h-4 w-4 sm:mr-2" />
                   <span className="hidden sm:inline">Entrar</span>
                 </Button>

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -129,49 +129,57 @@ export function PageHeader({
       </div>
 
       {/* ── Mobile: two-row layout ── */}
-      <div className={cn("mx-auto px-4 py-2 sm:hidden space-y-1", maxWidthMap[maxWidth])}>
+      <div className={cn("mx-auto px-3 py-2 sm:hidden space-y-1.5 pl-safe pr-safe", maxWidthMap[maxWidth])}>
         <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
             {(backTo || onBack) && (
               <BackWrapper {...backProps}>
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={onBack}
-                  className="shrink-0 h-11 w-11 sm:h-9 sm:w-9 rounded-full hover:bg-primary/10"
+                  className="shrink-0 h-11 w-11 rounded-full hover:bg-primary/10 active:bg-primary/15 active:scale-[0.94] transition-transform"
                   aria-label="Voltar"
                 >
-                  <ArrowLeft className="w-4 h-4" />
+                  <ArrowLeft className="w-5 h-5" />
                 </Button>
               </BackWrapper>
             )}
             {showLogo && (
-              <img src={bwildLogo} alt="Bwild" className="h-7 w-auto shrink-0" />
+              <img src={bwildLogo} alt="Bwild" className="h-6 w-auto shrink-0" />
             )}
           </div>
-          <div className="flex items-center gap-2 min-w-0 shrink">
-            {children && <div className="min-w-0">{children}</div>}
+          <div className="flex items-center gap-1 min-w-0 shrink">
+            {children && <div className="min-w-0 flex items-center gap-1">{children}</div>}
             <UserMenu />
           </div>
         </div>
         <div className="min-w-0">
           {breadcrumbs && breadcrumbs.length > 0 && (
-            <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-xs text-muted-foreground mb-0.5 overflow-hidden">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex items-center gap-1 text-[11px] text-muted-foreground mb-0.5 overflow-x-auto scrollbar-hide"
+            >
               {breadcrumbs.map((crumb, i) => (
                 <span key={i} className="flex items-center gap-1 shrink-0">
                   {i > 0 && <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />}
                   {crumb.href ? (
-                    <Link to={crumb.href} className="hover:text-foreground transition-colors truncate max-w-[120px]">
+                    <Link
+                      to={crumb.href}
+                      className="hover:text-foreground transition-colors truncate max-w-[140px]"
+                    >
                       {crumb.label}
                     </Link>
                   ) : (
-                    <span className="truncate max-w-[120px]">{crumb.label}</span>
+                    <span className="truncate max-w-[140px]">{crumb.label}</span>
                   )}
                 </span>
               ))}
             </nav>
           )}
-          <h1 className="text-page-title">{title}</h1>
+          <h1 className="text-[18px] font-bold text-foreground leading-tight truncate">
+            {title}
+          </h1>
         </div>
       </div>
     </div>

--- a/src/components/layout/ProjectMobileHeader.tsx
+++ b/src/components/layout/ProjectMobileHeader.tsx
@@ -1,0 +1,296 @@
+import { useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Building2, ChevronsUpDown, Search, Check } from "lucide-react";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { UserMenu } from "@/components/layout/UserMenu";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { useProject } from "@/contexts/ProjectContext";
+import { useProjectNavigation } from "@/hooks/useProjectNavigation";
+import { useProjectsQuery } from "@/hooks/useProjectsQuery";
+import { useUserRole } from "@/hooks/useUserRole";
+import { usePendingCountsByProject } from "@/hooks/usePendingCountsByProject";
+import { matchesSearch } from "@/lib/searchNormalize";
+import { cn } from "@/lib/utils";
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Rascunhos",
+  active: "Ativas",
+  paused: "Pausadas",
+  completed: "Concluídas",
+  cancelled: "Canceladas",
+};
+
+const STATUS_BADGE_STYLES: Record<string, string> = {
+  draft: "bg-slate-500/15 text-slate-600 border-slate-400/25",
+  active: "bg-primary/15 text-primary border-primary/25",
+  paused: "bg-[hsl(var(--warning))]/15 text-[hsl(var(--warning))] border-[hsl(var(--warning))]/25",
+  completed: "bg-emerald-500/15 text-emerald-600 border-emerald-500/25",
+  cancelled: "bg-muted text-muted-foreground border-border",
+};
+
+const STATUS_ORDER = ["draft", "active", "paused", "completed", "cancelled"];
+
+/**
+ * ProjectMobileHeader — slim mobile-only header for project pages.
+ *
+ * Provides parity with ProjectSlimHeader (desktop) on mobile:
+ * - Sidebar trigger to access full project nav (staff)
+ * - Project switcher with search and grouping by status
+ * - Notification bell
+ * - User menu
+ *
+ * Renders only on mobile (<md). Desktop continues to use ProjectSlimHeader.
+ */
+export function ProjectMobileHeader() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { project } = useProject();
+  const { projectId } = useProjectNavigation();
+  const { data: projects = [] } = useProjectsQuery();
+  const { isStaff } = useUserRole();
+  const { data: pendingByProject } = usePendingCountsByProject();
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const otherProjects = useMemo(
+    () => projects.filter((p) => p.id !== projectId),
+    [projects, projectId],
+  );
+
+  const groupedProjects = useMemo(() => {
+    const filtered = searchQuery.trim()
+      ? otherProjects.filter((p) =>
+          matchesSearch(searchQuery, [p.name, p.unit_name, p.customer_name]),
+        )
+      : otherProjects;
+
+    const groups: Record<string, typeof filtered> = {};
+    for (const p of filtered) {
+      const status = p.status || "active";
+      (groups[status] ??= []).push(p);
+    }
+
+    return STATUS_ORDER
+      .filter((s) => groups[s]?.length)
+      .map((s) => ({ status: s, label: STATUS_LABELS[s] || s, projects: groups[s] }));
+  }, [otherProjects, searchQuery]);
+
+  const handleProjectSwitch = (targetId: string) => {
+    setOpen(false);
+    setSearchQuery("");
+    if (!projectId) {
+      navigate(`/obra/${targetId}`);
+      return;
+    }
+    const currentSub = location.pathname.replace(`/obra/${projectId}`, "");
+    navigate(`/obra/${targetId}${currentSub}`);
+  };
+
+  const projectDisplayName = project
+    ? `${project.name}${project.unit_name ? ` – ${project.unit_name}` : ""}`
+    : "Carregando…";
+
+  const hasOthers = otherProjects.length > 0;
+
+  return (
+    <header
+      className={cn(
+        "md:hidden sticky top-0 z-shell h-12 shrink-0",
+        "border-b border-border-subtle surface-glass",
+        "flex items-center px-2 gap-1 pt-safe",
+      )}
+      aria-label="Cabeçalho da obra"
+    >
+      {/* Sidebar trigger — staff only (clients have no sidebar on mobile) */}
+      {isStaff && (
+        <SidebarTrigger
+          aria-label="Abrir menu da obra"
+          className="shrink-0 h-10 w-10 min-h-[44px] min-w-[44px]"
+        />
+      )}
+
+      {/* Project switcher */}
+      <Sheet
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setSearchQuery("");
+        }}
+      >
+        <SheetTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-left",
+              "hover:bg-accent/50 active:bg-accent transition-colors",
+              "focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary",
+            )}
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            aria-label={`Obra atual: ${projectDisplayName}. Toque para trocar de obra.`}
+          >
+            <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-[13px] font-bold text-foreground truncate leading-tight">
+                {projectDisplayName}
+              </span>
+              {project?.customer_name && (
+                <span className="block text-[10px] text-muted-foreground truncate leading-tight">
+                  {project.customer_name}
+                </span>
+              )}
+            </span>
+            {hasOthers && (
+              <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            )}
+          </button>
+        </SheetTrigger>
+
+        {hasOthers && (
+          <SheetContent
+            side="bottom"
+            className="rounded-t-3xl pb-safe max-h-[88dvh] flex flex-col p-0"
+          >
+            <SheetHeader className="px-5 pt-4 pb-2 shrink-0 text-left">
+              <SheetTitle className="text-base font-bold flex items-center gap-2">
+                <Building2 className="h-4 w-4" aria-hidden="true" />
+                Trocar de Obra
+              </SheetTitle>
+            </SheetHeader>
+
+            {otherProjects.length > 4 && (
+              <div className="px-5 pb-3 shrink-0 border-b border-border-subtle">
+                <div className="relative">
+                  <Search
+                    className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Buscar obra…"
+                    className="pl-9 h-11"
+                    aria-label="Buscar obra"
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="flex-1 overflow-y-auto px-3 py-2">
+              {/* Current project */}
+              <div className="px-3 py-2.5 rounded-xl bg-primary/5 mb-3 flex items-center gap-2">
+                <Check className="h-4 w-4 text-primary shrink-0" aria-hidden="true" />
+                <div className="min-w-0">
+                  <p className="text-[13px] font-semibold truncate">{projectDisplayName}</p>
+                  {project?.customer_name && (
+                    <p className="text-[11px] text-muted-foreground truncate">
+                      {project.customer_name}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {groupedProjects.length === 0 && searchQuery && (
+                <p className="text-sm text-muted-foreground text-center py-6">
+                  Nenhuma obra encontrada
+                </p>
+              )}
+
+              {groupedProjects.map((group) => (
+                <div key={group.status} className="mb-4 last:mb-0">
+                  <div className="flex items-center gap-2 px-2 mb-1.5">
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "text-[10px] px-1.5 py-0 h-5",
+                        STATUS_BADGE_STYLES[group.status],
+                      )}
+                    >
+                      {group.label}
+                    </Badge>
+                    <span className="text-[10px] text-muted-foreground">
+                      {group.projects.length}
+                    </span>
+                  </div>
+
+                  <div className="space-y-1">
+                    {group.projects.map((p) => {
+                      const pendingCount =
+                        pendingByProject instanceof Map
+                          ? pendingByProject.get(p.id) ?? 0
+                          : (pendingByProject as Record<string, number> | undefined)?.[p.id] ?? 0;
+                      return (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => handleProjectSwitch(p.id)}
+                          className={cn(
+                            "flex items-start gap-2 w-full px-3 py-3 rounded-xl text-left",
+                            "min-h-[56px] transition-all active:scale-[0.98]",
+                            "hover:bg-muted/60 active:bg-muted",
+                            "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                          )}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <span className="block text-[13px] font-semibold text-foreground truncate">
+                              {p.name}
+                              {p.unit_name && ` – ${p.unit_name}`}
+                            </span>
+                            <span className="flex items-center gap-1.5 mt-0.5">
+                              {p.customer_name && (
+                                <span className="text-[11px] text-muted-foreground truncate">
+                                  {p.customer_name}
+                                </span>
+                              )}
+                              {isStaff && (p as { engineer_name?: string }).engineer_name && (
+                                <>
+                                  <span className="text-[11px] text-muted-foreground/50">·</span>
+                                  <span className="text-[11px] text-muted-foreground/70 truncate">
+                                    {(p as { engineer_name?: string }).engineer_name}
+                                  </span>
+                                </>
+                              )}
+                            </span>
+                          </div>
+                          {pendingCount > 0 && (
+                            <Badge
+                              variant="destructive"
+                              className="shrink-0 min-w-5 h-5 px-1.5 text-[10px] font-bold mt-0.5"
+                              aria-label={`${pendingCount} pendências`}
+                            >
+                              {pendingCount}
+                            </Badge>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </SheetContent>
+        )}
+      </Sheet>
+
+      <Link
+        to="/"
+        className="sr-only"
+        aria-label="Ir para a página inicial"
+      >
+        Início
+      </Link>
+
+      <NotificationBell />
+      <UserMenu />
+    </header>
+  );
+}

--- a/src/components/layout/ProjectShell.tsx
+++ b/src/components/layout/ProjectShell.tsx
@@ -4,6 +4,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ProjectSidebar } from "@/components/layout/ProjectSidebar";
 import { ProjectSlimHeader } from "@/components/layout/ProjectSlimHeader";
+import { ProjectMobileHeader } from "@/components/layout/ProjectMobileHeader";
 import { ProjectLayoutProvider } from "@/components/layout/ProjectLayoutContext";
 import { MobileBottomNav } from "@/components/mobile/MobileBottomNav";
 import { FloatingApprovalBanner } from "@/components/pendencias/FloatingApprovalBanner";
@@ -52,11 +53,13 @@ export function ProjectShell({ children }: ProjectShellProps) {
     );
   }
 
-  // Clients get the existing experience + mobile bottom nav + floating approval banner
+  // Clients get the existing experience + mobile bottom nav + floating approval banner.
+  // On mobile, also render a slim project header so they can switch between obras.
   if (!isStaff) {
     return (
       <ProjectLayoutProvider value={{ hasShell: false }}>
         <div className="relative min-h-[100dvh]">
+          <ProjectMobileHeader />
           {isSwitching && <ProjectSwitchOverlay />}
           <div className="pb-bottom-nav">{children}</div>
         </div>
@@ -66,7 +69,7 @@ export function ProjectShell({ children }: ProjectShellProps) {
     );
   }
 
-  // Staff gets sidebar + slim header + mobile bottom nav
+  // Staff gets sidebar + slim header (desktop) / mobile header + mobile bottom nav
   return (
     <ProjectLayoutProvider value={{ hasShell: true }}>
       <SidebarProvider>
@@ -75,6 +78,7 @@ export function ProjectShell({ children }: ProjectShellProps) {
             <ProjectSidebar />
           </TooltipProvider>
           <div className="flex-1 flex flex-col min-w-0 relative">
+            <ProjectMobileHeader />
             <ProjectSlimHeader />
             {isSwitching && <ProjectSwitchOverlay />}
             <main className="flex-1 overflow-y-auto pb-bottom-nav">{children}</main>

--- a/src/components/mobile/BottomSheetPicker.tsx
+++ b/src/components/mobile/BottomSheetPicker.tsx
@@ -40,23 +40,19 @@ export function BottomSheetPicker({
       <SheetContent
         side="bottom"
         className={cn(
-          "max-h-[85dvh] rounded-t-2xl px-4 pb-safe overflow-y-auto",
-          className
+          "max-h-[88dvh] rounded-t-3xl px-4 pt-7 pb-safe overflow-y-auto",
+          className,
         )}
       >
-        <SheetHeader className="pb-3 border-b border-border mb-3">
-          <SheetTitle className="text-base font-semibold text-foreground">
-            {title}
-          </SheetTitle>
+        <SheetHeader className="pb-3 border-b border-border-subtle mb-3 text-left">
+          <SheetTitle className="text-base font-bold text-foreground">{title}</SheetTitle>
           {description && (
-            <SheetDescription className="text-sm text-muted-foreground">
+            <SheetDescription className="text-[13px] text-muted-foreground">
               {description}
             </SheetDescription>
           )}
         </SheetHeader>
-        <div className="min-w-0">
-          {children}
-        </div>
+        <div className="min-w-0">{children}</div>
       </SheetContent>
     </Sheet>
   );

--- a/src/components/mobile/GestaoBottomNav.tsx
+++ b/src/components/mobile/GestaoBottomNav.tsx
@@ -37,11 +37,11 @@ export function GestaoBottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 z-50 md:hidden"
+      className="fixed bottom-0 inset-x-0 z-shell md:hidden hide-on-keyboard"
       aria-label="Navegação gestão"
     >
       {/* Frosted glass bar */}
-      <div className="border-t border-border/60 bg-card/90 backdrop-blur-xl backdrop-saturate-150 pb-safe">
+      <div className="border-t border-border-subtle bg-card/90 backdrop-blur-xl backdrop-saturate-150 pb-safe pl-safe pr-safe">
         <div className="flex items-end justify-around h-16 relative px-2">
           {/* Painel */}
           <NavLink

--- a/src/components/mobile/MobileBottomNav.tsx
+++ b/src/components/mobile/MobileBottomNav.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from "react";
 import { NavLink } from "react-router-dom";
-import { Map, DollarSign, AlertCircle, Bell, GanttChartSquare, CheckSquare } from "lucide-react";
+import {
+  Map,
+  DollarSign,
+  AlertCircle,
+  Bell,
+  GanttChartSquare,
+  CheckSquare,
+  type LucideIcon,
+} from "lucide-react";
 import { useProjectNavigation } from "@/hooks/useProjectNavigation";
 import { usePendencias } from "@/hooks/usePendencias";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -12,10 +20,14 @@ import { MobileNotificationsSheet } from "./MobileNotificationsSheet";
 
 /**
  * MobileBottomNav — fixed bottom navigation for mobile users.
- * Shows role-appropriate tabs:
- * - Client: Jornada, Financeiro, Pendências, Avisos
- * - Staff: Pendências, Cronograma, Atividades, Financeiro, + Mais (full tool sheet)
- * Only rendered on mobile viewports.
+ *
+ * UX guarantees:
+ * - 44×44px minimum touch target per tab (WCAG 2.5.5).
+ * - Pill-style active state with high-contrast color (matches GestaoBottomNav).
+ * - Truncated labels remain legible at 11px / weight 600 with explicit foreground tone.
+ * - Keyboard-aware: hides itself when an input is focused on mobile so the
+ *   on-screen keyboard never overlaps form fields.
+ * - Tap feedback via active:scale.
  */
 export function MobileBottomNav() {
   const { paths, projectId } = useProjectNavigation();
@@ -26,7 +38,9 @@ export function MobileBottomNav() {
 
   const criticalPendencias = stats.overdueCount + stats.urgentCount;
 
-  const navItems = useMemo(() => {
+  const navItems = useMemo<
+    Array<{ label: string; icon: LucideIcon; to: string; badge: number }>
+  >(() => {
     if (isStaff) {
       return [
         { label: "Pendências", icon: AlertCircle, to: paths.pendencias, badge: criticalPendencias },
@@ -42,65 +56,117 @@ export function MobileBottomNav() {
     ];
   }, [isStaff, paths, criticalPendencias]);
 
-  // Enable swipe between the navigable tabs
-  const swipeRoutes = useMemo(
-    () => navItems.map((i) => i.to),
-    [navItems]
-  );
-
+  const swipeRoutes = useMemo(() => navItems.map((i) => i.to), [navItems]);
   useSwipeNavigation(swipeRoutes);
 
   return (
     <>
       <nav
-        className="fixed bottom-0 inset-x-0 z-50 border-t border-border/60 bg-card/95 backdrop-blur-xl backdrop-saturate-150 pb-safe md:hidden"
+        className={cn(
+          "fixed bottom-0 inset-x-0 z-shell md:hidden",
+          "border-t border-border-subtle bg-card/95 backdrop-blur-xl backdrop-saturate-150",
+          "pb-safe pl-safe pr-safe",
+          "hide-on-keyboard",
+        )}
         aria-label="Navegação principal"
       >
-        <div className="flex items-stretch justify-around h-16">
+        <div className="flex items-stretch justify-around h-16 px-1">
           {navItems.map((item) => (
             <NavLink
               key={item.label}
               to={item.to}
               className={({ isActive }) =>
                 cn(
-                  "relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 text-[10px] font-medium transition-colors",
-                  "active:scale-[0.95]",
-                  isActive
-                    ? "text-primary"
-                    : "text-muted-foreground"
+                  "relative flex flex-col items-center justify-center gap-1 flex-1 min-w-0 py-1.5",
+                  "min-h-[56px] transition-all active:scale-[0.94]",
+                  "focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-primary rounded-lg",
+                  isActive ? "text-primary" : "text-foreground-muted",
                 )
               }
+              aria-label={item.badge > 0 ? `${item.label} — ${item.badge} críticas` : item.label}
             >
-              <span className="relative">
-                <item.icon className="h-5 w-5" />
-                {item.badge > 0 && (
-                  <span className="absolute -top-1.5 -right-2 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[9px] font-bold flex items-center justify-center" aria-label={`${item.badge} pendências`}>
-                    {item.badge > 99 ? "99+" : item.badge}
+              {({ isActive }) => (
+                <>
+                  <span
+                    className={cn(
+                      "relative flex items-center justify-center w-11 h-7 rounded-full transition-all duration-200",
+                      isActive ? "bg-primary/12" : "bg-transparent",
+                    )}
+                  >
+                    <item.icon
+                      className={cn(
+                        "h-[22px] w-[22px] transition-colors",
+                        isActive ? "text-primary" : "text-foreground-muted",
+                      )}
+                      strokeWidth={isActive ? 2.25 : 2}
+                    />
+                    {item.badge > 0 && (
+                      <span
+                        className="absolute -top-1 -right-1 min-w-[16px] h-[16px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card"
+                        aria-hidden="true"
+                      >
+                        {item.badge > 99 ? "99+" : item.badge}
+                      </span>
+                    )}
                   </span>
-                )}
-              </span>
-              <span className="truncate">{item.label}</span>
+                  <span
+                    className={cn(
+                      "text-[11px] leading-none truncate max-w-full",
+                      isActive ? "font-semibold text-primary" : "font-medium",
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </>
+              )}
             </NavLink>
           ))}
 
           {/* Client: Notifications button */}
           {!isStaff && (
             <button
+              type="button"
               onClick={() => setNotificationsOpen(true)}
               className={cn(
-                "relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 text-[10px] font-medium transition-colors active:scale-[0.95]",
-                notificationsOpen ? "text-primary" : "text-muted-foreground"
+                "relative flex flex-col items-center justify-center gap-1 flex-1 min-w-0 py-1.5",
+                "min-h-[56px] transition-all active:scale-[0.94]",
+                "focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-primary rounded-lg",
+                notificationsOpen ? "text-primary" : "text-foreground-muted",
               )}
+              aria-label={unreadCount > 0 ? `Avisos — ${unreadCount} não lidas` : "Avisos"}
+              aria-haspopup="dialog"
+              aria-expanded={notificationsOpen}
             >
-              <span className="relative">
-                <Bell className="h-5 w-5" />
+              <span
+                className={cn(
+                  "relative flex items-center justify-center w-11 h-7 rounded-full transition-all duration-200",
+                  notificationsOpen ? "bg-primary/12" : "bg-transparent",
+                )}
+              >
+                <Bell
+                  className={cn(
+                    "h-[22px] w-[22px] transition-colors",
+                    notificationsOpen ? "text-primary" : "text-foreground-muted",
+                  )}
+                  strokeWidth={notificationsOpen ? 2.25 : 2}
+                />
                 {unreadCount > 0 && (
-                  <span className="absolute -top-1.5 -right-2 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[9px] font-bold flex items-center justify-center" aria-label={`${unreadCount} notificações não lidas`}>
+                  <span
+                    className="absolute -top-1 -right-1 min-w-[16px] h-[16px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card"
+                    aria-hidden="true"
+                  >
                     {unreadCount > 99 ? "99+" : unreadCount}
                   </span>
                 )}
               </span>
-              <span className="truncate">Avisos</span>
+              <span
+                className={cn(
+                  "text-[11px] leading-none truncate max-w-full",
+                  notificationsOpen ? "font-semibold text-primary" : "font-medium",
+                )}
+              >
+                Avisos
+              </span>
             </button>
           )}
 

--- a/src/components/mobile/MobileListItem.tsx
+++ b/src/components/mobile/MobileListItem.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
 
+type MobileListItemTone = "default" | "warning" | "destructive" | "success";
+
 interface MobileListItemProps {
   /** Primary label */
   title: string;
@@ -14,13 +16,37 @@ interface MobileListItemProps {
   showChevron?: boolean;
   /** Click handler */
   onClick?: () => void;
+  /** Visual emphasis tone (default · warning · destructive · success) */
+  tone?: MobileListItemTone;
+  /** Render as anchor (link). When provided, the row is rendered as an `<a>`. */
+  href?: string;
+  /** Disable interaction (button only) */
+  disabled?: boolean;
   /** Additional className */
   className?: string;
 }
 
+const toneClasses: Record<MobileListItemTone, string> = {
+  default: "",
+  warning: "bg-warning/5 hover:bg-warning/10 active:bg-warning/15",
+  destructive: "bg-destructive/5 hover:bg-destructive/10 active:bg-destructive/15",
+  success: "bg-success/5 hover:bg-success/10 active:bg-success/15",
+};
+
+const toneAccentBorder: Record<MobileListItemTone, string> = {
+  default: "",
+  warning: "border-l-2 border-l-warning",
+  destructive: "border-l-2 border-l-destructive",
+  success: "border-l-2 border-l-success",
+};
+
 /**
- * MobileListItem — standardized list row with consistent 44px touch target.
- * Leading icon/avatar + title/subtitle + trailing status/value + optional chevron.
+ * MobileListItem — standardized list row.
+ *
+ * - 56px minimum touch target (exceeds WCAG 2.5.5 — 44×44).
+ * - Optional `tone` for emphasis (warning · destructive · success).
+ * - Renders as `<button>`, `<a>` (when `href` is set), or plain `<div>`.
+ * - Visible focus ring; respects keyboard navigation.
  */
 export function MobileListItem({
   title,
@@ -29,23 +55,42 @@ export function MobileListItem({
   trailing,
   showChevron = true,
   onClick,
+  tone = "default",
+  href,
+  disabled = false,
   className,
 }: MobileListItemProps) {
-  const isClickable = !!onClick;
-  const Component = isClickable ? "button" : "div";
+  const isInteractive = (!!onClick || !!href) && !disabled;
+  const Component: React.ElementType = href ? "a" : isInteractive ? "button" : "div";
+
+  const componentProps: React.HTMLAttributes<HTMLElement> & {
+    href?: string;
+    type?: "button";
+    disabled?: boolean;
+  } = {
+    onClick: isInteractive ? onClick : undefined,
+    className: cn(
+      "flex items-center gap-3 w-full min-h-[56px] px-4 py-3 text-left",
+      "border-b border-border-subtle last:border-b-0",
+      isInteractive &&
+        "active:scale-[0.99] transition-[transform,background-color] duration-150 cursor-pointer",
+      isInteractive && tone === "default" && "hover:bg-muted/50 active:bg-muted",
+      tone !== "default" && toneClasses[tone],
+      tone !== "default" && toneAccentBorder[tone],
+      "focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary",
+      disabled && "opacity-60 cursor-not-allowed",
+      className,
+    ),
+  };
+
+  if (href) componentProps.href = href;
+  if (Component === "button") {
+    componentProps.type = "button";
+    componentProps.disabled = disabled;
+  }
 
   return (
-    <Component
-      className={cn(
-        "flex items-center gap-3 w-full min-h-[44px] px-4 py-3 text-left",
-        "border-b border-border last:border-b-0",
-        isClickable && "hover:bg-muted/50 active:bg-muted transition-colors cursor-pointer",
-        "focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary",
-        className
-      )}
-      onClick={onClick}
-      type={isClickable ? "button" : undefined}
-    >
+    <Component {...componentProps}>
       {leading && (
         <div className="shrink-0 flex items-center justify-center w-10 h-10">
           {leading}
@@ -53,20 +98,19 @@ export function MobileListItem({
       )}
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-foreground truncate">{title}</p>
+        <p className="text-[14px] font-medium text-foreground truncate">{title}</p>
         {subtitle && (
-          <p className="text-xs text-muted-foreground mt-0.5 truncate">{subtitle}</p>
+          <p className="text-[12px] text-muted-foreground mt-0.5 line-clamp-2">{subtitle}</p>
         )}
       </div>
 
-      {trailing && (
-        <div className="shrink-0 flex items-center">
-          {trailing}
-        </div>
-      )}
+      {trailing && <div className="shrink-0 flex items-center">{trailing}</div>}
 
-      {showChevron && isClickable && (
-        <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+      {showChevron && isInteractive && (
+        <ChevronRight
+          className="h-4 w-4 text-muted-foreground shrink-0"
+          aria-hidden="true"
+        />
       )}
     </Component>
   );

--- a/src/components/mobile/MobileMoreSheet.tsx
+++ b/src/components/mobile/MobileMoreSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
   MoreHorizontal,
@@ -11,7 +11,6 @@ import {
   Box,
   Ruler,
   DollarSign,
-  Bell,
   CheckSquare,
   AlertTriangle,
   Users,
@@ -19,6 +18,8 @@ import {
   AlertCircle,
   ClipboardList,
   Building2,
+  Search,
+  type LucideIcon,
 } from "lucide-react";
 import {
   Sheet,
@@ -27,14 +28,14 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { useProjectNavigation } from "@/hooks/useProjectNavigation";
-import { useNotifications } from "@/hooks/useNotifications";
+import { matchesSearch } from "@/lib/searchNormalize";
 import { cn } from "@/lib/utils";
 
 interface MoreItem {
   label: string;
-  icon: typeof Map;
+  icon: LucideIcon;
   to: string;
   description?: string;
 }
@@ -46,83 +47,157 @@ interface MoreGroup {
 
 export function MobileMoreSheet() {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const { paths } = useProjectNavigation();
-  const { unreadCount } = useNotifications();
   const location = useLocation();
 
-  const groups: MoreGroup[] = [
-    {
-      label: "Visão Geral",
-      items: [
-        { label: "Jornada", icon: Map, to: paths.jornada, description: "Acompanhe cada etapa" },
-        { label: "Painel da Obra", icon: Building2, to: paths.relatorio, description: "Resumo e evolução" },
-      ],
-    },
-    {
-      label: "Projeto",
-      items: [
-        { label: "Contrato", icon: FileText, to: paths.contrato, description: "Contrato do cliente" },
-        { label: "Projeto 3D", icon: Box, to: paths.projeto3D, description: "Modelos e renders" },
-        { label: "Executivo", icon: Ruler, to: paths.executivo, description: "Plantas e detalhes" },
-        { label: "Documentos", icon: FolderOpen, to: paths.documentos, description: "Todos os documentos" },
-      ],
-    },
-    {
-      label: "Dia a Dia",
-      items: [
-        { label: "Cronograma", icon: GanttChartSquare, to: paths.cronograma, description: "Atividades e prazos" },
-        { label: "Compras", icon: ShoppingCart, to: paths.compras, description: "Pedidos e cotações" },
-        { label: "Vistorias & NC", icon: Eye, to: paths.vistorias, description: "Inspeções de qualidade" },
-        { label: "Não Conformidades", icon: AlertTriangle, to: paths.naoConformidades, description: "Pendências técnicas" },
-        { label: "Atividades", icon: CheckSquare, to: paths.atividades, description: "Tarefas da equipe" },
-        { label: "Pendências", icon: AlertCircle, to: paths.pendencias, description: "O que resolver" },
-      ],
-    },
-    {
-      label: "Gestão",
-      items: [
-        { label: "Financeiro", icon: DollarSign, to: paths.financeiro, description: "Pagamentos e custos" },
-        { label: "Formalizações", icon: ClipboardSignature, to: paths.formalizacoes, description: "Aprovações e assinaturas" },
-        { label: "Dados do Cliente", icon: Users, to: paths.dadosCliente, description: "Cadastro do contratante" },
-        { label: "Orçamento", icon: ClipboardList, to: paths.orcamento, description: "Detalhamento de custos" },
-      ],
-    },
-  ];
+  const groups = useMemo<MoreGroup[]>(
+    () => [
+      {
+        label: "Visão Geral",
+        items: [
+          { label: "Jornada", icon: Map, to: paths.jornada, description: "Acompanhe cada etapa" },
+          { label: "Painel", icon: Building2, to: paths.relatorio, description: "Resumo e evolução" },
+        ],
+      },
+      {
+        label: "Projeto",
+        items: [
+          { label: "Contrato", icon: FileText, to: paths.contrato, description: "Contrato do cliente" },
+          { label: "Projeto 3D", icon: Box, to: paths.projeto3D, description: "Modelos e renders" },
+          { label: "Executivo", icon: Ruler, to: paths.executivo, description: "Plantas e detalhes" },
+          { label: "Documentos", icon: FolderOpen, to: paths.documentos, description: "Todos os documentos" },
+        ],
+      },
+      {
+        label: "Dia a Dia",
+        items: [
+          { label: "Cronograma", icon: GanttChartSquare, to: paths.cronograma, description: "Atividades e prazos" },
+          { label: "Compras", icon: ShoppingCart, to: paths.compras, description: "Pedidos e cotações" },
+          { label: "Vistorias", icon: Eye, to: paths.vistorias, description: "Inspeções de qualidade" },
+          { label: "Não Conformidades", icon: AlertTriangle, to: paths.naoConformidades, description: "Pendências técnicas" },
+          { label: "Atividades", icon: CheckSquare, to: paths.atividades, description: "Tarefas da equipe" },
+          { label: "Pendências", icon: AlertCircle, to: paths.pendencias, description: "O que resolver" },
+        ],
+      },
+      {
+        label: "Gestão",
+        items: [
+          { label: "Financeiro", icon: DollarSign, to: paths.financeiro, description: "Pagamentos e custos" },
+          { label: "Formalizações", icon: ClipboardSignature, to: paths.formalizacoes, description: "Aprovações e assinaturas" },
+          { label: "Dados do Cliente", icon: Users, to: paths.dadosCliente, description: "Cadastro do contratante" },
+          { label: "Orçamento", icon: ClipboardList, to: paths.orcamento, description: "Detalhamento de custos" },
+        ],
+      },
+    ],
+    [paths],
+  );
 
-  const allItems = groups.flatMap((g) => g.items);
+  const allItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
   const isAnyActive = allItems.some((i) => location.pathname.startsWith(i.to));
 
+  // Filtered groups (search is full-text on label + description)
+  const filteredGroups = useMemo<MoreGroup[]>(() => {
+    if (!query.trim()) return groups;
+    return groups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => matchesSearch(query, [item.label, item.description])),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [groups, query]);
+
+  const handleClose = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
       <SheetTrigger asChild>
         <button
+          type="button"
           className={cn(
-            "relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 text-[10px] font-medium transition-colors active:scale-[0.95]",
-            isAnyActive ? "text-primary" : "text-muted-foreground"
+            "relative flex flex-col items-center justify-center gap-1 flex-1 min-w-0 py-1.5",
+            "min-h-[56px] transition-all active:scale-[0.94]",
+            "focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-primary rounded-lg",
+            isAnyActive ? "text-primary" : "text-foreground-muted",
           )}
           aria-label="Mais opções"
+          aria-haspopup="dialog"
+          aria-expanded={open}
         >
-          <span className="relative">
-            <MoreHorizontal className="h-5 w-5" />
+          <span
+            className={cn(
+              "relative flex items-center justify-center w-11 h-7 rounded-full transition-all duration-200",
+              isAnyActive ? "bg-primary/12" : "bg-transparent",
+            )}
+          >
+            <MoreHorizontal
+              className={cn(
+                "h-[22px] w-[22px] transition-colors",
+                isAnyActive ? "text-primary" : "text-foreground-muted",
+              )}
+              strokeWidth={isAnyActive ? 2.25 : 2}
+            />
             {isAnyActive && (
-              <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-primary" />
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-primary" />
             )}
           </span>
-          <span className="truncate">Mais</span>
+          <span
+            className={cn(
+              "text-[11px] leading-none truncate max-w-full",
+              isAnyActive ? "font-semibold text-primary" : "font-medium",
+            )}
+          >
+            Mais
+          </span>
         </button>
       </SheetTrigger>
-      <SheetContent side="bottom" className="rounded-t-3xl pb-safe max-h-[85vh] overflow-y-auto">
-        <SheetHeader className="pb-1">
-          <SheetTitle className="text-base font-bold">Ferramentas</SheetTitle>
+      <SheetContent
+        side="bottom"
+        className="rounded-t-3xl pb-safe max-h-[88dvh] flex flex-col p-0"
+      >
+        <SheetHeader className="px-5 pt-4 pb-3 shrink-0 text-left">
+          <SheetTitle className="text-base font-bold">Ferramentas da obra</SheetTitle>
         </SheetHeader>
 
-        <nav className="space-y-4 pb-2">
-          {groups.map((group) => (
+        {/* Sticky search */}
+        <div className="px-5 pb-3 shrink-0 border-b border-border-subtle">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Buscar ferramenta…"
+              className="pl-9 h-11"
+              autoFocus={false}
+              aria-label="Buscar ferramenta"
+            />
+          </div>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto px-3 pt-3 pb-2 space-y-5">
+          {filteredGroups.length === 0 && (
+            <div className="px-2 py-10 text-center">
+              <p className="text-sm font-medium text-foreground">Nada encontrado</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Tente buscar por outro termo.
+              </p>
+            </div>
+          )}
+          {filteredGroups.map((group) => (
             <div key={group.label}>
-              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-1 mb-1.5">
+              <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider px-3 mb-2">
                 {group.label}
               </p>
-              <div className="grid grid-cols-3 gap-1.5">
+              <div className="grid grid-cols-2 gap-2">
                 {group.items.map((item) => {
                   const Icon = item.icon;
                   const isActive = location.pathname.startsWith(item.to);
@@ -130,31 +205,40 @@ export function MobileMoreSheet() {
                     <NavLink
                       key={item.to}
                       to={item.to}
-                      onClick={() => setOpen(false)}
+                      onClick={handleClose}
                       className={cn(
-                        "flex flex-col items-center gap-1.5 px-2 py-3 rounded-xl text-center transition-all min-h-[72px] active:scale-[0.96]",
+                        "flex items-start gap-2.5 px-3 py-3 rounded-2xl text-left transition-all",
+                        "min-h-[64px] active:scale-[0.97]",
+                        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
                         isActive
-                          ? "bg-primary/10 ring-1 ring-primary/20"
-                          : "hover:bg-muted/60"
+                          ? "bg-primary/10 ring-1 ring-primary/25"
+                          : "bg-muted/40 hover:bg-muted/60 active:bg-muted",
                       )}
                     >
-                      <div
+                      <span
                         className={cn(
                           "flex items-center justify-center w-10 h-10 rounded-xl shrink-0",
                           isActive
                             ? "bg-primary/15 text-primary"
-                            : "bg-muted text-muted-foreground"
+                            : "bg-card text-foreground-muted shadow-sm",
                         )}
                       >
-                        <Icon className="h-5 w-5" />
-                      </div>
-                      <span
-                        className={cn(
-                          "text-[11px] font-medium leading-tight line-clamp-2",
-                          isActive ? "text-primary font-semibold" : "text-foreground"
+                        <Icon className="h-[18px] w-[18px]" />
+                      </span>
+                      <span className="flex-1 min-w-0 pt-0.5">
+                        <span
+                          className={cn(
+                            "block text-[13px] font-semibold leading-tight truncate",
+                            isActive ? "text-primary" : "text-foreground",
+                          )}
+                        >
+                          {item.label}
+                        </span>
+                        {item.description && (
+                          <span className="block text-[11px] text-muted-foreground leading-snug mt-0.5 line-clamp-2">
+                            {item.description}
+                          </span>
                         )}
-                      >
-                        {item.label}
                       </span>
                     </NavLink>
                   );

--- a/src/components/mobile/MobileNotificationsSheet.tsx
+++ b/src/components/mobile/MobileNotificationsSheet.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Bell,
   CheckCheck,
@@ -127,12 +127,12 @@ export function MobileNotificationsSheet({ open, onOpenChange }: MobileNotificat
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="rounded-t-2xl pb-safe max-h-[85dvh] flex flex-col p-0">
-        {/* Header */}
+      <SheetContent side="bottom" className="rounded-t-3xl pb-safe max-h-[88dvh] flex flex-col p-0">
+        {/* Header (extra top padding leaves room for the drag-handle) */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2 shrink-0">
-          <SheetHeader className="p-0">
-            <SheetTitle className="text-base flex items-center gap-2">
-              <Bell className="h-4 w-4" />
+          <SheetHeader className="p-0 text-left">
+            <SheetTitle className="text-base font-bold flex items-center gap-2">
+              <Bell className="h-4 w-4" aria-hidden="true" />
               Notificações
               {unreadCount > 0 && (
                 <Badge variant="destructive" className="text-[10px] px-1.5 h-5">
@@ -142,7 +142,12 @@ export function MobileNotificationsSheet({ open, onOpenChange }: MobileNotificat
             </SheetTitle>
           </SheetHeader>
           {unreadCount > 0 && (
-            <Button variant="ghost" size="sm" onClick={markAllAsRead} className="text-xs text-primary h-auto py-1 px-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={markAllAsRead}
+              className="text-xs text-primary h-9 py-1 px-2 -mr-1"
+            >
               <CheckCheck className="w-3.5 h-3.5 mr-1" />
               Marcar todas
             </Button>
@@ -154,15 +159,15 @@ export function MobileNotificationsSheet({ open, onOpenChange }: MobileNotificat
           <TabsList className="w-full rounded-none border-b border-border bg-transparent h-auto p-0 shrink-0">
             <TabsTrigger
               value="all"
-              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[40px] text-xs"
+              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[44px] text-[13px] font-medium"
             >
               Todas
             </TabsTrigger>
             <TabsTrigger
               value="actions"
-              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-destructive data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[40px] text-xs"
+              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-destructive data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[44px] text-[13px] font-medium"
             >
-              <AlertCircle className="w-3 h-3 mr-1 text-destructive" />
+              <AlertCircle className="w-3.5 h-3.5 mr-1 text-destructive" aria-hidden="true" />
               Ação
               {unreadActionCount > 0 && (
                 <Badge variant="destructive" className="ml-1 h-4 min-w-[16px] px-1 text-[10px]">
@@ -172,9 +177,9 @@ export function MobileNotificationsSheet({ open, onOpenChange }: MobileNotificat
             </TabsTrigger>
             <TabsTrigger
               value="updates"
-              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[40px] text-xs"
+              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none min-h-[44px] text-[13px] font-medium"
             >
-              <Calendar className="w-3 h-3 mr-1 text-primary" />
+              <Calendar className="w-3.5 h-3.5 mr-1 text-primary" aria-hidden="true" />
               Atualizações
             </TabsTrigger>
           </TabsList>

--- a/src/components/mobile/MobileSectionCard.tsx
+++ b/src/components/mobile/MobileSectionCard.tsx
@@ -22,8 +22,11 @@ interface MobileSectionCardProps {
 }
 
 /**
- * MobileSectionCard — standard mobile card with title, subtitle, optional action.
- * Touch-friendly with 44px minimum hit area on clickable cards.
+ * MobileSectionCard — standard mobile card.
+ *
+ * - 44px minimum hit area when clickable.
+ * - Visible focus ring + active scale feedback.
+ * - Title/subtitle hierarchy tuned for mobile reading (14px / 12px).
  */
 export function MobileSectionCard({
   title,
@@ -41,43 +44,49 @@ export function MobileSectionCard({
     <Card
       className={cn(
         "overflow-hidden",
-        isClickable && "cursor-pointer active:bg-muted/50 transition-colors",
-        className
+        isClickable &&
+          "cursor-pointer active:bg-muted/50 active:scale-[0.995] transition-[transform,background-color] duration-150",
+        isClickable &&
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+        className,
       )}
       onClick={onClick}
       role={isClickable ? "button" : undefined}
       tabIndex={isClickable ? 0 : undefined}
-      onKeyDown={isClickable ? (e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick?.();
-        }
-      } : undefined}
+      onKeyDown={
+        isClickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick?.();
+              }
+            }
+          : undefined
+      }
     >
       <CardHeader className="p-4 pb-0">
         <div className="flex items-center gap-3 min-w-0">
           {Icon && (
             <div className="flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 shrink-0">
-              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+              <Icon className="h-[18px] w-[18px] text-primary" aria-hidden="true" />
             </div>
           )}
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-semibold text-foreground truncate">{title}</h3>
+            <h3 className="text-[14px] font-semibold text-foreground truncate">{title}</h3>
             {subtitle && (
-              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{subtitle}</p>
+              <p className="text-[12px] text-muted-foreground mt-0.5 line-clamp-2">{subtitle}</p>
             )}
           </div>
           {action && <div className="shrink-0">{action}</div>}
           {showChevron && !action && (
-            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+            <ChevronRight
+              className="h-4 w-4 text-muted-foreground shrink-0"
+              aria-hidden="true"
+            />
           )}
         </div>
       </CardHeader>
-      {children && (
-        <CardContent className="p-4 pt-3">
-          {children}
-        </CardContent>
-      )}
+      {children && <CardContent className="p-4 pt-3">{children}</CardContent>}
     </Card>
   );
 }

--- a/src/components/mobile/ProjectSwitcherSheet.tsx
+++ b/src/components/mobile/ProjectSwitcherSheet.tsx
@@ -87,10 +87,10 @@ export function ProjectSwitcherSheet({
           <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
         </button>
       </SheetTrigger>
-      <SheetContent side="bottom" className="rounded-t-2xl pb-safe max-h-[70dvh] flex flex-col">
-        <SheetHeader className="pb-2 shrink-0">
-          <SheetTitle className="text-base flex items-center gap-2">
-            <Building2 className="h-4 w-4" />
+      <SheetContent side="bottom" className="rounded-t-3xl pt-7 pb-safe max-h-[80dvh] flex flex-col">
+        <SheetHeader className="pb-2 shrink-0 text-left">
+          <SheetTitle className="text-base font-bold flex items-center gap-2">
+            <Building2 className="h-4 w-4" aria-hidden="true" />
             Trocar de Obra
           </SheetTitle>
         </SheetHeader>

--- a/src/components/mobile/ResponsivePageShell.tsx
+++ b/src/components/mobile/ResponsivePageShell.tsx
@@ -9,6 +9,8 @@ interface ResponsivePageShellProps {
   noPaddingY?: boolean;
   /** Render a sticky CTA footer (mobile-first, sits above bottom nav) */
   stickyFooter?: React.ReactNode;
+  /** Apply horizontal/vertical breathing room appropriate for mobile (default true) */
+  padded?: boolean;
 }
 
 const maxWidthMap = {
@@ -21,11 +23,14 @@ const maxWidthMap = {
 
 /**
  * ResponsivePageShell — standard mobile-first page wrapper.
- * - Fixed 16px lateral padding on mobile, scaling up on larger screens
- * - Overflow containment (no horizontal scroll)
- * - Safe-area padding for notched devices
- * - Consistent vertical rhythm
- * - Optional sticky CTA footer positioned above bottom nav
+ *
+ * - 16px lateral padding on mobile, scaling on larger screens.
+ * - Overflow containment (no horizontal scroll).
+ * - Safe-area padding for notched devices.
+ * - Consistent vertical rhythm.
+ * - Optional sticky CTA footer positioned above the bottom nav.
+ * - When `stickyFooter` is set, content gets bottom padding so the CTA never
+ *   overlaps the last row.
  */
 export function ResponsivePageShell({
   children,
@@ -33,19 +38,22 @@ export function ResponsivePageShell({
   maxWidth = "lg",
   noPaddingY = false,
   stickyFooter,
+  padded = true,
 }: ResponsivePageShellProps) {
   return (
     <>
       <main
         id="main-content"
         className={cn(
-          "mx-auto w-full px-4 sm:px-6 md:px-8",
+          "mx-auto w-full",
+          padded && "px-4 sm:px-6 md:px-8",
           "overflow-x-hidden min-w-0",
           maxWidthMap[maxWidth],
-          !noPaddingY && "py-4 md:py-8",
-          stickyFooter && "pb-20 md:pb-8", // extra room for sticky CTA
+          !noPaddingY && "py-3 md:py-8",
+          // Reserve room for sticky CTA so the last row isn't covered
+          stickyFooter && "pb-[calc(var(--sticky-cta-height)+24px)] md:pb-8",
           "pb-safe",
-          className
+          className,
         )}
       >
         {children}
@@ -54,13 +62,11 @@ export function ResponsivePageShell({
       {stickyFooter && (
         <div
           className={cn(
-            "fixed inset-x-0 z-40 bg-card/95 backdrop-blur-md border-t border-border",
-            "px-4 py-3 bottom-cta keyboard-aware",
+            "fixed inset-x-0 z-shell bg-card/95 backdrop-blur-md border-t border-border",
+            "px-4 py-3 bottom-cta keyboard-aware pl-safe pr-safe",
           )}
         >
-          <div className={cn("mx-auto w-full", maxWidthMap[maxWidth])}>
-            {stickyFooter}
-          </div>
+          <div className={cn("mx-auto w-full", maxWidthMap[maxWidth])}>{stickyFooter}</div>
         </div>
       )}
     </>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -56,10 +56,20 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {/* Visual drag-handle for bottom sheets — communicates swipe-to-dismiss affordance */}
+        {side === "bottom" && <span aria-hidden="true" className="sheet-drag-handle" />}
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <SheetPrimitive.Close
+          className={cn(
+            "absolute rounded-full opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none",
+            // Bigger hit-area on mobile sheets; standard on side sheets
+            side === "bottom"
+              ? "right-3 top-3 inline-flex h-10 w-10 items-center justify-center"
+              : "right-4 top-4",
+          )}
+        >
           <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
+          <span className="sr-only">Fechar</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,15 +1,22 @@
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, toast } from "sonner";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
+  const isMobile = useIsMobile();
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
+      // Mobile: top-center keeps toasts visible above bottom nav and within thumb-reach.
+      // Desktop: bottom-right (default Sonner behavior).
+      position={isMobile ? "top-center" : "bottom-right"}
       className="toaster group"
+      // Slightly larger duration on mobile so users have time to read while interacting.
+      duration={isMobile ? 5000 : 4000}
       toastOptions={{
         classNames: {
           toast:

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,9 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-toast flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      // Mobile: anchor to top so toasts stay above the bottom nav and within thumb-reach.
+      // Desktop: bottom-right (legacy behavior).
+      "fixed top-0 z-toast flex max-h-screen w-full flex-col p-3 pt-safe sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col sm:p-4 md:max-w-[420px]",
       className,
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -117,9 +117,10 @@
     --shadow-ring: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring) / 0.45);
 
     /* Mobile layout tokens */
-    --bottom-nav-height: 56px; /* h-14 */
+    --bottom-nav-height: 64px; /* h-16 — matches MobileBottomNav/GestaoBottomNav */
     --bottom-nav-offset: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
     --sticky-cta-height: 64px;
+    --mobile-header-height: 52px; /* slim mobile header inside ProjectShell */
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 212 43% 24%;
@@ -484,9 +485,18 @@
     display: none;
   }
 
-  /* Safe area padding for mobile */
+  /* Safe area paddings for mobile (notched / home-indicator devices) */
   .pb-safe {
     padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .pt-safe {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+  .pl-safe {
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+  .pr-safe {
+    padding-right: env(safe-area-inset-right, 0px);
   }
 
   /* Bottom nav spacing — use on page content containers on mobile */
@@ -533,6 +543,47 @@
     .keyboard-aware {
       transition: padding-bottom 0.2s ease;
       padding-bottom: env(keyboard-inset-height, 0px);
+    }
+  }
+
+  /* Bottom-sheet drag handle (visual affordance for swipe-to-dismiss).
+   * Sits inside the rounded-top edge, neutral gray pill. */
+  .sheet-drag-handle {
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 36px;
+    height: 4px;
+    border-radius: 9999px;
+    background-color: hsl(var(--border-strong));
+    opacity: 0.6;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  /* Toast viewport offset on mobile so toasts don't sit under the bottom nav.
+   * Only applies at <md, where bottom nav is rendered. */
+  .toaster-mobile-aware {
+    bottom: calc(var(--bottom-nav-offset) + 12px) !important;
+  }
+  @media (min-width: 768px) {
+    .toaster-mobile-aware {
+      bottom: 16px !important;
+    }
+  }
+
+  /* Auto-hide bottom nav when virtual keyboard is open (modern iOS/Android).
+   * Use on the bottom nav <nav> element. */
+  @supports (height: env(keyboard-inset-height)) {
+    .hide-on-keyboard {
+      transition: transform 0.18s ease;
+    }
+    @media (max-width: 767px) {
+      :root:has(input:focus, textarea:focus, [contenteditable="true"]:focus)
+        .hide-on-keyboard {
+        transform: translateY(110%);
+      }
     }
   }
 


### PR DESCRIPTION
- Corrige token --bottom-nav-height (56→64px) para alinhar com a altura
  real da bottom nav e evitar conteúdo encoberto.
- Bottom nav: tap target ≥56px, tipografia legível (11px), pílula ativa
  consistente, badges com anel de contraste, oculta quando teclado abre.
- Adiciona ProjectMobileHeader: header slim no mobile (cliente e staff)
  com troca de obra, busca, sino de notificações e menu de usuário.
- Bottom sheets: drag handle visual, botão de fechar com hit-area 40px,
  mais altura útil (88dvh) e cantos arredondados maiores.
- MobileMoreSheet: grid 2col com descrições, busca incremental,
  agrupamento por contexto e foco visível.
- Toaster (Sonner + Radix): top-center no mobile para não sobrepor a
  bottom nav; safe-area no viewport.
- MobileListItem: tons (warning/destructive/success), suporte a `href`,
  tap-target 56px, foco acessível.
- ResponsivePageShell: reserva espaço para sticky CTA, safe-area
  horizontal e padding mobile mais enxuto.
- PageHeader e AppHeader: tap targets 44px, safe-area, hierarquia
  tipográfica maior no mobile.
- Utilitários CSS: sheet-drag-handle, hide-on-keyboard, pt/pl/pr-safe.