### PR TITLE
Refatora UX mobile do Painel de Obras, Dados do cliente e editor rico

### DIFF
--- a/src/components/admin/obras/DadosClienteDialog.tsx
+++ b/src/components/admin/obras/DadosClienteDialog.tsx
@@ -1,13 +1,20 @@
 /**
- * DadosClienteDialog — abre a feature "Dados do Cliente" em popup,
- * usado a partir do Painel de Obras (coluna do ícone de documento).
+ * DadosClienteDialog — abre a feature "Dados do Cliente" como popup.
+ *
+ * Comportamento responsivo:
+ *  - Desktop (≥ md): Dialog centralizado (≤960px), header sticky e
+ *    body rolável internamente. Mantido o padrão Linear/Notion para
+ *    edição lado-a-lado da listagem.
+ *  - Mobile (< md): MobileFullscreenSheet — full-screen com header
+ *    sticky, body rolável que respeita safe-area, e a sticky save
+ *    bar provida pelo próprio `DadosCliente` (modo `embedded`).
  *
  * Reutiliza integralmente a página `DadosCliente` passando `projectId`
- * via prop, sem duplicar lógica de fetch/save. O Dialog é largo
- * (até ~960px) e rola internamente para acomodar as 3 abas
- * (Contratante / Imóvel / Informações do Projeto — rich text).
+ * via prop, sem duplicar lógica de fetch/save.
  */
