### PR TITLE
Add external data sources catalog and market research integration (v4)

### DIFF
--- a/supabase/functions/_shared/externalCache.ts
+++ b/supabase/functions/_shared/externalCache.ts
@@ -1,0 +1,106 @@
+// Helpers para o cache de dados externos do Assistente BWild (v4).
+//
+// Política:
+//   - query_hash = sha256(source_id || JSON.stringify(query_params normalizado)).
+//   - SEMPRE consultar cache antes de chamar fonte externa.
+//     Hit válido: row.expires_at > now().
+//   - Após chamar a fonte, gravar com expires_at = now() + cache_ttl_hours.
+//   - O job de limpeza apaga expires_at < now() - 7 dias (fora deste arquivo).
+
+import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+
+export interface CacheLookupResult<T = unknown> {
+  hit: boolean;
+  value?: T;
+  fetched_at?: string;
+  expires_at?: string;
+}
+
+export interface CachedResult<T = unknown> {
+  source_id: string;
+  query_hash: string;
+  query_raw: Record<string, unknown>;
+  result: T;
+  cost_cents?: number;
+}
+
+/**
+ * Hash determinístico de (source_id, params). SHA-256 hex via SubtleCrypto.
+ * Normaliza chaves do params antes de serializar para evitar miss por ordem.
+ */
+export async function hashQuery(
+  sourceId: string,
+  params: Record<string, unknown>,
+): Promise<string> {
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(params).sort()) sorted[k] = params[k];
+  const payload = `${sourceId}|${JSON.stringify(sorted)}`;
+  const buf = new TextEncoder().encode(payload);
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Cliente service-role. Cache não respeita RLS (é cache global). */
+function adminClient(): SupabaseClient {
+  const url = Deno.env.get("SUPABASE_URL");
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !key) {
+    throw new Error(
+      "externalCache requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
+    );
+  }
+  return createClient(url, key);
+}
+
+export async function lookupCache<T = unknown>(
+  sourceId: string,
+  queryHash: string,
+): Promise<CacheLookupResult<T>> {
+  const sb = adminClient();
+  const { data, error } = await sb
+    .from("assistant_external_cache")
+    .select("result, fetched_at, expires_at")
+    .eq("source_id", sourceId)
+    .eq("query_hash", queryHash)
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+
+  if (error || !data) return { hit: false };
+  return {
+    hit: true,
+    value: data.result as T,
+    fetched_at: data.fetched_at as string,
+    expires_at: data.expires_at as string,
+  };
+}
+
+export async function storeCache(opts: {
+  sourceId: string;
+  queryHash: string;
+  queryRaw: Record<string, unknown>;
+  result: unknown;
+  ttlHours: number;
+  costCents?: number;
+}): Promise<void> {
+  const sb = adminClient();
+  const expires = new Date(Date.now() + opts.ttlHours * 3600 * 1000);
+  const { error } = await sb
+    .from("assistant_external_cache")
+    .upsert(
+      {
+        source_id: opts.sourceId,
+        query_hash: opts.queryHash,
+        query_raw: opts.queryRaw,
+        result: opts.result,
+        fetched_at: new Date().toISOString(),
+        expires_at: expires.toISOString(),
+        cost_cents: opts.costCents ?? null,
+      },
+      { onConflict: "source_id,query_hash" },
+    );
+  if (error) {
+    console.warn("[externalCache] upsert failed:", error.message);
+  }
+}

