### PR TITLE
Refactor activity cascading logic to use delta-based date shifting

### DIFF
--- a/src/pages/Cronograma.tsx
+++ b/src/pages/Cronograma.tsx
@@ -349,6 +349,10 @@ const Cronograma = () => {
     value: string | string[],
   ) => {
     setActivities(prev => {
+      const changedIndex = prev.findIndex(a => a.id === id);
+      const oldAct = changedIndex >= 0 ? prev[changedIndex] : null;
+      const oldPlannedEnd = oldAct?.plannedEnd ?? '';
+
       const newActivities = prev.map((act) => {
         if (act.id !== id) return act;
         const updated = { ...act, [field]: value };
@@ -372,34 +376,40 @@ const Cronograma = () => {
         return updated;
       });
 
-      // If plannedStart changed, cascade dates to all subsequent activities
-      if (field === 'plannedStart' && typeof value === 'string' && value) {
-        const changedIndex = newActivities.findIndex(a => a.id === id);
-        if (changedIndex >= 0 && changedIndex < newActivities.length - 1) {
-          for (let i = changedIndex + 1; i < newActivities.length; i++) {
-            const prevAct = newActivities[i - 1];
-            const currAct = newActivities[i];
-            if (!prevAct.plannedEnd) break;
-
-            // Preserve original duration of this activity
-            let durationDays = 4; // default Mon-Fri
-            if (currAct.plannedStart && currAct.plannedEnd) {
-              const cs = new Date(currAct.plannedStart + 'T00:00:00');
-              const ce = new Date(currAct.plannedEnd + 'T00:00:00');
-              durationDays = Math.round((ce.getTime() - cs.getTime()) / (1000 * 60 * 60 * 24));
-              if (durationDays < 0) durationDays = 4;
+      // Cascade: when planned dates change, shift subsequent activities by the same delta
+      // (computed against the changed activity's plannedEnd). A delta-based shift preserves
+      // the gap structure (weekends, intentional pauses) between activities.
+      const isDateChange = field === 'plannedStart' || field === 'plannedEnd';
+      if (
+        isDateChange &&
+        changedIndex >= 0 &&
+        changedIndex < newActivities.length - 1 &&
+        oldPlannedEnd
+      ) {
+        const updatedAct = newActivities[changedIndex];
+        if (updatedAct.plannedEnd) {
+          const oldEndDate = new Date(oldPlannedEnd + 'T00:00:00');
+          const newEndDate = new Date(updatedAct.plannedEnd + 'T00:00:00');
+          if (!isNaN(oldEndDate.getTime()) && !isNaN(newEndDate.getTime())) {
+            const deltaDays = Math.round(
+              (newEndDate.getTime() - oldEndDate.getTime()) / (1000 * 60 * 60 * 24),
+            );
+            if (deltaDays !== 0) {
+              for (let i = changedIndex + 1; i < newActivities.length; i++) {
+                const a = newActivities[i];
+                const shiftIso = (iso: string) => {
+                  const d = new Date(iso + 'T00:00:00');
+                  if (isNaN(d.getTime())) return iso;
+                  d.setDate(d.getDate() + deltaDays);
+                  return toISO(d);
+                };
+                newActivities[i] = {
+                  ...a,
+                  plannedStart: a.plannedStart ? shiftIso(a.plannedStart) : a.plannedStart,
+                  plannedEnd: a.plannedEnd ? shiftIso(a.plannedEnd) : a.plannedEnd,
+                };
+              }
             }
-
-            const prevEnd = new Date(prevAct.plannedEnd + 'T00:00:00');
-            const nextStart = getNextMonday(prevEnd);
-            const nextEnd = new Date(nextStart);
-            nextEnd.setDate(nextEnd.getDate() + durationDays);
-
-            newActivities[i] = {
-              ...currAct,
-              plannedStart: toISO(nextStart),
-              plannedEnd: toISO(nextEnd),
-            };
           }
         }
       }


### PR DESCRIPTION
## Summary
Refactored the activity date cascading mechanism to use a delta-based approach instead of recalculating absolute positions. When a planned date changes, subsequent activities now shift by the same time delta, preserving the gap structure between activities.

## Key Changes
- **Changed trigger condition**: Now cascades on both `plannedStart` and `plannedEnd` changes (previously only `plannedStart`)
- **Replaced absolute positioning with delta-based shifting**: Instead of recalculating each subsequent activity's dates from scratch, the new logic:
  - Computes the time delta between the old and new `plannedEnd` of the changed activity
  - Applies this delta uniformly to all subsequent activities' start and end dates
- **Simplified logic**: Removed the duration preservation logic that was recalculating activity lengths; gaps and durations are now naturally preserved through the delta shift
- **Improved robustness**: Added validation for date parsing and NaN checks before applying shifts

## Implementation Details
- Captures the old `plannedEnd` value before modifications to calculate the delta
- Uses a helper function `shiftIso()` to safely shift individual ISO date strings by the computed delta
- Only applies cascading if the delta is non-zero, avoiding unnecessary updates
- Maintains the same activity order and structure while shifting all subsequent dates

https://claude.ai/code/session_013nLUzwVaL3Had6KxvL8UKJ