+import { useIsMobile } from '@/hooks/use-mobile';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { MobileFullscreenSheet } from '@/components/mobile';
 import DadosCliente from '@/pages/DadosCliente';
 
 interface DadosClienteDialogProps {
@@ -18,6 +25,12 @@ interface DadosClienteDialogProps {
   customerName?: string | null;
 }
 
+function buildSubtitle(customerName?: string | null, projectName?: string | null) {
+  if (!customerName && !projectName) return 'Informações cadastrais e do projeto';
+  if (customerName && projectName) return `${customerName} · ${projectName}`;
+  return customerName ?? projectName ?? '';
+}
+
 export function DadosClienteDialog({
   open,
   onOpenChange,
@@ -25,17 +38,39 @@ export function DadosClienteDialog({
   projectName,
   customerName,
 }: DadosClienteDialogProps) {
+  const isMobile = useIsMobile();
+  const subtitle = buildSubtitle(customerName, projectName);
+
+  // ── Mobile: full-screen sheet com header sticky e safe-area. Save fica
+  //    sticky dentro de DadosCliente (embedded), evitando conflito com a
+  //    bottom navigation e safe-area inferior. Não usa Dialog centralizado.
+  if (isMobile) {
+    return (
+      <MobileFullscreenSheet
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Dados do cliente"
+        description={subtitle}
+        closeAriaLabel="Voltar para a listagem"
+      >
+        {projectId ? (
+          <DadosCliente projectId={projectId} embedded />
+        ) : (
+          <p className="p-6 text-sm text-muted-foreground">Selecione uma obra.</p>
+        )}
+      </MobileFullscreenSheet>
+    );
+  }
+
+  // ── Desktop: dialog centralizado (preserva o comportamento original).
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        // Largura controlada para acomodar formulários em 2 colunas + área
-        // de rich text confortável. `max-h` + overflow para evitar que o
-        // dialog estoure a viewport em telas menores.
         className="max-w-[min(960px,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto p-0 gap-0"
       >
         <DialogHeader className="px-6 pt-6 pb-3 border-b border-border-subtle sticky top-0 bg-background z-10">
           <DialogTitle className="text-lg">Dados do cliente</DialogTitle>
-          <DialogDescription className="text-xs">
+          <DialogDescription className="text-xs truncate">
             {customerName ? <span className="font-medium text-foreground">{customerName}</span> : null}
             {customerName && projectName ? <span className="opacity-50"> · </span> : null}
             {projectName ? <span>{projectName}</span> : null}
@@ -44,9 +79,7 @@ export function DadosClienteDialog({
         </DialogHeader>
 
         {projectId ? (
-          // O componente já tem padding interno; removemos o padding do
-          // DialogContent (p-0) para evitar dupla margem.
-          <DadosCliente projectId={projectId} />
+          <DadosCliente projectId={projectId} embedded />
         ) : (
           <p className="p-6 text-sm text-muted-foreground">Selecione uma obra.</p>
         )}

--- a/src/components/mobile/MobileFiltersSheet.tsx
+++ b/src/components/mobile/MobileFiltersSheet.tsx
@@ -1,0 +1,99 @@
+import { ReactNode } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetClose } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { RotateCcw } from "lucide-react";
+
+interface MobileFiltersSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Conteúdo do painel — grupos de filtros, escolhas etc. */
+  children: ReactNode;
+  /** Quantidade de filtros ativos (mostra badge no título). */
+  activeCount?: number;
+  /** Callback para limpar todos os filtros. */
+  onClear?: () => void;
+  /** Label do botão "aplicar". Default: "Ver resultados". */
+  applyLabel?: string;
+  /** Disabilita o botão de aplicar (ex.: enquanto carrega). */
+  applyDisabled?: boolean;
+  /** Classe extra para o body da sheet. */
+  bodyClassName?: string;
+}
+
+/**
+ * MobileFiltersSheet — bottom sheet com filtros para listagens mobile.
+ *
+ * Reaproveita `Sheet` (Radix Dialog) com `side="bottom"` e cabeçalho/
+ * rodapé sticky. Concentra todos os filtros em um único ponto, evitando
+ * que chips e selects ocupem o topo da listagem em telas pequenas.
+ */
+export function MobileFiltersSheet({
+  open,
+  onOpenChange,
+  children,
+  activeCount = 0,
+  onClear,
+  applyLabel = "Ver resultados",
+  applyDisabled,
+  bodyClassName,
+}: MobileFiltersSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className={cn(
+          "rounded-t-3xl pt-7 px-0 pb-0 max-h-[88dvh]",
+          "flex flex-col gap-0",
+        )}
+      >
+        <SheetHeader className="px-5 pb-3 border-b border-border-subtle text-left shrink-0">
+          <div className="flex items-center justify-between gap-3">
+            <SheetTitle className="text-base font-bold text-foreground">
+              Filtros{activeCount > 0 ? ` (${activeCount})` : ""}
+            </SheetTitle>
+            {onClear && activeCount > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onClear}
+                className="h-8 gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Limpar
+              </Button>
+            )}
+          </div>
+        </SheetHeader>
+
+        <div
+          className={cn(
+            "flex-1 min-h-0 overflow-y-auto px-5 py-4 space-y-5",
+            bodyClassName,
+          )}
+        >
+          {children}
+        </div>
+
+        <div
+          className={cn(
+            "shrink-0 border-t border-border-subtle pb-safe",
+            "px-4 py-3",
+          )}
+        >
+          <SheetClose asChild>
+            <Button
+              type="button"
+              size="lg"
+              disabled={applyDisabled}
+              className="w-full h-12 text-sm font-semibold"
+            >
+              {applyLabel}
+            </Button>
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/mobile/MobileFullscreenSheet.tsx
+++ b/src/components/mobile/MobileFullscreenSheet.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X, ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MobileFullscreenSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  /** Sticky footer (ex.: ações primárias). Sobre safe-area inferior. */
+  footer?: React.ReactNode;
+  /** Variante do botão de fechar — `back` (←) sugere "voltar para a lista". */
+  closeVariant?: "back" | "x";
+  /** Aria-label do botão de fechar. */
+  closeAriaLabel?: string;
+  /** Classe extra para o body. */
+  bodyClassName?: string;
+}
+
+/**
+ * MobileFullscreenSheet — modal full-screen mobile-first.
+ *
+ * Substitui o Dialog desktop centralizado para formulários densos no
+ * mobile. Usa o Dialog primitive do Radix (focus trap, Esc para fechar,
+ * retorno de foco ao disparador) com layout 100dvh + header/footer
+ * sticky e safe areas.
+ *
+ * - Header respeita pt-safe; título e descrição ficam em coluna, com
+ *   `truncate`/`line-clamp` para nunca cortar elementos críticos.
+ * - Body rola; rodapé sticky com `pb-safe` para iOS home indicator.
+ * - Botão "voltar" (default) ou "fechar" — voltar é a metáfora correta
+ *   para uma página dedicada vinda de uma listagem.
+ */
+export function MobileFullscreenSheet({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  closeVariant = "back",
+  closeAriaLabel = "Fechar",
+  bodyClassName,
+}: MobileFullscreenSheetProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-modal bg-black/40",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed inset-0 z-modal-content flex flex-col bg-background",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "duration-200",
+          )}
+        >
+          <header
+            className={cn(
+              "shrink-0 sticky top-0 z-shell bg-background/95 backdrop-blur",
+              "border-b border-border-subtle pt-safe",
+            )}
+          >
+            <div className="flex items-center gap-2 px-3 py-2 min-h-[56px] pl-safe pr-safe">
+              <DialogPrimitive.Close
+                aria-label={closeAriaLabel}
+                className={cn(
+                  "shrink-0 inline-flex items-center justify-center h-11 w-11 rounded-full",
+                  "text-foreground hover:bg-muted active:bg-muted/80",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                )}
+              >
+                {closeVariant === "back" ? (
+                  <ArrowLeft className="h-5 w-5" />
+                ) : (
+                  <X className="h-5 w-5" />
+                )}
+              </DialogPrimitive.Close>
+
+              <div className="min-w-0 flex-1">
+                <DialogPrimitive.Title className="text-[15px] font-semibold text-foreground leading-tight truncate">
+                  {title}
+                </DialogPrimitive.Title>
+                {description && (
+                  <DialogPrimitive.Description className="text-[12px] text-muted-foreground leading-tight line-clamp-1">
+                    {description}
+                  </DialogPrimitive.Description>
+                )}
+              </div>
+            </div>
+          </header>
+
+          <div
+            className={cn(
+              "flex-1 min-h-0 overflow-y-auto overflow-x-hidden",
+              "pl-safe pr-safe",
+              bodyClassName,
+            )}
+          >
+            {children}
+          </div>
+
+          {footer && (
+            <div
+              className={cn(
+                "shrink-0 sticky bottom-0 z-shell",
+                "border-t border-border-subtle bg-background/95 backdrop-blur",
+                "pb-safe pl-safe pr-safe",
+              )}
+            >
+              <div className="px-4 py-3">{footer}</div>
+            </div>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/mobile/MobileRecordCard.tsx
+++ b/src/components/mobile/MobileRecordCard.tsx
@@ -1,0 +1,183 @@
+import { cn } from "@/lib/utils";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export interface MobileRecordCardChip {
+  label: string;
+  /** Tone — drives bg/text color via tokens. */
+  tone?: "neutral" | "info" | "success" | "warning" | "destructive" | "muted";
+  /** Optional dot/icon shown to the left of the label. */
+  leading?: React.ReactNode;
+  title?: string;
+}
+
+interface MobileRecordCardProps {
+  /** Primary line (cliente / nome do registro). */
+  title: string;
+  /** Secondary line (obra / unidade / metadado principal). */
+  subtitle?: string | null;
+  /** Optional eyebrow (responsável, identificador, etc.). */
+  eyebrow?: React.ReactNode;
+  /** Status / etapa / relacionamento como chips compactos. */
+  chips?: MobileRecordCardChip[];
+  /** Linha extra opcional (datas, progresso). */
+  meta?: React.ReactNode;
+  /** Conteúdo do menu de overflow (3 pontinhos). Use DropdownMenuItem. */
+  overflowMenu?: React.ReactNode;
+  /** Click principal: abre o detalhe do registro. */
+  onClick?: () => void;
+  /** Aria-label customizado (default: title + subtitle). */
+  ariaLabel?: string;
+  className?: string;
+  /** Mostra chevron à direita (default true quando há onClick). */
+  showChevron?: boolean;
+  /** Faixa de tonalidade na borda esquerda (urgência/erro). */
+  tone?: "default" | "warning" | "destructive" | "success";
+}
+
+const chipToneClass: Record<NonNullable<MobileRecordCardChip["tone"]>, string> = {
+  neutral:
+    "bg-muted/60 text-foreground/80 border border-border-subtle",
+  info: "bg-info/10 text-info border border-info/25",
+  success: "bg-success/10 text-success border border-success/25",
+  warning: "bg-warning/10 text-warning border border-warning/30",
+  destructive: "bg-destructive/10 text-destructive border border-destructive/25",
+  muted:
+    "bg-muted/40 text-muted-foreground border border-dashed border-border",
+};
+
+const toneAccent: Record<NonNullable<MobileRecordCardProps["tone"]>, string> = {
+  default: "",
+  warning: "border-l-2 border-l-warning",
+  destructive: "border-l-2 border-l-destructive",
+  success: "border-l-2 border-l-success",
+};
+
+/**
+ * MobileRecordCard — registro empilhado para listagens mobile-first.
+ *
+ * - Click principal abre o detalhe (onClick); ações secundárias ficam no
+ *   menu de overflow (3 pontinhos), nunca competindo com o clique do card.
+ * - Chips com tom semântico (status/etapa/relacionamento) sem sobrepor
+ *   título/subtítulo (sempre em uma linha dedicada abaixo, com flex-wrap).
+ * - Min height 72px para conforto de toque; chevron sinaliza navegação.
+ * - Truncamento por linha (não palavra-por-palavra): título e subtítulo
+ *   ganham `truncate`, chips usam `whitespace-nowrap` mas envolvem ao
+ *   fim da linha.
+ */
+export function MobileRecordCard({
+  title,
+  subtitle,
+  eyebrow,
+  chips,
+  meta,
+  overflowMenu,
+  onClick,
+  ariaLabel,
+  className,
+  showChevron,
+  tone = "default",
+}: MobileRecordCardProps) {
+  const isInteractive = !!onClick;
+  const chevron = showChevron ?? isInteractive;
+
+  return (
+    <div
+      className={cn(
+        "relative bg-card border-b border-border-subtle last:border-b-0",
+        tone !== "default" && toneAccent[tone],
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={!isInteractive}
+        aria-label={ariaLabel ?? `${title}${subtitle ? ` — ${subtitle}` : ""}`}
+        className={cn(
+          "flex items-start gap-3 w-full text-left px-4 py-3 min-h-[72px]",
+          // Reservar espaço à direita para o menu de overflow (44px) e/ou
+          // chevron — evita sobreposição entre o conteúdo e o botão de ações.
+          overflowMenu ? "pr-12" : chevron ? "pr-9" : "pr-4",
+          "transition-colors",
+          isInteractive && "hover:bg-muted/50 active:bg-muted cursor-pointer",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+        )}
+      >
+        <div className="flex-1 min-w-0 space-y-1">
+          {eyebrow && (
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground truncate">
+              {eyebrow}
+            </div>
+          )}
+
+          <div className="text-[15px] font-semibold text-foreground leading-snug truncate">
+            {title}
+          </div>
+
+          {subtitle && (
+            <div className="text-[13px] text-muted-foreground leading-snug truncate">
+              {subtitle}
+            </div>
+          )}
+
+          {chips && chips.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+              {chips.map((c, i) => (
+                <span
+                  key={i}
+                  title={c.title}
+                  className={cn(
+                    "inline-flex items-center gap-1 max-w-full rounded-md px-1.5 py-0.5 text-[11px] font-medium leading-none",
+                    "whitespace-nowrap",
+                    chipToneClass[c.tone ?? "neutral"],
+                  )}
+                >
+                  {c.leading}
+                  <span className="truncate">{c.label}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {meta && (
+            <div className="text-[12px] text-muted-foreground pt-0.5">
+              {meta}
+            </div>
+          )}
+        </div>
+
+        {chevron && !overflowMenu && (
+          <ChevronRight
+            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+
+      {overflowMenu && (
+        <div className="absolute right-1 top-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              aria-label="Mais ações"
+              className={cn(
+                "inline-flex items-center justify-center h-11 w-11 rounded-md text-muted-foreground",
+                "hover:bg-muted/70 hover:text-foreground",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+            >
+              <MoreHorizontal className="h-5 w-5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {overflowMenu}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/mobile/ResponsiveTabs.tsx
+++ b/src/components/mobile/ResponsiveTabs.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
+
+/**
+ * ResponsiveTabs — wrapper sobre Radix Tabs com lista rolável
+ * horizontalmente (sem barra visível) no mobile, evitando que abas com
+ * label longo estourem ou quebrem em duas linhas.
+ *
+ * - Toque confortável: cada trigger tem min-height 44px.
+ * - No desktop, comporta-se como uma TabsList tradicional.
+ * - Indicador é um underline sob a aba ativa (mobile-first), e cresce
+ *   para um pill de contraste no desktop. Mantém compatibilidade visual
+ *   com a TabsList do design system existente.
+ */
+
+export const Tabs = TabsPrimitive.Root;
+
+interface ResponsiveTabsListProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> {
+  ariaLabel?: string;
+}
+
+export const ResponsiveTabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  ResponsiveTabsListProps
+>(({ className, ariaLabel, ...props }, ref) => (
+  <div
+    role="presentation"
+    className={cn(
+      "relative w-full overflow-x-auto scrollbar-hide",
+      "border-b border-border-subtle",
+    )}
+  >
+    <TabsPrimitive.List
+      ref={ref}
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex min-w-full items-stretch gap-1 px-1",
+        // No desktop, recolhe em pill como o componente original.
+        "md:rounded-md md:bg-muted md:p-1 md:border-0 md:gap-0",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+ResponsiveTabsList.displayName = "ResponsiveTabsList";
+
+export const ResponsiveTabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "relative inline-flex items-center justify-center gap-1.5 whitespace-nowrap",
+      "px-3 py-2 min-h-[44px] text-[13px] font-medium",
+      "text-muted-foreground transition-colors",
+      "hover:text-foreground",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+      "disabled:pointer-events-none disabled:opacity-50",
+      // Mobile: underline ativo
+      "data-[state=active]:text-foreground",
+      "after:absolute after:left-2 after:right-2 after:bottom-0 after:h-[2px] after:rounded-full",
+      "after:bg-transparent data-[state=active]:after:bg-primary",
+      // Desktop: pill ativo (visual original)
+      "md:rounded-sm md:px-3 md:py-1.5 md:min-h-0 md:after:hidden md:text-sm",
+      "md:data-[state=active]:bg-background md:data-[state=active]:text-foreground md:data-[state=active]:shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+ResponsiveTabsTrigger.displayName = "ResponsiveTabsTrigger";
+
+export const TabsContent = TabsPrimitive.Content;

--- a/src/components/mobile/StickyActionBar.tsx
+++ b/src/components/mobile/StickyActionBar.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+
+interface StickyActionBarProps {
+  children: React.ReactNode;
+  className?: string;
+  /**
+   * Quando true, posiciona o bar acima da bottom navigation
+   * (`bottom-cta`) — útil em páginas dentro de Shells com nav fixa.
+   * Default: false (use dentro de full-screen sheets sem nav).
+   */
+  aboveBottomNav?: boolean;
+}
+
+/**
+ * StickyActionBar — barra inferior fixa para ações primárias em mobile.
+ *
+ * Respeita `pb-safe`, fica acima do conteúdo (z-shell) e, opcionalmente,
+ * acima da bottom navigation. Usar quando uma página/sheet precisa
+ * preservar uma ação como "Salvar" sempre acessível, sem depender de
+ * scroll até o footer ou modal centralizado no desktop.
+ */
+export function StickyActionBar({
+  children,
+  className,
+  aboveBottomNav = false,
+}: StickyActionBarProps) {
+  return (
+    <div
+      className={cn(
+        "sticky z-shell border-t border-border-subtle bg-background/95 backdrop-blur",
+        "pl-safe pr-safe pb-safe",
+        aboveBottomNav ? "bottom-cta" : "bottom-0",
+        className,
+      )}
+    >
+      <div className="px-4 py-3 flex items-center gap-2">{children}</div>
+    </div>
+  );
+}

--- a/src/components/mobile/index.ts
+++ b/src/components/mobile/index.ts
@@ -3,3 +3,14 @@ export { MobileSectionCard } from './MobileSectionCard';
 export { MobileListItem } from './MobileListItem';
 export { BottomSheetPicker } from './BottomSheetPicker';
 export { MobileBottomNav } from './MobileBottomNav';
+export { MobileRecordCard } from './MobileRecordCard';
+export type { MobileRecordCardChip } from './MobileRecordCard';
+export { MobileFullscreenSheet } from './MobileFullscreenSheet';
+export { MobileFiltersSheet } from './MobileFiltersSheet';
+export { StickyActionBar } from './StickyActionBar';
+export {
+  Tabs as ResponsiveTabsRoot,
+  ResponsiveTabsList,
+  ResponsiveTabsTrigger,
+  TabsContent as ResponsiveTabsContent,
+} from './ResponsiveTabs';

--- a/src/components/report/RichTextEditorModal.tsx
+++ b/src/components/report/RichTextEditorModal.tsx
@@ -35,8 +35,11 @@ import {
   Type,
   Strikethrough,
   Save,
+  MoreHorizontal,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { MobileFullscreenSheet } from "@/components/mobile";
 
 interface RichTextEditorModalProps {
   open: boolean;
@@ -108,6 +111,7 @@ export function RichTextEditorModal({
 }: RichTextEditorModalProps) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [fontSize, setFontSize] = useState("3");
+  const isMobile = useIsMobile();
 
   // Initialize editor content when modal opens
   // Use requestAnimationFrame to wait for the Radix portal to mount the DOM
@@ -162,6 +166,312 @@ export function RichTextEditorModal({
     onOpenChange(false);
   };
 
+  // ── Toolbar — duas variantes responsivas ──────────────────────────
+  // Desktop: linha única com todos os grupos visíveis.
+  // Mobile : ações essenciais (B / I / U / lista) inline; o restante
+  //          (cor, destaque, alinhamento, tamanho, riscado, undo/redo)
+  //          fica num popover "Mais" para evitar wrap de toolbar e
+  //          preservar área de edição confortável.
+  const DesktopToolbar = (
+    <div className="px-3 py-2 border-b border-border bg-muted/30 flex flex-wrap items-center gap-0.5">
+      {/* Undo / Redo */}
+      <ToolbarButton onClick={() => exec("undo")} title="Desfazer">
+        <Undo2 className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("redo")} title="Refazer">
+        <Redo2 className="w-4 h-4" />
+      </ToolbarButton>
+
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* Font Size */}
+      <Select value={fontSize} onValueChange={handleFontSize}>
+        <SelectTrigger className="w-[120px] h-8 text-xs border-border">
+          <Type className="w-3.5 h-3.5 mr-1.5 shrink-0" />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {FONT_SIZES.map((s) => (
+            <SelectItem key={s.value} value={s.value}>
+              {s.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* Format */}
+      <ToolbarButton onClick={() => exec("bold")} title="Negrito">
+        <Bold className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("italic")} title="Itálico">
+        <Italic className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("underline")} title="Sublinhado">
+        <Underline className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("strikeThrough")} title="Riscado">
+        <Strikethrough className="w-4 h-4" />
+      </ToolbarButton>
+
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* Text Color */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            title="Cor do texto"
+            className="p-1.5 rounded-md transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <Paintbrush className="w-4 h-4" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-3" align="start">
+          <p className="text-xs font-medium text-muted-foreground mb-2">Cor do texto</p>
+          <div className="grid grid-cols-6 gap-1.5">
+            {TEXT_COLORS.map((color) => (
+              <button
+                key={color}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleTextColor(color);
+                }}
+                className="w-6 h-6 rounded-md border border-border hover:scale-110 transition-transform"
+                style={{ backgroundColor: color }}
+                aria-label={`Cor ${color}`}
+              />
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Highlight */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            title="Destaque"
+            className="p-1.5 rounded-md transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <Highlighter className="w-4 h-4" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-3" align="start">
+          <p className="text-xs font-medium text-muted-foreground mb-2">Cor de destaque</p>
+          <div className="grid grid-cols-5 gap-1.5">
+            {HIGHLIGHT_COLORS.map((color) => (
+              <button
+                key={color}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleHighlight(color);
+                }}
+                className={cn(
+                  "w-6 h-6 rounded-md border border-border hover:scale-110 transition-transform",
+                  color === "transparent" && "bg-[repeating-conic-gradient(#ccc_0%_25%,transparent_0%_50%)] bg-[length:8px_8px]"
+                )}
+                style={color !== "transparent" ? { backgroundColor: color } : undefined}
+                aria-label={color === "transparent" ? "Remover destaque" : `Destacar com ${color}`}
+              />
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* Lists */}
+      <ToolbarButton onClick={() => exec("insertUnorderedList")} title="Lista com marcadores">
+        <List className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("insertOrderedList")} title="Lista numerada">
+        <ListOrdered className="w-4 h-4" />
+      </ToolbarButton>
+
+      <div className="w-px h-5 bg-border mx-1" />
+
+      {/* Alignment */}
+      <ToolbarButton onClick={() => exec("justifyLeft")} title="Alinhar à esquerda">
+        <AlignLeft className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("justifyCenter")} title="Centralizar">
+        <AlignCenter className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("justifyRight")} title="Alinhar à direita">
+        <AlignRight className="w-4 h-4" />
+      </ToolbarButton>
+    </div>
+  );
+
+  const MobileToolbar = (
+    <div
+      className="px-2 py-1.5 border-b border-border bg-muted/30 flex items-center gap-0.5 overflow-x-auto scrollbar-hide"
+      role="toolbar"
+      aria-label="Formatação de texto"
+    >
+      <ToolbarButton onClick={() => exec("bold")} title="Negrito">
+        <Bold className="w-5 h-5" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("italic")} title="Itálico">
+        <Italic className="w-5 h-5" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("underline")} title="Sublinhado">
+        <Underline className="w-5 h-5" />
+      </ToolbarButton>
+      <div className="w-px h-5 bg-border mx-1 shrink-0" aria-hidden />
+      <ToolbarButton onClick={() => exec("insertUnorderedList")} title="Lista">
+        <List className="w-5 h-5" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("insertOrderedList")} title="Lista numerada">
+        <ListOrdered className="w-5 h-5" />
+      </ToolbarButton>
+      <div className="w-px h-5 bg-border mx-1 shrink-0" aria-hidden />
+      <ToolbarButton onClick={() => exec("undo")} title="Desfazer">
+        <Undo2 className="w-5 h-5" />
+      </ToolbarButton>
+      <ToolbarButton onClick={() => exec("redo")} title="Refazer">
+        <Redo2 className="w-5 h-5" />
+      </ToolbarButton>
+
+      {/* Mais — concentra ações secundárias e evita overflow horizontal. */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            title="Mais opções de formatação"
+            aria-label="Mais opções de formatação"
+            className="ml-auto shrink-0 p-1.5 rounded-md min-h-[40px] min-w-[40px] flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <MoreHorizontal className="w-5 h-5" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-[280px] p-3 space-y-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Tamanho</p>
+            <Select value={fontSize} onValueChange={handleFontSize}>
+              <SelectTrigger className="h-10 text-sm">
+                <Type className="w-4 h-4 mr-2 shrink-0" />
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {FONT_SIZES.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Estilo</p>
+            <div className="flex items-center gap-1">
+              <ToolbarButton onClick={() => exec("strikeThrough")} title="Riscado">
+                <Strikethrough className="w-5 h-5" />
+              </ToolbarButton>
+              <ToolbarButton onClick={() => exec("justifyLeft")} title="Alinhar à esquerda">
+                <AlignLeft className="w-5 h-5" />
+              </ToolbarButton>
+              <ToolbarButton onClick={() => exec("justifyCenter")} title="Centralizar">
+                <AlignCenter className="w-5 h-5" />
+              </ToolbarButton>
+              <ToolbarButton onClick={() => exec("justifyRight")} title="Alinhar à direita">
+                <AlignRight className="w-5 h-5" />
+              </ToolbarButton>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Cor do texto</p>
+            <div className="grid grid-cols-6 gap-2">
+              {TEXT_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); handleTextColor(color); }}
+                  className="w-7 h-7 rounded-md border border-border"
+                  style={{ backgroundColor: color }}
+                  aria-label={`Cor ${color}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Destaque</p>
+            <div className="grid grid-cols-5 gap-2">
+              {HIGHLIGHT_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); handleHighlight(color); }}
+                  className={cn(
+                    "w-7 h-7 rounded-md border border-border",
+                    color === "transparent" && "bg-[repeating-conic-gradient(#ccc_0%_25%,transparent_0%_50%)] bg-[length:8px_8px]"
+                  )}
+                  style={color !== "transparent" ? { backgroundColor: color } : undefined}
+                  aria-label={color === "transparent" ? "Remover destaque" : `Destacar com ${color}`}
+                />
+              ))}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+
+  const EditorArea = (
+    <div
+      ref={editorRef}
+      contentEditable
+      suppressContentEditableWarning
+      role="textbox"
+      aria-multiline="true"
+      aria-label={title}
+      className={cn(
+        "min-h-[280px] outline-none",
+        "prose prose-sm max-w-none",
+        "text-foreground leading-[1.7]",
+        "[&_p]:mb-3 [&_ul]:pl-5 [&_ol]:pl-5 [&_li]:mb-1",
+        "[&_p]:text-sm [&_li]:text-sm",
+        "focus:outline-none"
+      )}
+    />
+  );
+
+  // ── Mobile: full-screen sheet com header sticky (Salvar inline) e
+  //    toolbar compacta. Sem modal centralizado, sem footer redundante.
+  if (isMobile) {
+    return (
+      <MobileFullscreenSheet
+        open={open}
+        onOpenChange={onOpenChange}
+        title={title}
+        closeAriaLabel="Cancelar e voltar"
+        bodyClassName="flex flex-col"
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} className="h-11">
+              Cancelar
+            </Button>
+            <Button onClick={handleSave} className="h-11 min-w-[120px]">
+              <Save className="w-4 h-4 mr-2" />
+              Aplicar
+            </Button>
+          </div>
+        }
+      >
+        {MobileToolbar}
+        <div className="flex-1 min-h-0 overflow-auto px-4 py-3">
+          {EditorArea}
+        </div>
+      </MobileFullscreenSheet>
+    );
+  }
+
+  // ── Desktop: dialog centralizado (preserva o comportamento original).
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col p-0 gap-0">
@@ -169,156 +479,11 @@ export function RichTextEditorModal({
           <DialogTitle className="text-base font-semibold">{title}</DialogTitle>
         </DialogHeader>
 
-        {/* Toolbar */}
-        <div className="px-3 py-2 border-b border-border bg-muted/30 flex flex-wrap items-center gap-0.5">
-          {/* Undo / Redo */}
-          <ToolbarButton onClick={() => exec("undo")} title="Desfazer">
-            <Undo2 className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("redo")} title="Refazer">
-            <Redo2 className="w-4 h-4" />
-          </ToolbarButton>
-
-          <div className="w-px h-5 bg-border mx-1" />
-
-          {/* Font Size */}
-          <Select value={fontSize} onValueChange={handleFontSize}>
-            <SelectTrigger className="w-[120px] h-8 text-xs border-border">
-              <Type className="w-3.5 h-3.5 mr-1.5 shrink-0" />
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {FONT_SIZES.map((s) => (
-                <SelectItem key={s.value} value={s.value}>
-                  {s.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <div className="w-px h-5 bg-border mx-1" />
-
-          {/* Format */}
-          <ToolbarButton onClick={() => exec("bold")} title="Negrito">
-            <Bold className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("italic")} title="Itálico">
-            <Italic className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("underline")} title="Sublinhado">
-            <Underline className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("strikeThrough")} title="Riscado">
-            <Strikethrough className="w-4 h-4" />
-          </ToolbarButton>
-
-          <div className="w-px h-5 bg-border mx-1" />
-
-          {/* Text Color */}
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                title="Cor do texto"
-                className="p-1.5 rounded-md transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <Paintbrush className="w-4 h-4" />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-3" align="start">
-              <p className="text-xs font-medium text-muted-foreground mb-2">Cor do texto</p>
-              <div className="grid grid-cols-6 gap-1.5">
-                {TEXT_COLORS.map((color) => (
-                  <button
-                    key={color}
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      handleTextColor(color);
-                    }}
-                    className="w-6 h-6 rounded-md border border-border hover:scale-110 transition-transform"
-                    style={{ backgroundColor: color }}
-                  />
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
-
-          {/* Highlight */}
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                title="Destaque"
-                className="p-1.5 rounded-md transition-colors min-h-[32px] min-w-[32px] flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <Highlighter className="w-4 h-4" />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-3" align="start">
-              <p className="text-xs font-medium text-muted-foreground mb-2">Cor de destaque</p>
-              <div className="grid grid-cols-5 gap-1.5">
-                {HIGHLIGHT_COLORS.map((color) => (
-                  <button
-                    key={color}
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      handleHighlight(color);
-                    }}
-                    className={cn(
-                      "w-6 h-6 rounded-md border border-border hover:scale-110 transition-transform",
-                      color === "transparent" && "bg-[repeating-conic-gradient(#ccc_0%_25%,transparent_0%_50%)] bg-[length:8px_8px]"
-                    )}
-                    style={color !== "transparent" ? { backgroundColor: color } : undefined}
-                  />
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
-
-          <div className="w-px h-5 bg-border mx-1" />
-
-          {/* Lists */}
-          <ToolbarButton onClick={() => exec("insertUnorderedList")} title="Lista com marcadores">
-            <List className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("insertOrderedList")} title="Lista numerada">
-            <ListOrdered className="w-4 h-4" />
-          </ToolbarButton>
-
-          <div className="w-px h-5 bg-border mx-1" />
-
-          {/* Alignment */}
-          <ToolbarButton onClick={() => exec("justifyLeft")} title="Alinhar à esquerda">
-            <AlignLeft className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("justifyCenter")} title="Centralizar">
-            <AlignCenter className="w-4 h-4" />
-          </ToolbarButton>
-          <ToolbarButton onClick={() => exec("justifyRight")} title="Alinhar à direita">
-            <AlignRight className="w-4 h-4" />
-          </ToolbarButton>
-        </div>
+        {DesktopToolbar}
 
         {/* Editor area */}
         <div className="flex-1 overflow-auto px-5 py-4 min-h-[300px] max-h-[55vh]">
-          <div
-            ref={editorRef}
-            contentEditable
-            suppressContentEditableWarning
-            className={cn(
-              "min-h-[280px] outline-none",
-              "prose prose-sm max-w-none",
-              "text-foreground leading-[1.7]",
-              "[&_p]:mb-3 [&_ul]:pl-5 [&_ol]:pl-5 [&_li]:mb-1",
-              "[&_p]:text-sm [&_li]:text-sm",
-              "focus:outline-none"
-            )}
-            onKeyDown={(e) => {
-              // Ctrl+B/I/U shortcuts are handled natively by contentEditable
-            }}
-          />
+          {EditorArea}
         </div>
 
         {/* Footer */}

--- a/src/pages/DadosCliente.tsx
+++ b/src/pages/DadosCliente.tsx
@@ -7,12 +7,16 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Save, User, Building2, Loader2, Search, FileText } from 'lucide-react';
 import { ProjectInfoDoc } from '@/components/project/ProjectInfoDoc';
 import { useCepLookup, formatCep } from '@/hooks/useCepLookup';
 import { formatCpf, formatRg, isValidCpf, isValidRg } from '@/lib/documentValidation';
+import {
+  ResponsiveTabsRoot,
+  ResponsiveTabsList,
+  ResponsiveTabsTrigger,
+} from '@/components/mobile';
+import { cn } from '@/lib/utils';
 
 interface CustomerData {
   id: string;
@@ -54,9 +58,19 @@ interface DadosClienteProps {
    * o componente ignora o roteador e funciona como widget embutido.
    */
   projectId?: string;
+  /**
+   * Quando true, o componente é tratado como widget embutido em
+   * Dialog/Sheet: o cabeçalho duplicado ("Dados do Cliente" + ação Salvar
+   * inline) é omitido e a ação Salvar fica em uma barra sticky no rodapé,
+   * compatível com a viewport mobile e safe areas.
+   *
+   * Use sempre que renderizar dentro de `DadosClienteDialog` ou
+   * `MobileFullscreenSheet` — o invólucro já provê título/descrição.
+   */
+  embedded?: boolean;
 }
 
-export default function DadosCliente({ projectId: propProjectId }: DadosClienteProps = {}) {
+export default function DadosCliente({ projectId: propProjectId, embedded = false }: DadosClienteProps = {}) {
   const params = useParams<{ projectId: string }>();
   const projectId = propProjectId ?? params.projectId;
   const [loading, setLoading] = useState(true);
@@ -230,36 +244,52 @@ export default function DadosCliente({ projectId: propProjectId }: DadosClienteP
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-4 md:p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Dados do Cliente</h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            Informações cadastrais do contratante e do imóvel
-          </p>
+    <div
+      className={cn(
+        'mx-auto w-full',
+        // Quando embutido (dialog/sheet) o invólucro já tem padding e
+        // largura; aqui só damos um respiro lateral consistente. Quando
+        // usado como página standalone, mantemos o layout original.
+        embedded ? 'max-w-3xl px-4 pt-3 pb-4 md:px-6 md:pt-4' : 'max-w-4xl p-4 md:p-6',
+        // Reserva espaço inferior para a sticky bar de Salvar não cobrir
+        // o último campo. ~80px = 64px barra + 16px folga (mais safe-area).
+        'pb-[calc(80px+env(safe-area-inset-bottom,0px))]',
+      )}
+    >
+      {/* Header inline — só quando NÃO está embutido (rota /obra/:id/dados-cliente). */}
+      {!embedded && (
+        <div className="flex items-center justify-between mb-5">
+          <div className="min-w-0">
+            <h1 className="text-xl md:text-2xl font-bold text-foreground truncate">Dados do Cliente</h1>
+            <p className="text-muted-foreground text-sm mt-1">
+              Informações cadastrais do contratante e do imóvel
+            </p>
+          </div>
         </div>
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
-          Salvar
-        </Button>
-      </div>
+      )}
 
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'contratante' | 'imovel' | 'info')}>
-        <TabsList className="w-full sm:w-auto">
-          <TabsTrigger value="contratante" className="gap-1.5">
+      <ResponsiveTabsRoot
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as 'contratante' | 'imovel' | 'info')}
+        className="w-full"
+      >
+        <ResponsiveTabsList ariaLabel="Seções dos dados do cliente" className="md:w-auto">
+          <ResponsiveTabsTrigger value="contratante">
             <User className="h-4 w-4" />
             Contratante
-          </TabsTrigger>
-          <TabsTrigger value="imovel" className="gap-1.5">
+          </ResponsiveTabsTrigger>
+          <ResponsiveTabsTrigger value="imovel">
             <Building2 className="h-4 w-4" />
             Imóvel
-          </TabsTrigger>
-          <TabsTrigger value="info" className="gap-1.5">
+          </ResponsiveTabsTrigger>
+          <ResponsiveTabsTrigger value="info">
             <FileText className="h-4 w-4" />
             Informações do Projeto
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
+          </ResponsiveTabsTrigger>
+        </ResponsiveTabsList>
+      </ResponsiveTabsRoot>
+
+      <div className="mt-4 space-y-6">
 
       {/* ── Cliente (Contratante) ── */}
       {activeTab === 'contratante' && (
@@ -518,6 +548,37 @@ export default function DadosCliente({ projectId: propProjectId }: DadosClienteP
       {activeTab === 'info' && projectId && (
         <ProjectInfoDoc projectId={projectId} />
       )}
+      </div>
+
+      {/* ── Sticky save bar ──────────────────────────────────────────────
+          Mantém "Salvar" sempre acessível mesmo em formulários longos no
+          mobile. Em DadosClienteDialog (mobile full-screen), esta barra
+          fica colada acima da safe-area inferior; no desktop standalone,
+          fica colada ao rodapé do scroller dentro do container. */}
+      <div
+        className={cn(
+          'sticky bottom-0 -mx-4 md:-mx-6 mt-6',
+          'bg-background/95 backdrop-blur border-t border-border-subtle',
+          'pl-safe pr-safe pb-safe',
+        )}
+      >
+        <div className="px-4 md:px-6 py-3 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            size="lg"
+            className="min-w-[140px] h-11"
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-2" />
+            )}
+            Salvar
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/PainelObras.tsx
+++ b/src/pages/PainelObras.tsx
@@ -101,6 +101,11 @@ import { EmptyState } from '@/components/ui/states';
 import { useStaffUsers } from '@/hooks/useStaffUsers';
 import { DailyLogInline } from '@/components/admin/obras/DailyLogInline';
 import { DadosClienteDialog } from '@/components/admin/obras/DadosClienteDialog';
+import {
+  MobileRecordCard,
+  MobileFiltersSheet,
+  type MobileRecordCardChip,
+} from '@/components/mobile';
 
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
@@ -316,6 +321,7 @@ export default function PainelObras() {
   const queryClient = useQueryClient();
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   // Modo de visualização da aba "Obras": tabela densa (default) ou kanban.
   // Persistido em URL para que o usuário compartilhe / volte na mesma visão.
@@ -584,7 +590,11 @@ export default function PainelObras() {
           title="Painel de Obras"
           description="Cockpit operacional unificado — monitore status, prazos e relacionamento de todas as obras em execução."
           actions={
-            <>
+            // Mobile: ações concorrentes (Customer Success + Nova obra) ficam
+            // ocultas porque (a) "Nova obra" já está como FAB central no
+            // GestaoBottomNav e (b) atalhos secundários ficam no menu "Mais".
+            // Isso preserva uma única ação primária dominante por viewport.
+            <div className="hidden md:flex items-center gap-2">
               <Button variant="outline" size="sm" onClick={() => navigate('/gestao/cs/operacional')} className="h-8 gap-2">
                 <Headset className="h-4 w-4" />
                 <span className="hidden sm:inline">Customer Success</span>
@@ -593,7 +603,7 @@ export default function PainelObras() {
               <Button size="sm" onClick={() => navigate('/gestao/nova-obra')} className="h-8 gap-2">
                 <Plus className="h-4 w-4" />Nova obra
               </Button>
-            </>
+            </div>
           }
           flush
           className="!pt-4 !pb-3 md:!pt-5 md:!pb-3 [&_h1]:!text-lg [&_h1]:md:!text-xl"
@@ -646,6 +656,46 @@ export default function PainelObras() {
         />
 
         <div className="mt-3">
+          {/* ── Mobile: cards empilhados + filtros em bottom sheet ───────────
+              Substitui a tabela densa por uma listagem 1-coluna que cabe em
+              320–430px sem scroll horizontal. Ações secundárias (Customer
+              Success, criar obra) já estão na bottom navigation; aqui o foco
+              é busca, filtros e o conteúdo. Veja `<MobilePainelView />`. */}
+          <MobilePainelView
+            obras={obras}
+            filtered={filtered}
+            isLoading={isLoading}
+            search={search}
+            onSearchChange={setSearch}
+            hasFilters={hasFilters}
+            activeFilterCount={
+              (search.trim() ? 1 : 0) +
+              (filterEtapa !== ALL ? 1 : 0) +
+              filterStatuses.size +
+              (filterRelacionamento !== ALL ? 1 : 0) +
+              (filterResponsavel !== ALL ? 1 : 0)
+            }
+            staffUsers={staffUsers}
+            filterEtapa={filterEtapa}
+            onFilterEtapa={setFilterEtapa}
+            filterStatuses={filterStatuses}
+            onToggleStatus={toggleStatusFilter}
+            onClearStatuses={clearStatusFilter}
+            filterRelacionamento={filterRelacionamento}
+            onFilterRelacionamento={setFilterRelacionamento}
+            filterResponsavel={filterResponsavel}
+            onFilterResponsavel={setFilterResponsavel}
+            clearAllFilters={clearFilters}
+            mobileFiltersOpen={mobileFiltersOpen}
+            setMobileFiltersOpen={setMobileFiltersOpen}
+            onOpen={(id) => navigate(`/obra/${id}`)}
+            onOpenDados={(o) => setDadosTarget(o)}
+            onDeleteRequest={(o) => setDeleteTarget(o)}
+            onCreate={() => navigate('/gestao/nova-obra')}
+          />
+
+          {/* ── Desktop: toolbar + tabela/board/kanban (preserva comportamento) ── */}
+          <div className="hidden md:block">
           {/*
             Toolbar redesenhada — referência híbrida (Linear + Notion):
             - linha única densa (h-9), divisores verticais entre grupos
@@ -1103,6 +1153,7 @@ export default function PainelObras() {
                 </SectionCard>
               )}
             </div>
+          </div>
         </div>
       </PageContainer>
     </TooltipProvider>
@@ -2700,6 +2751,435 @@ function BoardView({
           </SectionCard>
         );
       })}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Mobile view (md:hidden) — substitui a tabela densa por uma listagem em
+// cards. Toda a lógica de filtros/edição é compartilhada com o desktop;
+// este componente só assume responsabilidade pela apresentação mobile-first.
+// ──────────────────────────────────────────────────────────────────────────
+
+interface MobilePainelViewProps {
+  obras: PainelObra[];
+  filtered: PainelObra[];
+  isLoading: boolean;
+  search: string;
+  onSearchChange: (v: string) => void;
+  hasFilters: boolean;
+  activeFilterCount: number;
+  staffUsers: { id: string; nome: string }[];
+  filterEtapa: string;
+  onFilterEtapa: (v: string) => void;
+  filterStatuses: Set<string>;
+  onToggleStatus: (v: string) => void;
+  onClearStatuses: () => void;
+  filterRelacionamento: string;
+  onFilterRelacionamento: (v: string) => void;
+  filterResponsavel: string;
+  onFilterResponsavel: (v: string) => void;
+  clearAllFilters: () => void;
+  mobileFiltersOpen: boolean;
+  setMobileFiltersOpen: (open: boolean) => void;
+  onOpen: (id: string) => void;
+  onOpenDados: (o: PainelObra) => void;
+  onDeleteRequest: (o: PainelObra) => void;
+  onCreate: () => void;
+}
+
+function statusChipTone(s: PainelStatus | null): NonNullable<MobileRecordCardChip['tone']> {
+  switch (s) {
+    case 'Em dia':     return 'success';
+    case 'Aguardando': return 'info';
+    case 'Atrasado':   return 'destructive';
+    case 'Paralisada': return 'neutral';
+    default:           return 'muted';
+  }
+}
+
+function relacionamentoChipTone(r: PainelRelacionamento | null): NonNullable<MobileRecordCardChip['tone']> {
+  switch (r) {
+    case 'Normal':       return 'success';
+    case 'Atrito':       return 'warning';
+    case 'Insatisfeito': return 'warning';
+    case 'Crítico':      return 'destructive';
+    default:             return 'muted';
+  }
+}
+
+function MobilePainelView({
+  obras,
+  filtered,
+  isLoading,
+  search,
+  onSearchChange,
+  hasFilters,
+  activeFilterCount,
+  staffUsers,
+  filterEtapa,
+  onFilterEtapa,
+  filterStatuses,
+  onToggleStatus,
+  onClearStatuses,
+  filterRelacionamento,
+  onFilterRelacionamento,
+  filterResponsavel,
+  onFilterResponsavel,
+  clearAllFilters,
+  mobileFiltersOpen,
+  setMobileFiltersOpen,
+  onOpen,
+  onOpenDados,
+  onDeleteRequest,
+  onCreate,
+}: MobilePainelViewProps) {
+  return (
+    <div className="md:hidden">
+      {/* ── Topo compacto: search + Filtros + contador ───────────────────
+          Linha única (52px) com busca dominante e um único botão de
+          filtros. Contador ocupa apenas a linha secundária minimalista
+          quando há filtros — evita poluir o topo. */}
+      <div className="sticky top-0 z-shell bg-background pt-2 pb-2 -mx-4 px-4 border-b border-border-subtle">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1 min-w-0">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <Input
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Buscar obra ou cliente"
+              aria-label="Buscar obras"
+              className="h-11 pl-9 pr-9 text-[14px] bg-surface border-border-subtle"
+              inputMode="search"
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => onSearchChange('')}
+                aria-label="Limpar busca"
+                className="absolute right-1 top-1/2 -translate-y-1/2 h-9 w-9 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setMobileFiltersOpen(true)}
+            className={cn(
+              'shrink-0 h-11 px-3 gap-1.5 text-[13px] font-medium',
+              activeFilterCount > 0 && 'border-primary/40 bg-primary/5 text-foreground',
+            )}
+            aria-label={
+              activeFilterCount > 0
+                ? `Filtros (${activeFilterCount} ativos)`
+                : 'Abrir filtros'
+            }
+            aria-haspopup="dialog"
+          >
+            <Filter className="h-4 w-4" />
+            Filtros
+            {activeFilterCount > 0 && (
+              <span className="inline-flex h-5 min-w-5 px-1 items-center justify-center rounded-full bg-primary text-primary-foreground text-[11px] font-semibold tabular-nums">
+                {activeFilterCount}
+              </span>
+            )}
+          </Button>
+        </div>
+
+        {/* Linha secundária: contador + limpar (só quando há filtros) */}
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-[12px] text-muted-foreground tabular-nums">
+            <span className="font-semibold text-foreground">{filtered.length}</span>
+            <span className="opacity-60"> de {obras.length} obras</span>
+          </span>
+          {hasFilters && (
+            <button
+              type="button"
+              onClick={clearAllFilters}
+              className="inline-flex items-center gap-1 h-7 px-2 text-[12px] text-muted-foreground hover:text-foreground"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Limpar filtros
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Lista de obras ─────────────────────────────────────────────── */}
+      {isLoading ? (
+        <ul className="mt-1 divide-y divide-border-subtle bg-card rounded-lg overflow-hidden border border-border-subtle">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="px-4 py-3 space-y-2">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
+              <div className="flex gap-1.5">
+                <Skeleton className="h-4 w-14 rounded-md" />
+                <Skeleton className="h-4 w-20 rounded-md" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : filtered.length === 0 ? (
+        <div className="mt-3">
+          <EmptyState
+            icon={Table2}
+            title={obras.length === 0 ? 'Nenhuma obra cadastrada' : 'Nenhum resultado'}
+            description={
+              obras.length === 0
+                ? 'Crie sua primeira obra para começar.'
+                : 'Nenhuma obra corresponde aos filtros atuais.'
+            }
+            action={
+              obras.length === 0
+                ? { label: 'Nova obra', onClick: onCreate, icon: Plus }
+                : hasFilters
+                  ? { label: 'Limpar filtros', onClick: clearAllFilters, icon: RotateCcw }
+                  : undefined
+            }
+          />
+        </div>
+      ) : (
+        <ul className="mt-2 bg-card rounded-lg overflow-hidden border border-border-subtle">
+          {filtered.map((o) => {
+            const displayStatus = computeDisplayStatus(o);
+            const dias = computeOverdueDays(o);
+            const chips: MobileRecordCardChip[] = [];
+            if (displayStatus) {
+              chips.push({
+                label: displayStatus,
+                tone: statusChipTone(displayStatus),
+                leading: (
+                  <span
+                    className={cn('h-1.5 w-1.5 rounded-full shrink-0', statusDotClass(displayStatus))}
+                    aria-hidden
+                  />
+                ),
+              });
+            }
+            if (o.etapa) {
+              chips.push({
+                label: o.etapa,
+                tone:
+                  o.etapa === 'Finalizada'
+                    ? 'success'
+                    : o.etapa === 'Vistoria reprovada'
+                      ? 'destructive'
+                      : 'neutral',
+              });
+            }
+            if (o.relacionamento && o.relacionamento !== 'Normal') {
+              chips.push({
+                label: o.relacionamento,
+                tone: relacionamentoChipTone(o.relacionamento),
+              });
+            }
+
+            const tone: 'default' | 'destructive' | 'warning' =
+              displayStatus === 'Atrasado' || dias > 10
+                ? 'destructive'
+                : dias > 0
+                  ? 'warning'
+                  : 'default';
+
+            const responsavel = o.responsavel_nome
+              ? formatNomePessoa(o.responsavel_nome)
+              : null;
+            const meta = (
+              <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                {o.entrega_oficial && (
+                  <span className="inline-flex items-center gap-1 tabular-nums">
+                    <CalendarIcon className="h-3 w-3 opacity-60" />
+                    Entrega {fmtDate(o.entrega_oficial)}
+                  </span>
+                )}
+                {dias > 0 && (
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1 font-semibold tabular-nums',
+                      dias > 10 ? 'text-destructive' : 'text-warning',
+                    )}
+                  >
+                    <AlertTriangle className="h-3 w-3" />
+                    {dias}d atraso
+                  </span>
+                )}
+                {responsavel && (
+                  <span className="inline-flex items-center gap-1 truncate">
+                    <User className="h-3 w-3 opacity-60" />
+                    <span className="truncate max-w-[140px]">{responsavel}</span>
+                  </span>
+                )}
+              </span>
+            );
+
+            return (
+              <li key={o.id}>
+                <MobileRecordCard
+                  title={o.customer_name ?? 'Sem cliente'}
+                  subtitle={o.nome ?? '—'}
+                  chips={chips}
+                  meta={meta}
+                  tone={tone}
+                  onClick={() => onOpen(o.id)}
+                  ariaLabel={`Abrir obra ${o.nome ?? ''} de ${o.customer_name ?? 'cliente sem nome'}`}
+                  overflowMenu={
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => onOpen(o.id)}
+                        className="text-sm gap-2"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                        Abrir obra
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => onOpenDados(o)}
+                        className="text-sm gap-2"
+                      >
+                        <FileText className="h-4 w-4" />
+                        Dados do cliente
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => onDeleteRequest(o)}
+                        className="text-sm gap-2 text-destructive focus:text-destructive focus:bg-destructive/10"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Excluir obra
+                      </DropdownMenuItem>
+                    </>
+                  }
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* ── Bottom sheet de filtros ─────────────────────────────────────── */}
+      <MobileFiltersSheet
+        open={mobileFiltersOpen}
+        onOpenChange={setMobileFiltersOpen}
+        activeCount={activeFilterCount}
+        onClear={clearAllFilters}
+        applyLabel={`Ver ${filtered.length} obras`}
+      >
+        {/* Status (multi) */}
+        <fieldset>
+          <legend className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+            Status
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            {[NONE, ...STATUS_OPTIONS].map((s) => {
+              const checked = filterStatuses.has(s);
+              const label = s === NONE ? 'Sem status' : s;
+              return (
+                <button
+                  type="button"
+                  key={`m-status-${s}`}
+                  onClick={() => onToggleStatus(s)}
+                  role="checkbox"
+                  aria-checked={checked}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 h-9 px-3 rounded-full text-[13px] border transition-colors',
+                    checked
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-surface text-foreground border-border-subtle hover:border-border-strong',
+                  )}
+                >
+                  {s !== NONE && (
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 rounded-full',
+                        checked ? 'bg-primary-foreground' : statusDotClass(s as PainelStatus),
+                      )}
+                      aria-hidden
+                    />
+                  )}
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          {filterStatuses.size > 0 && (
+            <button
+              type="button"
+              onClick={onClearStatuses}
+              className="mt-2 text-[12px] text-muted-foreground hover:text-foreground"
+            >
+              Limpar status
+            </button>
+          )}
+        </fieldset>
+
+        {/* Etapa */}
+        <fieldset>
+          <legend className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+            Etapa
+          </legend>
+          <Select value={filterEtapa} onValueChange={onFilterEtapa}>
+            <SelectTrigger
+              aria-label="Filtrar por etapa"
+              className="h-11 w-full text-[14px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todas etapas</SelectItem>
+              <SelectItem value={NONE}>(sem etapa)</SelectItem>
+              {ETAPA_OPTIONS.map((e) => (
+                <SelectItem key={e} value={e}>{e}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </fieldset>
+
+        {/* Relacionamento */}
+        <fieldset>
+          <legend className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+            Relacionamento
+          </legend>
+          <Select value={filterRelacionamento} onValueChange={onFilterRelacionamento}>
+            <SelectTrigger
+              aria-label="Filtrar por relacionamento"
+              className="h-11 w-full text-[14px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todos relacionamentos</SelectItem>
+              <SelectItem value={NONE}>(sem relacionamento)</SelectItem>
+              {RELACIONAMENTO_OPTIONS.map((r) => (
+                <SelectItem key={r} value={r}>{r}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </fieldset>
+
+        {/* Responsável */}
+        <fieldset>
+          <legend className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+            Responsável
+          </legend>
+          <Select value={filterResponsavel} onValueChange={onFilterResponsavel}>
+            <SelectTrigger
+              aria-label="Filtrar por responsável"
+              className="h-11 w-full text-[14px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todos responsáveis</SelectItem>
+              <SelectItem value={NONE}>(sem responsável)</SelectItem>
+              {staffUsers.map((u) => (
+                <SelectItem key={u.id} value={u.id}>{u.nome}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </fieldset>
+      </MobileFiltersSheet>
     </div>
   );
 }

--- a/tests/e2e/painel-obras-sticky.spec.ts
+++ b/tests/e2e/painel-obras-sticky.spec.ts
@@ -84,36 +84,44 @@ test.describe('Painel de Obras — sticky "Cliente / Obra" column', () => {
     });
   });
 
-  test.describe('Mobile (375x812)', () => {
+  // ── Mobile (< md): a tabela densa foi substituída por uma listagem em
+  //    cards (`MobilePainelView`). As assertivas de coluna sticky deixam de
+  //    fazer sentido — agora validamos que (a) a tabela está oculta, (b) a
+  //    lista de cards aparece sem scroll horizontal acidental, (c) o topo
+  //    expõe busca + botão "Filtros" como ação primária da viewport.
+  test.describe('Mobile (375x812) — cards empilhados', () => {
     test.use({ viewport: { width: 375, height: 812 } });
 
-    test('sticky column keeps 240px even on small viewport', async ({ page }) => {
+    test('table is hidden and mobile card list renders without horizontal scroll', async ({ page }) => {
       await gotoPainel(page);
-      await getFirstRow(page);
 
-      const clienteWidth = await getCellWidth(page, '[data-testid="painel-obras-th-cliente"]');
-      expect(Math.round(clienteWidth)).toBe(STICKY_WIDTH);
+      // Cards mobile devem estar presentes (link com aria-label "Abrir obra…").
+      const cards = page.locator('button[aria-label^="Abrir obra"]');
+      const cardCount = await cards.count();
+      if (cardCount === 0) {
+        test.skip(true, 'No projects available in environment to test mobile cards');
+      }
+      await expect(cards.first()).toBeVisible();
+
+      // Tabela desktop não pode estar visível no mobile.
+      await expect(page.locator('[data-testid="painel-obras-th-cliente"]')).toBeHidden();
+
+      // Sem overflow horizontal acidental.
+      const docOverflow = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect(docOverflow.scrollWidth).toBeLessThanOrEqual(docOverflow.clientWidth + 1);
     });
 
-    test('expanding row in mobile does not collapse adjacent columns', async ({ page }) => {
+    test('top exposes search + Filtros as primary actions', async ({ page }) => {
       await gotoPainel(page);
-      const row = await getFirstRow(page);
 
-      const widthBefore = await getCellWidth(page, '[data-testid="painel-obras-cell-cliente"]');
-      const statusBefore = await getCellWidth(page, '[data-testid="painel-obras-th-status"]');
+      const search = page.getByLabel('Buscar obras');
+      await expect(search).toBeVisible();
 
-      await row.locator('button[aria-label="Expandir detalhes"]').click();
-      await expect(row).toHaveAttribute('data-expanded', 'true');
-      await page.waitForTimeout(300);
-
-      const widthAfter = await getCellWidth(page, '[data-testid="painel-obras-cell-cliente"]');
-      const statusAfter = await getCellWidth(page, '[data-testid="painel-obras-th-status"]');
-
-      expect(Math.round(widthAfter)).toBe(STICKY_WIDTH);
-      // Status column should not collapse below its declared min-width (120px)
-      expect(statusAfter).toBeGreaterThanOrEqual(120 - 1);
-      expect(Math.abs(statusAfter - statusBefore)).toBeLessThan(2);
-      expect(Math.abs(widthAfter - widthBefore)).toBeLessThan(1);
+      const filtersButton = page.getByRole('button', { name: /Filtros|filtros/i });
+      await expect(filtersButton.first()).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
- Painel de Obras: substitui a tabela densa de 13 colunas por listagem
  em cards (`MobileRecordCard`) com chips de status/etapa e overflow
  menu. Toolbar mobile compacta com busca dominante + botão "Filtros"
  que abre `MobileFiltersSheet`. Hide das CTAs redundantes do header
  ("Nova obra" e "Customer Success") já cobertas pelo bottom nav.
- Dados do cliente: dialog desktop substituído por `MobileFullscreenSheet`
  no mobile (header sticky, body rolável, safe-area). Tabs trocadas por
  `ResponsiveTabs` com scroll horizontal sem cortar labels. Botão
  Salvar sticky no rodapé via `embedded` no `DadosCliente`. Header
  duplicado removido quando embutido.
- Editor rico (`RichTextEditorModal`): no mobile vira full-screen sheet
  com toolbar essencial (B/I/U, listas, undo/redo) em uma única linha
  rolável e ações secundárias (cor, destaque, alinhamento, tamanho)
  agrupadas em popover "Mais". Save sticky no footer.
- Novos primitivos em `src/components/mobile/`: `MobileRecordCard`,
  `MobileFullscreenSheet`, `MobileFiltersSheet`, `ResponsiveTabs`,
  `StickyActionBar`.
- Atualiza e2e `painel-obras-sticky.spec.ts` para validar o novo
  comportamento mobile (cards visíveis, sem overflow horizontal,
  busca + filtros como ações primárias).

Desktop preservado integralmente (toolbar densa, tabela/board/kanban,
sticky column 240px, dialog centralizado, toolbar full do editor).

https://claude.ai/code/session_01GF5ZkMfX1oVbfLbyjD83ML