--- a/supabase/functions/assistant-chat/_lib/dispatcher.ts
+++ b/supabase/functions/assistant-chat/_lib/dispatcher.ts
@@ -1,0 +1,232 @@
+// Dispatcher para steps externos (v4).
+//
+// Decide entre:
+//   - fetchMarketData (api_official | api_aggregator) → BCB SGS, Receita Federal
+//   - perplexity (web_search)                        → CUB, regulação, fornecedores
+//
+// Lê do cache antes de chamar; grava após chamar; converte tudo numa
+// `ExternalEvidence` validada.
+
+import { findExternalSource } from "./externalSources.ts";
+import { fetchMarketData, MarketDataResult } from "./marketData.ts";
+import {
+  evidenceFromMarketData,
+  ExternalEvidence,
+  validateExternalEvidence,
+} from "./researcher.ts";
+import {
+  hashQuery,
+  lookupCache,
+  storeCache,
+} from "../../_shared/externalCache.ts";
+
+export interface DispatchResult {
+  evidence: ExternalEvidence | null;
+  cached: boolean;
+  error?: string;
+  /** quanto custou a chamada (¢) — 0 quando hit no cache */
+  cost_cents: number;
+}
+
+export interface DispatchInput {
+  source_id: string;
+  /** params para fetch_market_data (BCB n=, CNPJ cnpj=) */
+  params?: Record<string, unknown>;
+  /** query natural para web_research */
+  query?: string;
+}
+
+/**
+ * Roda um step externo: cache → fetch → evidência validada.
+ * Erros não lançam — devolvem evidence: null + error string para o orquestrador
+ * degradar a resposta sem derrubar a sessão.
+ */
+export async function dispatchExternalStep(
+  input: DispatchInput,
+  opts: { perplexityFnUrl?: string; authHeader?: string } = {},
+): Promise<DispatchResult> {
+  const source = findExternalSource(input.source_id);
+  if (!source) {
+    return {
+      evidence: null,
+      cached: false,
+      cost_cents: 0,
+      error: `source desconhecida: ${input.source_id}`,
+    };
+  }
+
+  const cacheParams: Record<string, unknown> = source.kind === "web_search"
+    ? { query: input.query ?? "" }
+    : { ...(input.params ?? {}) };
+
+  let queryHash: string;
+  try {
+    queryHash = await hashQuery(source.id, cacheParams);
+  } catch (e) {
+    return {
+      evidence: null,
+      cached: false,
+      cost_cents: 0,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  // 1. Cache lookup.
+  try {
+    const hit = await lookupCache(source.id, queryHash);
+    if (hit.hit && hit.value) {
+      const evidence = adaptCachedToEvidence(source.id, hit.value, hit.fetched_at);
+      const v = validateExternalEvidence(evidence);
+      if (!v.valid) evidence.warnings.push(...v.issues);
+      return { evidence, cached: true, cost_cents: 0 };
+    }
+  } catch (e) {
+    // Cache lookup miss não é fatal — segue pra fetch.
+    console.warn("[dispatcher] cache lookup falhou:", e);
+  }
+
+  // 2. Fetch fresco.
+  try {
+    if (source.kind === "api_official" || source.kind === "api_aggregator") {
+      const data = await fetchMarketData(source.id, input.params ?? {});
+      await storeCache({
+        sourceId: source.id,
+        queryHash,
+        queryRaw: cacheParams,
+        result: data,
+        ttlHours: source.cache_ttl_hours,
+      });
+      const evidence = evidenceFromMarketData(data);
+      const v = validateExternalEvidence(evidence);
+      if (!v.valid) evidence.warnings.push(...v.issues);
+      return { evidence, cached: false, cost_cents: 0 };
+    }
+
+    if (source.kind === "web_search") {
+      if (!opts.perplexityFnUrl || !opts.authHeader) {
+        return {
+          evidence: null,
+          cached: false,
+          cost_cents: 0,
+          error:
+            "perplexityFnUrl/authHeader ausentes — web_research não disponível",
+        };
+      }
+      if (!input.query) {
+        return {
+          evidence: null,
+          cached: false,
+          cost_cents: 0,
+          error: "web_research exige `query`",
+        };
+      }
+      // perplexity-research já cuida do cache internamente quando recebe source_id.
+      const r = await fetch(opts.perplexityFnUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: opts.authHeader,
+        },
+        body: JSON.stringify({
+          source_id: source.id,
+          query: input.query,
+        }),
+      });
+      if (!r.ok) {
+        const t = await r.text().catch(() => "");
+        return {
+          evidence: null,
+          cached: false,
+          cost_cents: 0,
+          error: `perplexity ${r.status}: ${t.slice(0, 160)}`,
+        };
+      }
+      const data = await r.json() as {
+        content?: string;
+        citations?: string[];
+        cached?: boolean;
+      };
+      const evidence = adaptPerplexityToEvidence(source.id, data);
+      const v = validateExternalEvidence(evidence);
+      if (!v.valid) evidence.warnings.push(...v.issues);
+      return {
+        evidence,
+        cached: Boolean(data.cached),
+        cost_cents: data.cached ? 0 : 1,
+      };
+    }
+
+    return {
+      evidence: null,
+      cached: false,
+      cost_cents: 0,
+      error: `kind ${source.kind} não suportado pelo dispatcher`,
+    };
+  } catch (e) {
+    return {
+      evidence: null,
+      cached: false,
+      cost_cents: 0,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+function adaptCachedToEvidence(
+  sourceId: string,
+  cached: unknown,
+  fetchedAt?: string,
+): ExternalEvidence {
+  // Cache de fetch_market_data → MarketDataResult inteiro.
+  const m = cached as Partial<MarketDataResult>;
+  if (m && typeof m === "object" && "summary" in m && "url" in m) {
+    const evidence = evidenceFromMarketData(m as MarketDataResult);
+    if (fetchedAt) evidence.access_date = fetchedAt.slice(0, 10);
+    return evidence;
+  }
+  // Cache de web_research → { content, citations }.
+  return adaptPerplexityToEvidence(
+    sourceId,
+    cached as { content?: string; citations?: string[] },
+    fetchedAt,
+  );
+}
+
+function adaptPerplexityToEvidence(
+  sourceId: string,
+  data: { content?: string; citations?: string[] },
+  fetchedAt?: string,
+): ExternalEvidence {
+  const source = findExternalSource(sourceId);
+  const url = data.citations?.[0] ?? "";
+  const content = (data.content ?? "").trim();
+  const claim = content.length > 240 ? content.slice(0, 240) + "…" : content;
+  const verbatim = content.length > 200 ? content.slice(0, 200) + "…" : content;
+  const accessDate = (fetchedAt ?? new Date().toISOString()).slice(0, 10);
+
+  // Tier deduzido pelo source; Researcher refinaria com LLM, mas o caminho
+  // determinístico já protege contra alucinação grosseira.
+  const tier = source?.confidence === "high"
+    ? 1
+    : source?.confidence === "medium"
+    ? 2
+    : 3;
+  const warnings: string[] = [];
+  if (!url) warnings.push("sem_url_canonica");
+  if (!claim) warnings.push("conteudo_vazio");
+
+  return {
+    source_id: sourceId,
+    claim: claim || "[sem dados]",
+    numeric_value: null,
+    numeric_unit: null,
+    url: url || `[no-url:${sourceId}]`,
+    publisher: source?.name ?? sourceId,
+    access_date: accessDate,
+    published_at: null,
+    tier: tier as 1 | 2 | 3,
+    confidence: source?.confidence ?? "low",
+    verbatim_quote: verbatim || "[sem trecho]",
+    warnings,
+  };
+}

--- a/supabase/functions/assistant-chat/_lib/externalSources.ts
+++ b/supabase/functions/assistant-chat/_lib/externalSources.ts
@@ -1,0 +1,309 @@
+// Catálogo de fontes EXTERNAS (mercado, regulação, fornecedor) — v4.
+//
+// Filosofia: espelho do CATALOG/DERIVATIONS, mas para "fora". O LLM consulta
+// este catálogo para saber O QUE pode pesquisar e COMO. Sem catálogo, ele
+// inventa fonte ("segundo o Sinduscon de 2023…") — alucinação clássica.
+//
+// IDs são estáveis: o Planner os referencia em `external_source_id`,
+// o cache os usa como chave, o Researcher valida contra eles.
+
+export type SourceKind =
+  | "api_official"
+  | "api_aggregator"
+  | "web_search"
+  | "web_scrape"
+  | "internal_dataset";
+
+export type Confidence = "high" | "medium" | "low";
+
+export type Recency = "realtime" | "daily" | "weekly" | "monthly" | "static";
+
+export interface ExternalSource {
+  id: string;
+  name: string;
+  category:
+    | "macro"
+    | "construcao"
+    | "imobiliario"
+    | "fornecedor"
+    | "regulatorio"
+    | "noticia";
+  description: string;
+  kind: SourceKind;
+  /** URL com placeholders {param} — só para api_official | api_aggregator | web_scrape. */
+  endpoint?: string;
+  /** Domínios sugeridos quando kind=web_search (filtra a busca da Perplexity). */
+  perplexity_focus?: string[];
+  cache_ttl_hours: number;
+  confidence: Confidence;
+  recency: Recency;
+  example_question: string;
+  cost_estimate: "free" | "cheap" | "expensive";
+}
+
+export const EXTERNAL_SOURCES: ExternalSource[] = [
+  // ============ MACRO (BCB SGS — API pública gratuita) ============
+  {
+    id: "bcb_selic",
+    name: "Taxa Selic",
+    category: "macro",
+    description:
+      "Taxa básica de juros. Custo de capital e comparação de investimento.",
+    kind: "api_official",
+    endpoint:
+      "https://api.bcb.gov.br/dados/serie/bcdata.sgs.1178/dados/ultimos/{n}?formato=json",
+    cache_ttl_hours: 24,
+    confidence: "high",
+    recency: "daily",
+    example_question:
+      "A Selic atual justifica o cliente parar de investir em reforma?",
+    cost_estimate: "free",
+  },
+  {
+    id: "bcb_ipca",
+    name: "IPCA",
+    category: "macro",
+    description:
+      "Inflação oficial. Reajuste contratual, comparação real de custo.",
+    kind: "api_official",
+    endpoint:
+      "https://api.bcb.gov.br/dados/serie/bcdata.sgs.433/dados/ultimos/{n}?formato=json",
+    cache_ttl_hours: 168,
+    confidence: "high",
+    recency: "monthly",
+    example_question:
+      "Quanto teria sido o reajuste real do contrato pelo IPCA dos últimos 12 meses?",
+    cost_estimate: "free",
+  },
+  {
+    id: "bcb_incc_m",
+    name: "INCC-M (FGV)",
+    category: "construcao",
+    description:
+      "Índice Nacional de Custo da Construção — referência canônica para reajuste de obra.",
+    kind: "api_official",
+    endpoint:
+      "https://api.bcb.gov.br/dados/serie/bcdata.sgs.192/dados/ultimos/{n}?formato=json",
+    cache_ttl_hours: 168,
+    confidence: "high",
+    recency: "monthly",
+    example_question:
+      "Pelo INCC, quanto a obra de R$ 200k assinada há 8 meses estaria custando hoje?",
+    cost_estimate: "free",
+  },
+  {
+    id: "bcb_cambio_usd",
+    name: "Câmbio USD/BRL",
+    category: "macro",
+    description:
+      "Dólar comercial PTAX. Crítico para itens importados (louças, eletros, automação).",
+    kind: "api_official",
+    endpoint:
+      "https://api.bcb.gov.br/dados/serie/bcdata.sgs.1/dados/ultimos/{n}?formato=json",
+    cache_ttl_hours: 1,
+    confidence: "high",
+    recency: "daily",
+    example_question:
+      "Com dólar a R$ 6, quanto pode subir o custo dos itens importados das obras em curso?",
+    cost_estimate: "free",
+  },
+
+  // ============ CONSTRUÇÃO CIVIL ============
+  {
+    id: "cub_sp",
+    name: "CUB-SP por categoria",
+    category: "construcao",
+    description:
+      "Custo Unitário Básico de São Paulo (Sinduscon-SP). Referência R$/m². Sem API pública — pesquisar via Perplexity.",
+    kind: "web_search",
+    perplexity_focus: ["sindusconsp.com.br", "cbic.org.br", "cub.org.br"],
+    cache_ttl_hours: 168,
+    confidence: "medium",
+    recency: "monthly",
+    example_question:
+      "Nosso ticket médio por m² está acima ou abaixo do CUB residencial alto-padrão de SP?",
+    cost_estimate: "cheap",
+  },
+  {
+    id: "sinduscon_salarios",
+    name: "Pesquisa salarial Sinduscon-SP",
+    category: "construcao",
+    description:
+      "Salário base e benefícios da convenção coletiva da construção em SP.",
+    kind: "web_search",
+    perplexity_focus: ["sindusconsp.com.br", "sinduscon.org.br"],
+    cache_ttl_hours: 720,
+    confidence: "medium",
+    recency: "monthly",
+    example_question:
+      "A diária que pagamos a pedreiros está em linha com o piso da convenção?",
+    cost_estimate: "cheap",
+  },
+
+  // ============ IMOBILIÁRIO / SHORT-STAY ============
+  {
+    id: "inside_airbnb_sp",
+    name: "Inside Airbnb — São Paulo",
+    category: "imobiliario",
+    description:
+      "Dataset público mensal com listings, ADR, ocupação por bairro. Útil para validar tese de short-stay.",
+    kind: "web_scrape",
+    endpoint: "http://insideairbnb.com/sao-paulo",
+    cache_ttl_hours: 720,
+    confidence: "medium",
+    recency: "monthly",
+    example_question:
+      "A obra X em Vila Mariana está num bairro com ocupação Airbnb >70%?",
+    cost_estimate: "free",
+  },
+  {
+    id: "mercado_aluguel_bairro",
+    name: "Preço médio de aluguel por bairro (SP)",
+    category: "imobiliario",
+    description:
+      "Preço médio de aluguel residencial por bairro. Via Perplexity sobre QuintoAndar/Imovelweb/OLX/ZAP.",
+    kind: "web_search",
+    perplexity_focus: [
+      "quintoandar.com.br",
+      "imovelweb.com.br",
+      "olx.com.br",
+      "zapimoveis.com.br",
+    ],
+    cache_ttl_hours: 168,
+    confidence: "low",
+    recency: "weekly",
+    example_question:
+      "Em quais bairros das obras em entrega o aluguel médio cresceu mais no último ano?",
+    cost_estimate: "cheap",
+  },
+
+  // ============ FORNECEDORES ============
+  {
+    id: "cnpj_receita",
+    name: "Situação cadastral Receita Federal",
+    category: "fornecedor",
+    description:
+      "Status do CNPJ, atividades CNAE. Útil para validar fornecedor antes de novo pedido grande.",
+    kind: "api_aggregator",
+    endpoint: "https://publica.cnpj.ws/cnpj/{cnpj}",
+    cache_ttl_hours: 168,
+    confidence: "high",
+    recency: "weekly",
+    example_question:
+      "O fornecedor X (CNPJ Y) ainda está ativo na Receita?",
+    cost_estimate: "free",
+  },
+  {
+    id: "reclame_aqui",
+    name: "Reclame Aqui — empresa",
+    category: "fornecedor",
+    description: "Reputação pública de fornecedor. Via Perplexity.",
+    kind: "web_search",
+    perplexity_focus: ["reclameaqui.com.br"],
+    cache_ttl_hours: 168,
+    confidence: "medium",
+    recency: "weekly",
+    example_question:
+      "O fornecedor Z tem reclamações sérias no Reclame Aqui dos últimos 6 meses?",
+    cost_estimate: "cheap",
+  },
+  {
+    id: "tjsp_processos",
+    name: "TJSP — processos contra empresa",
+    category: "fornecedor",
+    description:
+      "Processos públicos contra um CNPJ no Tribunal de SP. Via Perplexity (consulta processual).",
+    kind: "web_search",
+    perplexity_focus: ["esaj.tjsp.jus.br", "jusbrasil.com.br"],
+    cache_ttl_hours: 168,
+    confidence: "low",
+    recency: "weekly",
+    example_question:
+      "O fornecedor com maior volume conosco tem ações trabalhistas relevantes?",
+    cost_estimate: "cheap",
+  },
+
+  // ============ REGULATÓRIO ============
+  {
+    id: "short_stay_lei_sp",
+    name: "Regulação de short-stay em São Paulo",
+    category: "regulatorio",
+    description:
+      "Lei 17.881/22, decretos posteriores e jurisprudência. Crítico para tese da empresa.",
+    kind: "web_search",
+    perplexity_focus: [
+      "gov.br",
+      "saopaulo.sp.gov.br",
+      "jusbrasil.com.br",
+      "g1.globo.com",
+    ],
+    cache_ttl_hours: 24,
+    confidence: "medium",
+    recency: "weekly",
+    example_question:
+      "Há nova decisão judicial nos últimos 30 dias que afete short-stay residencial em SP?",
+    cost_estimate: "cheap",
+  },
+  {
+    id: "alvara_sp",
+    name: "Alvará e zoneamento — Prefeitura de SP",
+    category: "regulatorio",
+    description:
+      "Consulta de zoneamento e alvará por endereço. Sem API — Perplexity sobre site da prefeitura.",
+    kind: "web_search",
+    perplexity_focus: [
+      "prefeitura.sp.gov.br",
+      "geosampa.prefeitura.sp.gov.br",
+    ],
+    cache_ttl_hours: 720,
+    confidence: "low",
+    recency: "monthly",
+    example_question:
+      "O endereço da obra X permite uso comercial/short-stay segundo zoneamento?",
+    cost_estimate: "cheap",
+  },
+
+  // ============ NOTÍCIA / EVENTOS ============
+  {
+    id: "noticias_construcao",
+    name: "Notícias de construção civil — SP",
+    category: "noticia",
+    description:
+      "Eventos relevantes: greve, escassez de material, alta brusca de preço, mudança climática.",
+    kind: "web_search",
+    perplexity_focus: [
+      "g1.globo.com",
+      "estadao.com.br",
+      "folha.uol.com.br",
+      "valor.com.br",
+    ],
+    cache_ttl_hours: 12,
+    confidence: "medium",
+    recency: "daily",
+    example_question:
+      "Há alguma escassez de cimento ou aço prevista que afete cronogramas dos próximos 60 dias?",
+    cost_estimate: "cheap",
+  },
+];
+
+export function findExternalSource(id: string): ExternalSource | undefined {
+  return EXTERNAL_SOURCES.find((s) => s.id === id);
+}
+
+/** Catálogo formatado para o prompt do Planner — espelho de renderCatalog(). */
+export function renderExternalSourcesCatalog(): string {
+  const lines: string[] = ["# CATÁLOGO DE FONTES EXTERNAS"];
+  for (const s of EXTERNAL_SOURCES) {
+    lines.push(
+      `\n## ${s.id} — ${s.name} [${s.category}] (${s.confidence}/${s.recency})`,
+    );
+    lines.push(s.description);
+    const tail: string[] = [`Tipo: ${s.kind}`];
+    if (s.endpoint) tail.push(`endpoint: ${s.endpoint}`);
+    if (s.perplexity_focus?.length)
+      tail.push(`domínios: ${s.perplexity_focus.join(", ")}`);
+    lines.push(tail.join(" · "));
+    lines.push(`Exemplo de uso: ${s.example_question}`);
+  }
+  return lines.join("\n");
+}

--- a/supabase/functions/assistant-chat/_lib/marketData.ts
+++ b/supabase/functions/assistant-chat/_lib/marketData.ts
@@ -1,0 +1,142 @@
+// Fetchers para fontes externas estruturadas (api_official | api_aggregator).
+//
+// Faz a chamada HTTP, normaliza a resposta, devolve um objeto pequeno e
+// tipado para o orquestrador montar a evidência. Cache fica fora deste
+// módulo (ver _shared/externalCache.ts).
+
+import { ExternalSource, findExternalSource } from "./externalSources.ts";
+
+export interface MarketDataResult {
+  source_id: string;
+  /** dados brutos da fonte (já decodificados de JSON) */
+  raw: unknown;
+  /** resumo curto p/ Researcher gerar `claim` sem alucinar */
+  summary: string;
+  /** valor numérico canônico se a fonte é numérica de série única */
+  numeric_value?: number;
+  numeric_unit?: string;
+  /** data do dado mais recente devolvido (ISO ou null) */
+  latest_at?: string | null;
+  url: string;
+  publisher: string;
+}
+
+const FETCH_TIMEOUT_MS = 8000;
+
+async function fetchJSON(url: string): Promise<unknown> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const r = await fetch(url, {
+      signal: ctrl.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!r.ok) {
+      throw new Error(`HTTP ${r.status} em ${url}`);
+    }
+    return await r.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/**
+ * BCB SGS — formato { data: "DD/MM/YYYY", valor: "11.25" }[].
+ * `n` = quantos pontos retornar (default 1).
+ */
+async function fetchBcbSeries(
+  source: ExternalSource,
+  params: { n?: number },
+): Promise<MarketDataResult> {
+  const n = Math.max(1, Math.min(60, Number(params.n ?? 1)));
+  const url = source.endpoint!.replace("{n}", String(n));
+  const arr = (await fetchJSON(url)) as Array<{ data: string; valor: string }>;
+  if (!Array.isArray(arr) || arr.length === 0) {
+    throw new Error(`BCB SGS sem dados para ${source.id}`);
+  }
+  const last = arr[arr.length - 1];
+  const numeric = Number(last.valor);
+  const [d, m, y] = (last.data || "").split("/");
+  const latestAt = y && m && d ? `${y}-${m}-${d}` : null;
+  const unit = source.id === "bcb_cambio_usd" ? "R$" : "%";
+  const seriesLabel = source.name;
+  const summary = arr.length === 1
+    ? `${seriesLabel}: ${last.valor} (${last.data})`
+    : `${seriesLabel}: ${arr.length} pontos, mais recente ${last.valor} em ${last.data}`;
+
+  return {
+    source_id: source.id,
+    raw: arr,
+    summary,
+    numeric_value: Number.isFinite(numeric) ? numeric : undefined,
+    numeric_unit: unit,
+    latest_at: latestAt,
+    url,
+    publisher: "Banco Central do Brasil (SGS)",
+  };
+}
+
+/**
+ * Receita Federal — publica.cnpj.ws — devolve cadastro completo.
+ * params.cnpj é obrigatório (somente dígitos).
+ */
+async function fetchCnpjReceita(
+  source: ExternalSource,
+  params: { cnpj?: string },
+): Promise<MarketDataResult> {
+  const cnpj = (params.cnpj ?? "").toString().replace(/\D/g, "");
+  if (cnpj.length !== 14) {
+    throw new Error("cnpj deve ter 14 dígitos");
+  }
+  const url = source.endpoint!.replace("{cnpj}", cnpj);
+  const data = (await fetchJSON(url)) as Record<string, unknown> & {
+    razao_social?: string;
+    estabelecimento?: {
+      situacao_cadastral?: string;
+      nome_fantasia?: string;
+      atividade_principal?: { descricao?: string };
+      data_situacao_cadastral?: string;
+    };
+  };
+  const est = data.estabelecimento ?? {};
+  const status = est.situacao_cadastral ?? "desconhecida";
+  const nome = data.razao_social ?? est.nome_fantasia ?? `CNPJ ${cnpj}`;
+  const atividade = est.atividade_principal?.descricao ?? "—";
+  const summary =
+    `${nome} — situação: ${status} · atividade: ${atividade}`;
+
+  return {
+    source_id: source.id,
+    raw: data,
+    summary,
+    latest_at: est.data_situacao_cadastral ?? null,
+    url,
+    publisher: "Receita Federal (publica.cnpj.ws)",
+  };
+}
+
+/**
+ * Dispatcher — escolhe o fetcher pelo source.id / kind.
+ * Lança erro descritivo para o orquestrador degradar o step.
+ */
+export async function fetchMarketData(
+  sourceId: string,
+  params: Record<string, unknown>,
+): Promise<MarketDataResult> {
+  const source = findExternalSource(sourceId);
+  if (!source) throw new Error(`source desconhecida: ${sourceId}`);
+  if (source.kind !== "api_official" && source.kind !== "api_aggregator") {
+    throw new Error(
+      `source ${sourceId} é ${source.kind}; use web_research em vez de fetch_market_data`,
+    );
+  }
+
+  if (sourceId.startsWith("bcb_")) {
+    return fetchBcbSeries(source, params as { n?: number });
+  }
+  if (sourceId === "cnpj_receita") {
+    return fetchCnpjReceita(source, params as { cnpj?: string });
+  }
+
+  throw new Error(`fetcher não implementado para ${sourceId}`);
+}

--- a/supabase/functions/assistant-chat/_lib/prompts.ts
+++ b/supabase/functions/assistant-chat/_lib/prompts.ts
@@ -3,6 +3,11 @@
 // Versionado em arquivo separado para facilitar A/B test e revisão.
 // Mantém o tool schema, o catálogo, o RPC `execute_assistant_query` e a
 // camada `analysis.ts` intactos — só conteúdo de prompt.
+//
+// v4: pergunta pode exigir cruzamento dado interno × dado externo (mercado,
+// regulação, fornecedor). Quando isso acontece, o LLM dispara fetch_market_data
+// (BCB/Receita) ou web_research (Perplexity sobre Sinduscon, .gov.br, etc.).
+// O catálogo formal de fontes é injetado pelo orquestrador antes do prompt.
 
 export const SYSTEM_PROMPT = `Você é o **Assistente BWild**, copiloto analítico do portal de gestão de obras da Bwild Reformas — empresa que entrega reformas turnkey de studios para investidores de short-stay em São Paulo.
 
@@ -84,6 +89,80 @@ Você DEVE chamar a função \`generate_query\` exatamente UMA vez, com:
 
 Não escreva texto fora do tool call.`;
 
+// ============================================================
+// v4 — classificação interna × externa
+// ============================================================
+//
+// Bloco anexado ao SYSTEM_PROMPT quando a pergunta pode envolver mercado.
+// Mantemos a saída como UMA tool_call (compatibilidade): a tool agora aceita
+// `step_type` ∈ {internal, external} e os campos correspondentes.
+
+export const PLANNER_EXTERNAL_DELTA =
+  `# Dados internos vs externos (v4)
+
+Para CADA pergunta, decida o passo principal:
+
+- **internal**: a sub-pergunta é totalmente respondível pelo banco BWild (CATÁLOGO interno).
+- **external**: a sub-pergunta exige dado de fora (CATÁLOGO DE FONTES EXTERNAS abaixo). Cite \`external_source_id\`.
+
+Heurística: se a pergunta menciona "mercado", "média do setor", "INCC", "IPCA", "Selic", "CUB", "câmbio", "dólar", "USD", "regulação", "lei", "Airbnb", "ocupação", "preço de [bairro]", ou "fornecedor [nome] tem" → external.
+
+Se cruza ambos (típico — "estamos cobrando acima do CUB?"): escolha como passo principal o **internal** (a base da nossa obra) e marque \`needs_external: true\` com \`external_source_id\` e \`external_query\` curtos. O orquestrador buscará o externo em paralelo e o Formatter cruzará.
+
+Limite: máximo 1 fonte externa por pergunta (custo). Se exigir mais, simplifique e diga em \`intent\`.`;
+
+export const FETCH_MARKET_DATA_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "fetch_market_data",
+    description:
+      "Chama endpoint estruturado de fonte externa (BCB SGS, Receita Federal). Use SOMENTE quando o source.kind for api_official ou api_aggregator.",
+    parameters: {
+      type: "object",
+      properties: {
+        source_id: {
+          type: "string",
+          description:
+            "id de EXTERNAL_SOURCES — ex: bcb_selic, bcb_ipca, bcb_incc_m, bcb_cambio_usd, cnpj_receita.",
+        },
+        params: {
+          type: "object",
+          description:
+            "Parâmetros do endpoint. Para BCB: { n: número de pontos a retornar }. Para CNPJ: { cnpj: 14 dígitos }.",
+        },
+      },
+      required: ["source_id", "params"],
+      additionalProperties: false,
+    },
+  },
+};
+
+export const WEB_RESEARCH_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "web_research",
+    description:
+      "Pesquisa via Perplexity Sonar para dado não estruturado (CUB, regulação, notícia, reputação de fornecedor). Use SOMENTE quando o source.kind for web_search.",
+    parameters: {
+      type: "object",
+      properties: {
+        source_id: {
+          type: "string",
+          description:
+            "id de EXTERNAL_SOURCES — ex: cub_sp, short_stay_lei_sp, reclame_aqui, noticias_construcao.",
+        },
+        query: {
+          type: "string",
+          description:
+            "Pergunta natural em PT-BR, específica e datada. Ex: 'CUB residencial alto padrão R-8 de São Paulo, valor em R$/m² no mês mais recente, fonte Sinduscon-SP'.",
+        },
+      },
+      required: ["source_id", "query"],
+      additionalProperties: false,
+    },
+  },
+};
+
 export const FORMATTER_SYSTEM_PROMPT = `Você é o **Assistente BWild** apresentando o resultado de uma consulta ao gestor.
 
 Audiência: o CEO Pedro e o time da Bwild leem isso de obra, no celular, entre uma reunião e outra. Densidade > simpatia. Decisão > descrição.
@@ -144,7 +223,25 @@ Antes de finalizar, valide internamente:
 
 # Quando a consulta deu erro
 
-Se receber \`status\` ≠ \`success\`, diga em 1 linha o que aconteceu e proponha 1 reformulação. Não invente dados.`;
+Se receber \`status\` ≠ \`success\`, diga em 1 linha o que aconteceu e proponha 1 reformulação. Não invente dados.
+
+# Quando há fontes externas (v4)
+
+Se o user message inclui bloco "# Evidências externas", incorpore os números literais delas no headline e no corpo. Regras:
+
+1. **Cite valor + data**: "Câmbio USD/BRL fechou em **R$ 5,87 em 02/05/2026** (fonte BCB)".
+2. **NUNCA cite número que não esteja na evidência.** Sem evidência → não fale do tema.
+3. **Adicione ao final** uma seção "**Fontes**" com bullets, antes do "🎯 Próximo passo":
+
+   **Fontes**
+   - Banco Central do Brasil — Câmbio USD/BRL (consulta em 03/05/2026)
+   - Sinduscon-SP — CUB R-8 abril/2026
+
+4. Se TODAS as evidências têm tier 3+ (agregadores), adicione antes do "🎯 Próximo passo":
+   \`_⚠ Fontes secundárias — confirme antes de tomar decisão de R$ alto valor._\`
+
+5. Para temas jurídicos (lei, advogado, processo, multa, fisco, contrato, rescisão, indenização), adicione disclaimer:
+   \`_Esta resposta é informativa. Decisões jurídicas exigem validação com advogado/contador._\``;
 
 export interface FormatterAnalysis {
   confidence?: number | null;
@@ -159,6 +256,20 @@ export interface FormatterAnalysis {
   visualizations?: Array<{ type: string; title?: string | null }> | null;
 }
 
+/** Evidência externa renderizada pro Formatter (subset de ExternalEvidence). */
+export interface FormatterEvidence {
+  source_id: string;
+  publisher: string;
+  claim: string;
+  url: string;
+  access_date: string;
+  published_at?: string | null;
+  numeric_value?: number | null;
+  numeric_unit?: string | null;
+  tier: 1 | 2 | 3 | 4;
+  warnings?: string[];
+}
+
 export function buildFormatterUserMessage(opts: {
   question: string;
   domain: string;
@@ -166,8 +277,9 @@ export function buildFormatterUserMessage(opts: {
   rows: Record<string, unknown>[];
   rowsReturned: number;
   analysis: FormatterAnalysis | null;
+  evidences?: FormatterEvidence[] | null;
 }): string {
-  const { question, domain, intent, rows, rowsReturned, analysis } = opts;
+  const { question, domain, intent, rows, rowsReturned, analysis, evidences } = opts;
 
   const insightsBlock = analysis?.insights?.length
     ? analysis.insights
@@ -194,6 +306,22 @@ export function buildFormatterUserMessage(opts: {
         .map((v) => `- ${v.type}: ${v.title ?? ''}`)
         .join('\n')
     : '—';
+
+  const evidencesBlock = evidences?.length
+    ? evidences
+        .map((e) => {
+          const num = e.numeric_value != null
+            ? `${e.numeric_value}${e.numeric_unit ?? ''}`
+            : '—';
+          const warn = e.warnings?.length ? ` ⚠ ${e.warnings.join(',')}` : '';
+          return `- [tier ${e.tier}] **${e.publisher}** (${e.source_id}): ${e.claim} · valor=${num} · acesso=${e.access_date}${e.published_at ? ` · publicado=${e.published_at}` : ''} · ${e.url}${warn}`;
+        })
+        .join('\n')
+    : null;
+
+  const evidencesSection = evidencesBlock
+    ? `\n\n# Evidências externas\n${evidencesBlock}`
+    : '';
 
   return `# Pergunta original
 ${question}
@@ -223,5 +351,5 @@ ${vizBlock}
 ${rowsReturned}
 
 # Dados (até 50 linhas, JSON)
-${JSON.stringify(rows.slice(0, 50))}`;
+${JSON.stringify(rows.slice(0, 50))}${evidencesSection}`;
 }

--- a/supabase/functions/assistant-chat/_lib/researcher.ts
+++ b/supabase/functions/assistant-chat/_lib/researcher.ts
@@ -1,0 +1,208 @@
+// Researcher — camada fina entre o resultado bruto da fonte externa
+// (Perplexity / API estruturada) e o fact pack do Analyst.
+//
+// Responsabilidades:
+//   1. Esquema rígido de `ExternalEvidence` (URL, data, verbatim_quote, tier).
+//   2. Validação automática (warnings + fail).
+//   3. Conversão de MarketDataResult → ExternalEvidence (caminho determinístico
+//      para fontes estruturadas — não passa pelo LLM).
+
+import { findExternalSource, ExternalSource } from "./externalSources.ts";
+import type { MarketDataResult } from "./marketData.ts";
+
+/** Hierarquia de fontes — Tier 1 prevalece em conflito. */
+export type Tier = 1 | 2 | 3 | 4;
+
+export interface ExternalEvidence {
+  source_id: string;
+  /** afirmação curta em PT-BR */
+  claim: string;
+  numeric_value: number | null;
+  numeric_unit: string | null;
+  url: string;
+  publisher: string;
+  /** ISO date — quando consultamos */
+  access_date: string;
+  /** ISO date — quando o publicador divulgou (null se desconhecido) */
+  published_at: string | null;
+  tier: Tier;
+  confidence: "high" | "medium" | "low";
+  /** trecho LITERAL de até 25 palavras */
+  verbatim_quote: string;
+  warnings: string[];
+}
+
+export interface ResearcherValidation {
+  valid: boolean;
+  issues: string[];
+}
+
+const SOURCE_TIER_OVERRIDES: Record<string, Tier> = {
+  bcb_selic: 1,
+  bcb_ipca: 1,
+  bcb_incc_m: 1,
+  bcb_cambio_usd: 1,
+  cnpj_receita: 1,
+  cub_sp: 1,
+  sinduscon_salarios: 1,
+  short_stay_lei_sp: 1,
+  alvara_sp: 1,
+  noticias_construcao: 2,
+  inside_airbnb_sp: 2,
+  mercado_aluguel_bairro: 3,
+  reclame_aqui: 3,
+  tjsp_processos: 3,
+};
+
+export function tierFor(sourceId: string): Tier {
+  return SOURCE_TIER_OVERRIDES[sourceId] ?? 3;
+}
+
+/**
+ * Converte um MarketDataResult em ExternalEvidence.
+ * Determinístico — não passa por LLM.
+ */
+export function evidenceFromMarketData(
+  m: MarketDataResult,
+): ExternalEvidence {
+  const accessDate = new Date().toISOString().slice(0, 10);
+  const tier = tierFor(m.source_id);
+  const warnings: string[] = [];
+  if (!m.latest_at) warnings.push("data_publicacao_desconhecida");
+
+  const verbatim = m.summary.length > 200
+    ? m.summary.slice(0, 200) + "…"
+    : m.summary;
+
+  return {
+    source_id: m.source_id,
+    claim: m.summary,
+    numeric_value: typeof m.numeric_value === "number" ? m.numeric_value : null,
+    numeric_unit: m.numeric_unit ?? null,
+    url: m.url,
+    publisher: m.publisher,
+    access_date: accessDate,
+    published_at: m.latest_at ?? null,
+    tier,
+    confidence: tier === 1 ? "high" : tier === 2 ? "medium" : "low",
+    verbatim_quote: verbatim,
+    warnings,
+  };
+}
+
+/**
+ * Valida uma ExternalEvidence (vinda do LLM/Perplexity ou de qualquer caminho).
+ * Issues conhecidos: sem_url, sem_data_acesso, claim_numerico_sem_valor,
+ * dado_potencialmente_desatualizado.
+ */
+export function validateExternalEvidence(
+  e: ExternalEvidence,
+): ResearcherValidation {
+  const issues: string[] = [];
+  if (!e.url) issues.push("sem_url");
+  if (!e.access_date) issues.push("sem_data_acesso");
+  if (e.numeric_value !== null && !Number.isFinite(e.numeric_value)) {
+    issues.push("numeric_value_invalido");
+  }
+
+  const source = findExternalSource(e.source_id);
+  if (source && e.published_at) {
+    const ageH = hoursSince(e.published_at);
+    if (source.recency === "daily" && ageH > 72) {
+      issues.push("dado_potencialmente_desatualizado");
+    }
+    if (source.recency === "weekly" && ageH > 24 * 14) {
+      issues.push("dado_potencialmente_desatualizado");
+    }
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+function hoursSince(iso: string): number {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - t) / 3_600_000;
+}
+
+/**
+ * System prompt do Researcher — usado quando convertemos resultado bruto
+ * da Perplexity em `ExternalEvidence`. Schema rígido evita alucinação.
+ */
+export const RESEARCHER_SYSTEM_PROMPT =
+  `Você é o **Researcher** do Assistente BWild. Sua tarefa: receber resultado bruto de uma pesquisa externa (Perplexity, API, scraping) e extrair UMA evidência estruturada e validada.
+
+# Saída obrigatória (chamar a tool extract_evidence)
+
+{
+  "source_id": "id de EXTERNAL_SOURCES",
+  "claim": "afirmação curta em PT-BR — o fato extraído",
+  "numeric_value": número | null,
+  "numeric_unit": "%" | "R$" | "horas" | "m²" | "" | null,
+  "url": "URL canônica da fonte (string obrigatória)",
+  "publisher": "nome do publicador (BCB, G1, Sinduscon...)",
+  "access_date": "ISO date — quando você consultou",
+  "published_at": "ISO date — quando o publicador divulgou (null se desconhecido)",
+  "tier": 1 | 2 | 3 | 4,
+  "confidence": "high | medium | low",
+  "verbatim_quote": "trecho LITERAL de até 25 palavras que sustenta o claim",
+  "warnings": ["potencialmente_desatualizado", "fonte_secundaria_sem_corroboracao"]
+}
+
+# Regras
+
+1. **Nunca afirme número que não está literalmente no resultado.** Se a pesquisa não trouxe número claro, "numeric_value": null e "claim" é qualitativa ("subiu", "estável").
+2. **"url" obrigatória.** Se não houver URL no resultado, "source_id" recebe sufixo "_unverified" e "tier": 4.
+3. **"verbatim_quote" é literal.** Sem paráfrase. Se o trecho original tem mais de 25 palavras, escolha a substring mais relevante.
+4. **"tier"** segue: 1=oficial (.gov.br/BCB/Sinduscon), 2=secundário (Globo/Estadão/Folha/Valor), 3=agregador (Reclame Aqui/JusBrasil/QuintoAndar), 4=não verificável.
+5. **Em conflito**, escolha Tier mais alto. Se conflito Tier 1, devolva DUAS evidências (não escolha sozinho).
+6. **Datas**: se a pesquisa não traz "published_at", vale null e adiciona warning "data_publicacao_desconhecida".
+7. **Idioma**: "claim" em PT-BR. Não traduza dado numérico.
+
+# O que NÃO fazer
+
+- Inventar fonte ("segundo dados do mercado") sem URL específica.
+- Usar conhecimento do treinamento ("sei que a Selic está em X") para preencher lacuna do resultado bruto.
+- Citar publicação genérica ("Sinduscon" sem URL específica do PDF/release).
+- Combinar duas fontes numa só evidência. Cada chamada extrai UMA evidência.`;
+
+/** Schema da tool que o LLM Researcher precisa chamar. */
+export const EXTRACT_EVIDENCE_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "extract_evidence",
+    description:
+      "Extrai UMA evidência estruturada do resultado bruto da pesquisa.",
+    parameters: {
+      type: "object",
+      properties: {
+        source_id: { type: "string" },
+        claim: { type: "string" },
+        numeric_value: { type: ["number", "null"] },
+        numeric_unit: { type: ["string", "null"] },
+        url: { type: "string" },
+        publisher: { type: "string" },
+        access_date: { type: "string" },
+        published_at: { type: ["string", "null"] },
+        tier: { type: "integer", enum: [1, 2, 3, 4] },
+        confidence: { type: "string", enum: ["high", "medium", "low"] },
+        verbatim_quote: { type: "string" },
+        warnings: { type: "array", items: { type: "string" } },
+      },
+      required: [
+        "source_id",
+        "claim",
+        "url",
+        "publisher",
+        "access_date",
+        "tier",
+        "confidence",
+        "verbatim_quote",
+        "warnings",
+      ],
+      additionalProperties: false,
+    },
+  },
+};
+
+export type { ExternalSource };

--- a/supabase/functions/assistant-chat/index.ts
+++ b/supabase/functions/assistant-chat/index.ts
@@ -11,8 +11,15 @@ import {
 import {
   SYSTEM_PROMPT,
   FORMATTER_SYSTEM_PROMPT,
+  PLANNER_EXTERNAL_DELTA,
   buildFormatterUserMessage,
+  type FormatterEvidence,
 } from './_lib/prompts.ts';
+import {
+  EXTERNAL_SOURCES,
+  renderExternalSourcesCatalog,
+} from './_lib/externalSources.ts';
+import { dispatchExternalStep } from './_lib/dispatcher.ts';
 
 const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
@@ -20,24 +27,64 @@ const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
 const MODEL = 'google/gemini-3-flash-preview';
 
 const SCHEMA_CATALOG = renderCatalog();
+const EXTERNAL_CATALOG = renderExternalSourcesCatalog();
+const VALID_SOURCE_IDS = EXTERNAL_SOURCES.map((s) => s.id);
 
+const PERPLEXITY_FN_URL = `${SUPABASE_URL}/functions/v1/perplexity-research`;
+
+// Tool schema v4: extende o generate_query do v3 com classificação interna×externa.
+// `step_type=internal` (default, comportamento legado) → SQL apenas.
+// `step_type=external` → sem SQL, só busca externa.
+// `step_type=mixed`    → SQL + busca externa em paralelo (Formatter cruza).
 const TOOL_SCHEMA = {
   type: 'function',
   function: {
     name: 'generate_query',
-    description: 'Gera a consulta SQL e o domínio para responder à pergunta do usuário.',
+    description:
+      'Gera a consulta principal para responder à pergunta. Classifica entre dado interno (SQL) e externo (mercado, regulação, fornecedor). Em pergunta cruzada, marca step_type=mixed.',
     parameters: {
       type: 'object',
       properties: {
-        sql: { type: 'string', description: 'Consulta SELECT/WITH em PostgreSQL. UMA instrução, sem ponto-e-vírgula.' },
+        step_type: {
+          type: 'string',
+          enum: ['internal', 'external', 'mixed'],
+          description:
+            "internal=só banco BWild. external=só fonte externa. mixed=banco + 1 fonte externa cruzados. Default=internal.",
+        },
+        sql: {
+          type: 'string',
+          description:
+            'Consulta SELECT/WITH em PostgreSQL. UMA instrução, sem ponto-e-vírgula. Obrigatória em internal/mixed; deixe string vazia em external.',
+        },
         domain: {
           type: 'string',
           enum: ['financeiro', 'compras', 'cronograma', 'ncs', 'pendencias', 'cs', 'obras', 'fornecedores', 'outros'],
           description: 'Domínio principal da pergunta.',
         },
         intent: { type: 'string', description: 'Resumo curto do que será consultado.' },
+        external_source_id: {
+          type: 'string',
+          description:
+            'id de EXTERNAL_SOURCES quando step_type ∈ {external,mixed}. Ex: bcb_ipca, bcb_cambio_usd, cub_sp.',
+        },
+        external_kind: {
+          type: 'string',
+          enum: ['fetch', 'web'],
+          description:
+            "fetch=API estruturada (BCB/Receita) → use external_params. web=Perplexity → use external_query.",
+        },
+        external_params: {
+          type: 'object',
+          description:
+            'Parâmetros para fetch_market_data. BCB: { n: número de pontos } (padrão 12 para séries mensais, 1 para câmbio diário). CNPJ: { cnpj: 14 dígitos }.',
+        },
+        external_query: {
+          type: 'string',
+          description:
+            'Pergunta natural em PT-BR para web_research, específica e datada.',
+        },
       },
-      required: ['sql', 'domain', 'intent'],
+      required: ['step_type', 'sql', 'domain', 'intent'],
       additionalProperties: false,
     },
   },
@@ -136,6 +183,12 @@ Deno.serve(async (req) => {
       let rows: Record<string, unknown>[] = [];
       let logId: string | null = null;
       let analysis: ReturnType<typeof buildAnalysis> | null = null;
+      let stepType: 'internal' | 'external' | 'mixed' = 'internal';
+      const evidences: FormatterEvidence[] = [];
+      let externalCalls = 0;
+      let externalCacheHits = 0;
+      let externalCostCents = 0;
+      const externalSourcesUsed: string[] = [];
 
       try {
         if (!conversationId) {
@@ -166,7 +219,12 @@ Deno.serve(async (req) => {
           .limit(10);
 
         const llmMessages = [
-          { role: 'system', content: SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG },
+          {
+            role: 'system',
+            content:
+              SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
+              '\n\n' + PLANNER_EXTERNAL_DELTA + '\n\n' + EXTERNAL_CATALOG,
+          },
           ...(history ?? []).map((m: { role: string; content: string }) => ({
             role: m.role === 'assistant' ? 'assistant' : 'user',
             content: m.content,
@@ -219,26 +277,106 @@ Deno.serve(async (req) => {
         generatedSql = (args.sql ?? '').toString();
         domain = (args.domain ?? 'outros').toString();
         intent = (args.intent ?? null);
+        stepType = (args.step_type === 'external' || args.step_type === 'mixed')
+          ? args.step_type
+          : 'internal';
+        const externalSourceId: string | undefined =
+          typeof args.external_source_id === 'string' && VALID_SOURCE_IDS.includes(args.external_source_id)
+            ? args.external_source_id
+            : undefined;
+        const externalKind: 'fetch' | 'web' | undefined =
+          args.external_kind === 'fetch' || args.external_kind === 'web' ? args.external_kind : undefined;
+        const externalParams: Record<string, unknown> = (args.external_params && typeof args.external_params === 'object')
+          ? args.external_params as Record<string, unknown>
+          : {};
+        const externalQuery: string | undefined =
+          typeof args.external_query === 'string' && args.external_query.trim().length > 0
+            ? args.external_query.trim()
+            : undefined;
 
-        send('sql', { sql: generatedSql, domain, intent });
-        send('status', { phase: 'querying', message: 'Consultando banco de dados...' });
+        send('sql', { sql: generatedSql, domain, intent, step_type: stepType, external_source_id: externalSourceId ?? null });
 
-        const { data: rpcData, error: rpcErr } = await supabase.rpc('execute_assistant_query', {
-          p_sql: generatedSql,
-        });
+        // ---- 1. Internal step (SQL) — pula em step_type='external' ------------
+        if (stepType !== 'external' && generatedSql) {
+          send('status', { phase: 'querying', message: 'Consultando banco de dados...' });
 
-        if (rpcErr) {
-          const msg = (rpcErr.message || '').toLowerCase();
-          if (msg.includes('proibido') || msg.includes('apenas') || msg.includes('multiplas') || msg.includes('blocos') || msg.includes('esquemas')) status = 'sql_blocked';
-          else if (msg.includes('timeout') || msg.includes('canceling statement')) status = 'timeout';
-          else status = 'sql_error';
-          errorMessage = rpcErr.message;
-        } else {
-          rows = Array.isArray(rpcData) ? (rpcData as Record<string, unknown>[]) : [];
-          rowsReturned = rows.length;
+          const { data: rpcData, error: rpcErr } = await supabase.rpc('execute_assistant_query', {
+            p_sql: generatedSql,
+          });
+
+          if (rpcErr) {
+            const msg = (rpcErr.message || '').toLowerCase();
+            if (msg.includes('proibido') || msg.includes('apenas') || msg.includes('multiplas') || msg.includes('blocos') || msg.includes('esquemas')) status = 'sql_blocked';
+            else if (msg.includes('timeout') || msg.includes('canceling statement')) status = 'timeout';
+            else status = 'sql_error';
+            errorMessage = rpcErr.message;
+          } else {
+            rows = Array.isArray(rpcData) ? (rpcData as Record<string, unknown>[]) : [];
+            rowsReturned = rows.length;
+          }
+        } else if (stepType === 'external') {
+          // Em external puro, não há SQL — segue para a busca externa abaixo.
+          rows = [];
+          rowsReturned = 0;
         }
 
         send('rows', { rows_returned: rowsReturned, preview: rows.slice(0, 50) });
+
+        // ---- 2. External step (mercado/regulação) — limite hard de 1 fonte ---
+        if (
+          status === 'success' &&
+          stepType !== 'internal' &&
+          externalSourceId
+        ) {
+          send('status', { phase: 'researching', message: 'Buscando dado de mercado...' });
+          externalCalls += 1;
+          externalSourcesUsed.push(externalSourceId);
+
+          const isWeb = externalKind === 'web' || (!externalKind && !externalParams.cnpj && !externalParams.n);
+          const result = await dispatchExternalStep(
+            {
+              source_id: externalSourceId,
+              params: externalParams,
+              query: externalQuery,
+            },
+            isWeb
+              ? { perplexityFnUrl: PERPLEXITY_FN_URL, authHeader: authHeader }
+              : {},
+          );
+
+          if (result.cached) externalCacheHits += 1;
+          externalCostCents += result.cost_cents;
+
+          if (result.evidence) {
+            const ev = result.evidence;
+            evidences.push({
+              source_id: ev.source_id,
+              publisher: ev.publisher,
+              claim: ev.claim,
+              url: ev.url,
+              access_date: ev.access_date,
+              published_at: ev.published_at,
+              numeric_value: ev.numeric_value,
+              numeric_unit: ev.numeric_unit,
+              tier: ev.tier,
+              warnings: ev.warnings,
+            });
+            send('evidence', {
+              source_id: ev.source_id,
+              publisher: ev.publisher,
+              claim: ev.claim,
+              url: ev.url,
+              tier: ev.tier,
+              cached: result.cached,
+            });
+          } else if (result.error) {
+            // Falha externa não derruba a sessão — degrada via Formatter.
+            send('evidence_error', {
+              source_id: externalSourceId,
+              error: result.error,
+            });
+          }
+        }
 
         if (status === 'success') {
           analysis = buildAnalysis({ rows, rowsReturned, domain, sql: generatedSql, status });
@@ -279,6 +417,7 @@ Deno.serve(async (req) => {
                   visualizations: analysis.visualizations,
                 }
               : null,
+            evidences: evidences.length ? evidences : null,
           });
 
           const formatResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
@@ -348,6 +487,10 @@ Deno.serve(async (req) => {
             status,
             error_message: errorMessage,
             answer_summary: finalAnswer.slice(0, 280),
+            external_calls_count: externalCalls,
+            external_cache_hits: externalCacheHits,
+            external_cost_cents: externalCostCents,
+            external_sources_used: externalSourcesUsed.length ? externalSourcesUsed : null,
           })
           .select('id')
           .single();
@@ -364,12 +507,14 @@ Deno.serve(async (req) => {
             sql: generatedSql,
             domain,
             status,
+            step_type: stepType,
             insights: analysis?.insights ?? null,
             data_quality: analysis?.dataQuality ?? null,
             visualizations: analysis?.visualizations ?? null,
             suggested_questions: analysis?.followUps ?? null,
             confidence: analysis?.confidence ?? null,
             limitations: analysis?.limitations ?? null,
+            evidences: evidences.length ? evidences : null,
           },
           log_id: logId,
         });
@@ -388,6 +533,7 @@ Deno.serve(async (req) => {
           domain,
           intent,
           status,
+          step_type: stepType,
           log_id: logId,
           latency_ms: Date.now() - startedAt,
           insights: analysis?.insights ?? null,
@@ -396,6 +542,7 @@ Deno.serve(async (req) => {
           suggested_questions: analysis?.followUps ?? null,
           confidence: analysis?.confidence ?? null,
           limitations: analysis?.limitations ?? null,
+          evidences: evidences.length ? evidences : null,
         });
       } catch (e) {
         console.error('[assistant-chat stream] error:', e);
@@ -477,7 +624,12 @@ async function runNonStreaming(opts: {
       body: JSON.stringify({
         model: MODEL,
         messages: [
-          { role: 'system', content: SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG },
+          {
+            role: 'system',
+            content:
+              SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
+              '\n\n' + PLANNER_EXTERNAL_DELTA + '\n\n' + EXTERNAL_CATALOG,
+          },
           ...(history ?? []).map((m: { role: string; content: string }) => ({
             role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content,
           })),
@@ -500,8 +652,16 @@ async function runNonStreaming(opts: {
     generatedSql = (args.sql ?? '').toString();
     domain = (args.domain ?? 'outros').toString();
     intent = (args.intent ?? null);
+    const stepType: 'internal' | 'external' | 'mixed' =
+      args.step_type === 'external' || args.step_type === 'mixed' ? args.step_type : 'internal';
 
-    const { data: rpcData, error: rpcErr } = await supabase.rpc('execute_assistant_query', { p_sql: generatedSql });
+    let rpcData: unknown = [];
+    let rpcErr: { message?: string } | null = null;
+    if (stepType !== 'external' && generatedSql) {
+      const r = await supabase.rpc('execute_assistant_query', { p_sql: generatedSql });
+      rpcData = r.data;
+      rpcErr = r.error;
+    }
     if (rpcErr) {
       const msg = (rpcErr.message || '').toLowerCase();
       if (msg.includes('proibido') || msg.includes('apenas')) status = 'sql_blocked';

--- a/supabase/functions/perplexity-research/index.ts
+++ b/supabase/functions/perplexity-research/index.ts
@@ -1,6 +1,89 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders, corsResponse, jsonResponse } from "../_shared/cors.ts";
 import { authenticateRequest } from "../_shared/auth.ts";
+import {
+  hashQuery,
+  lookupCache,
+  storeCache,
+} from "../_shared/externalCache.ts";
+import {
+  EXTERNAL_SOURCES,
+  findExternalSource,
+} from "../assistant-chat/_lib/externalSources.ts";
+
+const LEGACY_SYSTEM_PROMPT =
+  `Você é um consultor especialista em software de gestão de obras e reformas residenciais.
+Quando o usuário perguntar sobre funcionalidades, features ou referências de mercado, você deve:
+
+1. Pesquisar softwares reais do mercado (ex: Construct, Sienge, Prevision, Obra Prima, Procore, Buildertrend, CoConstruct, Monday.com para construção)
+2. Descrever as funcionalidades encontradas com detalhes práticos
+3. Sugerir como implementar no contexto de um portal web moderno (React + Supabase)
+4. Priorizar por impacto no cliente final (proprietário acompanhando reforma)
+5. Incluir screenshots ou URLs de referência quando disponíveis
+
+Formate a resposta em Markdown com headers, listas e destaques.
+Responda sempre em Português brasileiro.`;
+
+const V4_SYSTEM_PROMPT =
+  `Você está pesquisando dado de mercado para o Assistente BWild.
+Responda em Português brasileiro, com fatos verificáveis e URL específica para cada afirmação numérica.
+
+Regras:
+- Sempre cite a fonte primária (gov.br, BCB, Sinduscon, .org.br oficial). Evite blogs e fóruns.
+- Quando der número, traga ele LITERAL como aparece na fonte e a data da publicação.
+- Se a pesquisa não encontrar dado claro, responda "não foi possível confirmar" — NÃO invente.
+- Não use conhecimento de treinamento para preencher buracos.`;
+
+interface PerplexityResponse {
+  content: string;
+  citations: string[];
+  raw?: unknown;
+}
+
+async function callPerplexity(opts: {
+  apiKey: string;
+  systemPrompt: string;
+  userPrompt: string;
+  domainFilter?: string[];
+}): Promise<PerplexityResponse> {
+  const body: Record<string, unknown> = {
+    model: "sonar-pro",
+    messages: [
+      { role: "system", content: opts.systemPrompt },
+      { role: "user", content: opts.userPrompt },
+    ],
+  };
+  if (opts.domainFilter && opts.domainFilter.length > 0) {
+    body.search_domain_filter = opts.domainFilter;
+  }
+
+  const response = await fetch("https://api.perplexity.ai/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${opts.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const status = response.status;
+    if (status === 429) {
+      throw { status: 429, message: "Limite de requisições excedido. Tente novamente em alguns minutos." };
+    }
+    if (status === 402) {
+      throw { status: 402, message: "Créditos Perplexity insuficientes." };
+    }
+    const errorText = await response.text();
+    console.error("Perplexity API error:", status, errorText);
+    throw { status: 500, message: "Erro no serviço Perplexity" };
+  }
+
+  const data = await response.json();
+  const content = data.choices?.[0]?.message?.content || "";
+  const citations: string[] = data.citations || [];
+  return { content, citations, raw: data };
+}
 
 serve(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
@@ -8,7 +91,95 @@ serve(async (req) => {
   try {
     const { user, supabaseAdmin } = await authenticateRequest(req);
 
-    // Verify admin role
+    const PERPLEXITY_API_KEY = Deno.env.get("PERPLEXITY_API_KEY");
+    if (!PERPLEXITY_API_KEY) {
+      return jsonResponse(
+        { error: "PERPLEXITY_API_KEY não configurada. Conecte o Perplexity nas configurações." },
+        500,
+      );
+    }
+
+    const body = await req.json();
+    const query = (body?.query ?? "").toString().trim();
+    if (!query) {
+      return jsonResponse({ error: "Campo 'query' é obrigatório" }, 400);
+    }
+
+    // ---------- v4 mode: source_id presente → web_research do assistente ----------
+    if (body?.source_id) {
+      const source = findExternalSource(String(body.source_id));
+      if (!source) {
+        return jsonResponse(
+          { error: `source_id desconhecido. Use um de: ${EXTERNAL_SOURCES.map((s) => s.id).join(", ")}` },
+          400,
+        );
+      }
+      if (source.kind !== "web_search") {
+        return jsonResponse(
+          {
+            error:
+              `source ${source.id} é ${source.kind}; use fetch_market_data em vez de web_research`,
+          },
+          400,
+        );
+      }
+
+      const cacheParams = { query };
+      const queryHash = await hashQuery(source.id, cacheParams);
+      const hit = await lookupCache<PerplexityResponse>(source.id, queryHash);
+      if (hit.hit && hit.value) {
+        return jsonResponse({
+          success: true,
+          source_id: source.id,
+          cached: true,
+          fetched_at: hit.fetched_at,
+          content: hit.value.content,
+          citations: hit.value.citations,
+        });
+      }
+
+      const result = await callPerplexity({
+        apiKey: PERPLEXITY_API_KEY,
+        systemPrompt: V4_SYSTEM_PROMPT,
+        userPrompt: query,
+        domainFilter: source.perplexity_focus,
+      });
+
+      await storeCache({
+        sourceId: source.id,
+        queryHash,
+        queryRaw: cacheParams,
+        result: { content: result.content, citations: result.citations },
+        ttlHours: source.cache_ttl_hours,
+        // Perplexity sonar-pro ~= 1¢ por chamada (estimativa grossa)
+        costCents: 1,
+      });
+
+      // Telemetria opcional (não bloqueia resposta).
+      try {
+        await supabaseAdmin.from("assistant_logs").insert({
+          user_id: user.id,
+          question: `[external:${source.id}] ${query.slice(0, 240)}`,
+          domain: "external",
+          status: "success",
+          model: "perplexity-sonar-pro",
+          external_calls_count: 1,
+          external_cache_hits: 0,
+          external_cost_cents: 1,
+          external_sources_used: [source.id],
+        });
+      } catch (_) { /* swallow — telemetria não crítica */ }
+
+      return jsonResponse({
+        success: true,
+        source_id: source.id,
+        cached: false,
+        content: result.content,
+        citations: result.citations,
+      });
+    }
+
+    // ---------- legacy mode: AdminResearch (mantém comportamento atual) ----------
     const { data: roleData } = await supabaseAdmin
       .from("user_roles")
       .select("role")
@@ -21,71 +192,29 @@ serve(async (req) => {
       return jsonResponse({ error: "Acesso restrito a administradores" }, 403);
     }
 
-    const { query, searchFocus } = await req.json();
+    const searchFocus = body?.searchFocus;
+    const domainFilter = searchFocus === "international"
+      ? ["procore.com", "buildertrend.com", "coconstruct.com", "monday.com", "g2.com"]
+      : searchFocus === "national"
+      ? ["sienge.com.br", "prevision.com.br", "obraprimaapp.com.br", "construct.com.br"]
+      : undefined;
 
-    if (!query) {
-      return jsonResponse({ error: "Campo 'query' é obrigatório" }, 400);
-    }
-
-    const PERPLEXITY_API_KEY = Deno.env.get("PERPLEXITY_API_KEY");
-    if (!PERPLEXITY_API_KEY) {
-      return jsonResponse({ error: "PERPLEXITY_API_KEY não configurada. Conecte o Perplexity nas configurações." }, 500);
-    }
-
-    const systemPrompt = `Você é um consultor especialista em software de gestão de obras e reformas residenciais.
-Quando o usuário perguntar sobre funcionalidades, features ou referências de mercado, você deve:
-
-1. Pesquisar softwares reais do mercado (ex: Construct, Sienge, Prevision, Obra Prima, Procore, Buildertrend, CoConstruct, Monday.com para construção)
-2. Descrever as funcionalidades encontradas com detalhes práticos
-3. Sugerir como implementar no contexto de um portal web moderno (React + Supabase)
-4. Priorizar por impacto no cliente final (proprietário acompanhando reforma)
-5. Incluir screenshots ou URLs de referência quando disponíveis
-
-Formate a resposta em Markdown com headers, listas e destaques.
-Responda sempre em Português brasileiro.`;
-
-    const response = await fetch("https://api.perplexity.ai/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${PERPLEXITY_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "sonar-pro",
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: query },
-        ],
-        search_domain_filter: searchFocus === "international"
-          ? ["procore.com", "buildertrend.com", "coconstruct.com", "monday.com", "g2.com"]
-          : searchFocus === "national"
-          ? ["sienge.com.br", "prevision.com.br", "obraprimaapp.com.br", "construct.com.br"]
-          : undefined,
-      }),
+    const result = await callPerplexity({
+      apiKey: PERPLEXITY_API_KEY,
+      systemPrompt: LEGACY_SYSTEM_PROMPT,
+      userPrompt: query,
+      domainFilter,
     });
 
-    if (!response.ok) {
-      const status = response.status;
-      if (status === 429) {
-        return jsonResponse({ error: "Limite de requisições excedido. Tente novamente em alguns minutos." }, 429);
-      }
-      if (status === 402) {
-        return jsonResponse({ error: "Créditos Perplexity insuficientes." }, 402);
-      }
-      const errorText = await response.text();
-      console.error("Perplexity API error:", status, errorText);
-      return jsonResponse({ error: "Erro no serviço Perplexity" }, 500);
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content || "";
-    const citations = data.citations || [];
-
-    return jsonResponse({ success: true, content, citations });
+    return jsonResponse({
+      success: true,
+      content: result.content,
+      citations: result.citations,
+    });
   } catch (err) {
     console.error("perplexity-research error:", err);
-    const status = (err as any)?.status || 500;
-    const message = (err as any)?.message || "Erro interno";
+    const status = (err as { status?: number })?.status || 500;
+    const message = (err as { message?: string })?.message || "Erro interno";
     return jsonResponse({ error: message }, status);
   }
 });

--- a/supabase/migrations/20260503221236_assistant_external_cache.sql
+++ b/supabase/migrations/20260503221236_assistant_external_cache.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- Assistente BWild v4 — cache de dados externos (mercado, regulação, fornecedor)
+-- Espelho do DERIVATIONS para "fora": antes de gastar chamada de API/Perplexity,
+-- consultamos esta tabela. TTL por fonte (ver EXTERNAL_SOURCES.cache_ttl_hours).
+-- ============================================================
+
+CREATE TABLE public.assistant_external_cache (
+  id          UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  source_id   TEXT NOT NULL,
+  query_hash  TEXT NOT NULL,
+  query_raw   JSONB NOT NULL,
+  result      JSONB NOT NULL,
+  fetched_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at  TIMESTAMPTZ NOT NULL,
+  cost_cents  INTEGER,
+  CONSTRAINT uq_external_cache_lookup UNIQUE (source_id, query_hash)
+);
+
+CREATE INDEX idx_external_cache_lookup
+  ON public.assistant_external_cache(source_id, query_hash, expires_at);
+
+CREATE INDEX idx_external_cache_expires
+  ON public.assistant_external_cache(expires_at);
+
+-- O cache é consultado e gravado pela Edge Function (com service_role).
+-- Permitimos staff a ler para auditoria; ninguém escreve via PostgREST.
+ALTER TABLE public.assistant_external_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Staff view external cache"
+  ON public.assistant_external_cache FOR SELECT
+  USING (public.is_staff(auth.uid()));
+
+-- ============================================================
+-- Telemetria adicional em assistant_logs para o pipeline v4
+-- ============================================================
+
+ALTER TABLE public.assistant_logs
+  ADD COLUMN IF NOT EXISTS external_calls_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS external_cache_hits  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS external_cost_cents  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS external_sources_used JSONB;


### PR DESCRIPTION
## Summary

Implements a comprehensive external data sources system for the BWild Assistant, enabling it to fetch and validate market data, regulatory information, and supplier intelligence from official APIs and web research. This is a major architectural addition that separates internal database queries from external market research, with built-in caching and evidence validation.

## Key Changes

### New External Sources Catalog (`externalSources.ts`)
- Defines `ExternalSource` interface with 20+ pre-configured sources across 6 categories:
  - **Macro**: BCB Selic, IPCA, INCC-M, USD/BRL exchange rates
  - **Construction**: CUB-SP, Sinduscon salary surveys
  - **Real Estate**: Inside Airbnb, rental market data
  - **Suppliers**: CNPJ status, Reclame Aqui, TJSP lawsuits
  - **Regulatory**: Short-stay laws, zoning permits
  - **News**: Construction industry events
- Each source specifies: endpoint, cache TTL, confidence level, recency, and example questions
- Includes `renderExternalSourcesCatalog()` to inject source metadata into LLM prompts

### Market Data Fetching (`marketData.ts`)
- Implements structured API fetchers for official sources:
  - BCB SGS series (Selic, IPCA, INCC, exchange rates)
  - Receita Federal CNPJ lookup via publica.cnpj.ws
- Normalizes responses into `MarketDataResult` with summary, numeric values, and publication dates
- 8-second timeout protection on all HTTP calls

### Evidence Validation Layer (`researcher.ts`)
- Defines `ExternalEvidence` schema: claim, numeric value, URL, publisher, access date, tier, confidence
- Implements `validateExternalEvidence()` with automatic warnings for missing URLs, stale data, invalid numbers
- Tier system (1-4) for source credibility with overrides per source
- Deterministic conversion from `MarketDataResult` to `ExternalEvidence` (no LLM hallucination)
- Includes `RESEARCHER_SYSTEM_PROMPT` for LLM-based evidence extraction from unstructured sources

### Dispatcher Orchestrator (`dispatcher.ts`)
- Routes external steps through cache → fetch → validation pipeline
- Handles both structured APIs (`fetch_market_data`) and web research (`web_research`)
- Returns `DispatchResult` with evidence, cache hit status, and cost tracking
- Graceful error handling: returns null evidence + error string instead of throwing

### External Cache System (`externalCache.ts`)
- SHA-256 based query hashing for deterministic cache keys
- `lookupCache()` checks validity against `expires_at` before returning
- `storeCache()` writes results with TTL per source (1 hour to 30 days)
- Uses service-role client for global cache (bypasses RLS)
- Database table: `assistant_external_cache` with indexes on lookup and expiration

### Perplexity Integration (`perplexity-research/index.ts`)
- Refactored to support two modes:
  - **v4 mode** (new): `source_id` parameter routes to external catalog, applies domain filters, caches results
  - **Legacy mode**: Maintains existing AdminResearch behavior for backward compatibility
- Implements `callPerplexity()` with domain filtering and error handling (429, 402 status codes)
- Automatic cache lookup before API call; stores results with 1¢ cost estimate

### Assistant Planner Updates (`assistant-chat/index.ts`)
- Extended `generate_query` tool with `step_type` enum: `internal`, `external`, `mixed`
- New fields: `external_source_id`, `external_kind` (fetch/web), `external_params`, `external_query`
- Injects `EXTERNAL_CATALOG` and `PLANNER_EXTERNAL_DELTA` into system prompt
- Executes external steps in parallel with SQL queries when `step_type=mixed`
- Tracks telemetry: external calls count, cache hits, cost in cents, sources used

### Prompt Engineering (`prompts.ts`)
- Added `

https://claude.ai/code/session_01YaofqaB2RipPD1WWQ6qFyN