### PR TITLE
Refactor assistant chat to multi-step planning architecture (v4)

### DIFF
--- a/supabase/functions/assistant-chat/_lib/prompts.ts
+++ b/supabase/functions/assistant-chat/_lib/prompts.ts
@@ -78,38 +78,57 @@ Se a pergunta exige dado que não está no CATÁLOGO (ex: "qual a margem real po
 
 # O que retornar
 
-Você DEVE chamar a função \`generate_query\` exatamente UMA vez, com:
+Você DEVE chamar a função \`plan_query\` exatamente UMA vez, devolvendo um **plano** com 1-3 steps. As regras detalhadas do schema (steps[], step_type, final_calculation, assumptions, limite hard de 2 steps externos) estão no bloco "**Plano multi-step (v4)**" mais abaixo. A regra acima — apenas SELECT/WITH, catálogo, datas, ordenação, etc. — vale para o \`sql\` de cada step internal.
 
-- **\`sql\`**: a consulta. Limpa, comentada com \`-- comentário\` apenas em CTEs complexas (1 linha).
-- **\`domain\`**: um de \`financeiro | compras | cronograma | ncs | pendencias | cs | obras | fornecedores | outros\`. Se a pergunta cruza domínios (ex: "saldo de obras com NCs abertas"), escolha o domínio do **fato principal** (aqui: financeiro).
-- **\`intent\`**: 1 frase de até 140 caracteres explicando o que a consulta entrega e quaisquer assunções. Exemplos:
+Para perguntas simples sobre dado interno, use **1 step internal só** com \`final_calculation\` vazio. Não force decomposição.
+
+Exemplos de \`intent\` (1 frase de até 140 chars):
   - "Lista pagamentos vencidos por obra, ordenados pelo mais antigo."
-  - "Compara compras pagas neste mês vs mês anterior, agrupado por categoria. Considerei mês corrente como referência."
+  - "Compara compras pagas neste mês vs mês anterior, agrupado por categoria."
   - "Top 5 obras com maior saldo (recebido - pago). Aproximação: ignora compras pendentes não pagas."
 
 Não escreva texto fora do tool call.`;
 
 // ============================================================
-// v4 — classificação interna × externa
+// v4 — Planner multi-step (internal × external)
 // ============================================================
 //
-// Bloco anexado ao SYSTEM_PROMPT quando a pergunta pode envolver mercado.
-// Mantemos a saída como UMA tool_call (compatibilidade): a tool agora aceita
-// `step_type` ∈ {internal, external} e os campos correspondentes.
+// Bloco anexado ao SYSTEM_PROMPT que instrui o LLM a produzir um PLANO com
+// até 3 steps. Cada step é internal (SQL) ou external (BCB/Receita/Perplexity);
+// o orquestrador executa step a step e o Formatter cruza via final_calculation.
 
 export const PLANNER_EXTERNAL_DELTA =
-  `# Dados internos vs externos (v4)
+  `# Plano multi-step (v4)
 
-Para CADA pergunta, decida o passo principal:
+Em vez de UMA consulta, você produz um **plano**: lista ordenada de \`steps\` que, executados, respondem à pergunta. Cada step é \`internal\` (SQL no banco BWild) ou \`external\` (fonte do CATÁLOGO DE FONTES EXTERNAS abaixo).
 
-- **internal**: a sub-pergunta é totalmente respondível pelo banco BWild (CATÁLOGO interno).
-- **external**: a sub-pergunta exige dado de fora (CATÁLOGO DE FONTES EXTERNAS abaixo). Cite \`external_source_id\`.
+## Regras do plano
 
-Heurística: se a pergunta menciona "mercado", "média do setor", "INCC", "IPCA", "Selic", "CUB", "câmbio", "dólar", "USD", "regulação", "lei", "Airbnb", "ocupação", "preço de [bairro]", ou "fornecedor [nome] tem" → external.
+1. **Mínimo 1, máximo 3 steps.** Se a pergunta exige mais, simplifique e diga em \`assumptions\`.
+2. **Máximo 2 steps externos.** Custo de Perplexity/API explode além disso.
+3. **Cada step responde a UMA sub_question.** Sub_question deve ser auto-contida (o leitor entende sem ver as outras).
+4. **Steps independentes**, não há fan-out: o resultado do step 2 NÃO alimenta o SQL do step 3. Quem cruza os resultados é o Formatter (via \`final_calculation\`).
+5. **Em pergunta cruzada interno×externo** (ex.: "estamos cobrando acima do CUB?"): step 1 = internal (lista as obras com R$/m²), step 2 = external (CUB atual), e \`final_calculation\` descreve a comparação.
 
-Se cruza ambos (típico — "estamos cobrando acima do CUB?"): escolha como passo principal o **internal** (a base da nossa obra) e marque \`needs_external: true\` com \`external_source_id\` e \`external_query\` curtos. O orquestrador buscará o externo em paralelo e o Formatter cruzará.
+## Como decidir o tipo de step
 
-Limite: máximo 1 fonte externa por pergunta (custo). Se exigir mais, simplifique e diga em \`intent\`.`;
+- **internal**: respondível 100% pelo banco BWild (CATÁLOGO interno + DERIVATIONS). Campo obrigatório: \`sql\` (mesmas regras de SELECT/WITH do prompt principal).
+- **external**: exige dado de fora. Campos obrigatórios: \`external_source_id\` (id do CATÁLOGO DE FONTES EXTERNAS), \`external_kind\` (\`fetch\` para api_official/api_aggregator, \`web\` para web_search/web_scrape), e \`external_params\` (\`{ n: 12 }\` em séries BCB; \`{ cnpj: "14digitos" }\` em Receita) ou \`external_query\` (PT-BR específico e datado, em web_research).
+
+Heurística para escolher external: a pergunta cita "mercado", "média do setor", "INCC", "IPCA", "Selic", "CUB", "câmbio", "dólar", "USD", "regulação", "lei", "Airbnb", "ocupação", "preço de [bairro]", "Reclame Aqui", "TJSP", "alvará", "zoneamento", "notícia" → considere external.
+
+## Campos do tool \`plan_query\`
+
+- \`question_type\` — \`factual | diagnostica | comparativa | decisoria | exploratoria\`.
+- \`domain\` — domínio do FATO principal (mesmo enum do v3).
+- \`intent\` — 1 frase de até 140 caracteres explicando a leitura final.
+- \`steps[]\` — a lista ordenada (cada item com \`id\`, \`sub_question\`, \`step_type\`, e os campos de execução).
+- \`final_calculation\` — como cruzar os resultados dos steps para chegar à resposta. Pode ser vazio quando há 1 step.
+- \`assumptions[]\` — decisões do Planner ("este mês = mês corrente"; "CUB R-8 = padrão alto").
+
+## Quando há 1 step só (caminho mais comum)
+
+Não force decomposição: pergunta simples ("quanto vence esta semana") = 1 step internal, \`final_calculation\` vazio.`;
 
 export const FETCH_MARKET_DATA_TOOL = {
   type: "function" as const,
@@ -270,16 +289,45 @@ export interface FormatterEvidence {
   warnings?: string[];
 }
 
+/** Resultado de um step (interno ou externo) renderizado pro Formatter. */
+export interface FormatterStep {
+  id: number;
+  sub_question: string;
+  step_type: 'internal' | 'external';
+  /** internal: rows do SQL (até 30 linhas). */
+  rows?: Record<string, unknown>[] | null;
+  rows_returned?: number | null;
+  /** external: source_id + (claim/numeric) — a evidência completa fica em `evidences`. */
+  external_source_id?: string | null;
+  /** mensagem de erro do step quando ele falhou (sql_error, perplexity timeout, etc.). */
+  error?: string | null;
+}
+
 export function buildFormatterUserMessage(opts: {
   question: string;
   domain: string;
   intent: string | null;
+  /** Linhas agregadas (compat com v3 — primeiro step internal). */
   rows: Record<string, unknown>[];
   rowsReturned: number;
   analysis: FormatterAnalysis | null;
   evidences?: FormatterEvidence[] | null;
+  steps?: FormatterStep[] | null;
+  finalCalculation?: string | null;
+  assumptions?: string[] | null;
 }): string {
-  const { question, domain, intent, rows, rowsReturned, analysis, evidences } = opts;
+  const {
+    question,
+    domain,
+    intent,
+    rows,
+    rowsReturned,
+    analysis,
+    evidences,
+    steps,
+    finalCalculation,
+    assumptions,
+  } = opts;
 
   const insightsBlock = analysis?.insights?.length
     ? analysis.insights
@@ -323,6 +371,38 @@ export function buildFormatterUserMessage(opts: {
     ? `\n\n# Evidências externas\n${evidencesBlock}`
     : '';
 
+  const stepsBlock = steps?.length
+    ? steps
+        .map((s) => {
+          const head = `## Step ${s.id} [${s.step_type}] — ${s.sub_question}`;
+          if (s.error) return `${head}\nFALHA: ${s.error}`;
+          if (s.step_type === 'internal') {
+            const r = s.rows ?? [];
+            const preview = r.length
+              ? JSON.stringify(r.slice(0, 30))
+              : '[]';
+            return `${head}\nlinhas=${s.rows_returned ?? r.length}\ndados=${preview}`;
+          }
+          return `${head}\nfonte=${s.external_source_id ?? '—'} (ver Evidências externas)`;
+        })
+        .join('\n\n')
+    : null;
+
+  const stepsSection = stepsBlock
+    ? `\n\n# Steps executados\n${stepsBlock}`
+    : '';
+
+  const finalCalcSection = finalCalculation && finalCalculation.trim()
+    ? `\n\n# Como cruzar os steps\n${finalCalculation.trim()}`
+    : '';
+
+  const assumptionsBlock = assumptions?.length
+    ? assumptions.map((a) => `- ${a}`).join('\n')
+    : null;
+  const assumptionsSection = assumptionsBlock
+    ? `\n\n# Assunções do Planner\n${assumptionsBlock}`
+    : '';
+
   return `# Pergunta original
 ${question}
 
@@ -347,9 +427,9 @@ ${limitationsBlock}
 # Sugestões de visualização (apenas referência — não renderize, só use para guiar como apresentar)
 ${vizBlock}
 
-# Total de linhas retornadas
+# Total de linhas retornadas (step principal)
 ${rowsReturned}
 
-# Dados (até 50 linhas, JSON)
-${JSON.stringify(rows.slice(0, 50))}${evidencesSection}`;
+# Dados (até 50 linhas, JSON — step principal)
+${JSON.stringify(rows.slice(0, 50))}${stepsSection}${finalCalcSection}${assumptionsSection}${evidencesSection}`;
 }

--- a/supabase/functions/assistant-chat/index.ts
+++ b/supabase/functions/assistant-chat/index.ts
@@ -14,6 +14,7 @@ import {
   PLANNER_EXTERNAL_DELTA,
   buildFormatterUserMessage,
   type FormatterEvidence,
+  type FormatterStep,
 } from './_lib/prompts.ts';
 import {
   EXTERNAL_SOURCES,
@@ -32,59 +33,87 @@ const VALID_SOURCE_IDS = EXTERNAL_SOURCES.map((s) => s.id);
 
 const PERPLEXITY_FN_URL = `${SUPABASE_URL}/functions/v1/perplexity-research`;
 
-// Tool schema v4: extende o generate_query do v3 com classificação interna×externa.
-// `step_type=internal` (default, comportamento legado) → SQL apenas.
-// `step_type=external` → sem SQL, só busca externa.
-// `step_type=mixed`    → SQL + busca externa em paralelo (Formatter cruza).
-const TOOL_SCHEMA = {
+// Tool schema v4 multi-step: o Planner produz uma LISTA ordenada de steps.
+// Cada step é internal (SQL) ou external (BCB/Receita/Perplexity). O orquestrador
+// executa cada um e o Formatter cruza via final_calculation.
+const PLAN_TOOL = {
   type: 'function',
   function: {
-    name: 'generate_query',
+    name: 'plan_query',
     description:
-      'Gera a consulta principal para responder à pergunta. Classifica entre dado interno (SQL) e externo (mercado, regulação, fornecedor). Em pergunta cruzada, marca step_type=mixed.',
+      'Planeja a resolução da pergunta como lista ordenada de 1-3 steps. Cada step é internal (SQL no banco BWild) ou external (BCB/Receita/Perplexity). Limite hard de 2 steps externos. O Formatter cruza os resultados via final_calculation.',
     parameters: {
       type: 'object',
       properties: {
-        step_type: {
+        question_type: {
           type: 'string',
-          enum: ['internal', 'external', 'mixed'],
-          description:
-            "internal=só banco BWild. external=só fonte externa. mixed=banco + 1 fonte externa cruzados. Default=internal.",
-        },
-        sql: {
-          type: 'string',
-          description:
-            'Consulta SELECT/WITH em PostgreSQL. UMA instrução, sem ponto-e-vírgula. Obrigatória em internal/mixed; deixe string vazia em external.',
+          enum: ['factual', 'diagnostica', 'comparativa', 'decisoria', 'exploratoria'],
         },
         domain: {
           type: 'string',
           enum: ['financeiro', 'compras', 'cronograma', 'ncs', 'pendencias', 'cs', 'obras', 'fornecedores', 'outros'],
-          description: 'Domínio principal da pergunta.',
+          description: 'Domínio do FATO principal da resposta.',
         },
-        intent: { type: 'string', description: 'Resumo curto do que será consultado.' },
-        external_source_id: {
+        intent: {
+          type: 'string',
+          description: 'Resumo curto (até 140 chars) do que o plano entrega.',
+        },
+        steps: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 3,
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer', minimum: 1, maximum: 3 },
+              sub_question: {
+                type: 'string',
+                description: 'Sub-pergunta auto-contida que esse step responde.',
+              },
+              step_type: { type: 'string', enum: ['internal', 'external'] },
+              sql: {
+                type: 'string',
+                description:
+                  'PostgreSQL SELECT/WITH (mesmas regras do v3). Obrigatório se step_type=internal; ignorado em external.',
+              },
+              external_source_id: {
+                type: 'string',
+                description:
+                  'id de EXTERNAL_SOURCES (ex: bcb_ipca, bcb_cambio_usd, cub_sp). Obrigatório se step_type=external.',
+              },
+              external_kind: {
+                type: 'string',
+                enum: ['fetch', 'web'],
+                description:
+                  'fetch=API estruturada (BCB/Receita) → use external_params. web=Perplexity → use external_query.',
+              },
+              external_params: {
+                type: 'object',
+                description:
+                  'Parâmetros do endpoint para external_kind=fetch. BCB: { n: 12 }; CNPJ: { cnpj: "14digitos" }.',
+              },
+              external_query: {
+                type: 'string',
+                description:
+                  'Pergunta natural PT-BR específica e datada para external_kind=web.',
+              },
+            },
+            required: ['id', 'sub_question', 'step_type'],
+            additionalProperties: false,
+          },
+        },
+        final_calculation: {
           type: 'string',
           description:
-            'id de EXTERNAL_SOURCES quando step_type ∈ {external,mixed}. Ex: bcb_ipca, bcb_cambio_usd, cub_sp.',
+            'Como cruzar os resultados dos steps para chegar à resposta final. Vazio se há 1 step só.',
         },
-        external_kind: {
-          type: 'string',
-          enum: ['fetch', 'web'],
-          description:
-            "fetch=API estruturada (BCB/Receita) → use external_params. web=Perplexity → use external_query.",
-        },
-        external_params: {
-          type: 'object',
-          description:
-            'Parâmetros para fetch_market_data. BCB: { n: número de pontos } (padrão 12 para séries mensais, 1 para câmbio diário). CNPJ: { cnpj: 14 dígitos }.',
-        },
-        external_query: {
-          type: 'string',
-          description:
-            'Pergunta natural em PT-BR para web_research, específica e datada.',
+        assumptions: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Decisões do Planner (ex: "este mês = mês corrente").',
         },
       },
-      required: ['step_type', 'sql', 'domain', 'intent'],
+      required: ['domain', 'intent', 'steps'],
       additionalProperties: false,
     },
   },
@@ -126,6 +155,114 @@ function buildAnalysis(opts: {
   return { insights, dataQuality, visualizations, followUps, confidence, limitations };
 }
 
+// ============================================================
+// Plan validation (v4 multi-step)
+// ============================================================
+//
+// Aceita o output bruto de plan_query e devolve uma lista normalizada de
+// steps + warnings sobre tudo o que foi descartado (SQL ausente, fonte
+// externa inválida, excesso de steps externos). O orquestrador trata os
+// warnings como limitações da resposta — não derruba a sessão.
+
+interface PlanStep {
+  id: number;
+  sub_question: string;
+  step_type: 'internal' | 'external';
+  sql?: string;
+  external_source_id?: string;
+  external_kind?: 'fetch' | 'web';
+  external_params?: Record<string, unknown>;
+  external_query?: string;
+}
+
+interface NormalizedPlan {
+  steps: PlanStep[];
+  warnings: string[];
+  final_calculation: string;
+  assumptions: string[];
+  question_type: string | null;
+}
+
+function normalizePlan(args: Record<string, unknown>): NormalizedPlan {
+  const warnings: string[] = [];
+  const rawSteps = Array.isArray(args.steps) ? (args.steps as Record<string, unknown>[]) : [];
+  const accepted: PlanStep[] = [];
+  let externalCount = 0;
+
+  for (const s of rawSteps) {
+    if (accepted.length >= 3) {
+      warnings.push('plan_truncado_em_3_steps');
+      break;
+    }
+    if (!s || typeof s !== 'object') continue;
+
+    const id = Number.isFinite(Number(s.id)) ? Number(s.id) : accepted.length + 1;
+    const subQuestion = typeof s.sub_question === 'string' ? s.sub_question.trim() : '';
+    const stepType = s.step_type === 'external' ? 'external' : 'internal';
+
+    if (stepType === 'internal') {
+      const sql = typeof s.sql === 'string' ? s.sql.trim() : '';
+      if (!sql) {
+        warnings.push(`step_${id}_internal_sem_sql`);
+        continue;
+      }
+      accepted.push({ id, sub_question: subQuestion, step_type: 'internal', sql });
+      continue;
+    }
+
+    const sourceId = typeof s.external_source_id === 'string' ? s.external_source_id : '';
+    if (!VALID_SOURCE_IDS.includes(sourceId)) {
+      warnings.push(`step_${id}_source_invalida:${sourceId || 'vazio'}`);
+      continue;
+    }
+    if (externalCount >= 2) {
+      warnings.push(`step_${id}_descartado_max_2_externos`);
+      continue;
+    }
+    externalCount += 1;
+
+    const params = s.external_params && typeof s.external_params === 'object' && !Array.isArray(s.external_params)
+      ? (s.external_params as Record<string, unknown>)
+      : {};
+    const query = typeof s.external_query === 'string' && s.external_query.trim()
+      ? s.external_query.trim()
+      : undefined;
+    const kind: 'fetch' | 'web' | undefined =
+      s.external_kind === 'fetch' || s.external_kind === 'web' ? s.external_kind : undefined;
+
+    accepted.push({
+      id,
+      sub_question: subQuestion,
+      step_type: 'external',
+      external_source_id: sourceId,
+      external_kind: kind,
+      external_params: params,
+      external_query: query,
+    });
+  }
+
+  const finalCalculation = typeof args.final_calculation === 'string' ? args.final_calculation : '';
+  const assumptions = Array.isArray(args.assumptions)
+    ? (args.assumptions as unknown[]).filter((a): a is string => typeof a === 'string')
+    : [];
+  const questionType = typeof args.question_type === 'string' ? args.question_type : null;
+
+  return { steps: accepted, warnings, final_calculation: finalCalculation, assumptions, question_type: questionType };
+}
+
+/** Decide entre fetch/web quando o LLM esquece external_kind. */
+function inferExternalKind(step: PlanStep): 'fetch' | 'web' {
+  if (step.external_kind) return step.external_kind;
+  // CNPJ ou n=BCB → fetch; query string → web.
+  const params = step.external_params ?? {};
+  if ('cnpj' in params || 'n' in params) return 'fetch';
+  if (step.external_query) return 'web';
+  // Fallback pela id da fonte (bcb_*, cnpj_* são fetch).
+  const id = step.external_source_id ?? '';
+  if (id.startsWith('bcb_') || id === 'cnpj_receita') return 'fetch';
+  return 'web';
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse();
 
@@ -158,7 +295,7 @@ Deno.serve(async (req) => {
   const userId = userData.user.id;
 
   if (!wantsStream) {
-    return await runNonStreaming({ supabase, userId, question, conversationId });
+    return await runNonStreaming({ supabase, userId, question, conversationId, authHeader });
   }
 
   const stream = new ReadableStream<Uint8Array>({
@@ -183,12 +320,15 @@ Deno.serve(async (req) => {
       let rows: Record<string, unknown>[] = [];
       let logId: string | null = null;
       let analysis: ReturnType<typeof buildAnalysis> | null = null;
-      let stepType: 'internal' | 'external' | 'mixed' = 'internal';
       const evidences: FormatterEvidence[] = [];
+      const formatterSteps: FormatterStep[] = [];
+      let plan: NormalizedPlan | null = null;
+      let questionType: string | null = null;
       let externalCalls = 0;
       let externalCacheHits = 0;
       let externalCostCents = 0;
       const externalSourcesUsed: string[] = [];
+      const planLimitations: string[] = [];
 
       try {
         if (!conversationId) {
@@ -237,8 +377,8 @@ Deno.serve(async (req) => {
           body: JSON.stringify({
             model: MODEL,
             messages: llmMessages,
-            tools: [TOOL_SCHEMA],
-            tool_choice: { type: 'function', function: { name: 'generate_query' } },
+            tools: [PLAN_TOOL],
+            tool_choice: { type: 'function', function: { name: 'plan_query' } },
           }),
         });
 
@@ -269,117 +409,215 @@ Deno.serve(async (req) => {
         const toolCall = llmData?.choices?.[0]?.message?.tool_calls?.[0];
         if (!toolCall?.function?.arguments) {
           status = 'llm_error';
-          errorMessage = 'Modelo não retornou consulta';
+          errorMessage = 'Modelo não retornou plano';
           send('error', { message: errorMessage, status });
           return;
         }
         const args = JSON.parse(toolCall.function.arguments);
-        generatedSql = (args.sql ?? '').toString();
-        domain = (args.domain ?? 'outros').toString();
-        intent = (args.intent ?? null);
-        stepType = (args.step_type === 'external' || args.step_type === 'mixed')
-          ? args.step_type
-          : 'internal';
-        const externalSourceId: string | undefined =
-          typeof args.external_source_id === 'string' && VALID_SOURCE_IDS.includes(args.external_source_id)
-            ? args.external_source_id
-            : undefined;
-        const externalKind: 'fetch' | 'web' | undefined =
-          args.external_kind === 'fetch' || args.external_kind === 'web' ? args.external_kind : undefined;
-        const externalParams: Record<string, unknown> = (args.external_params && typeof args.external_params === 'object')
-          ? args.external_params as Record<string, unknown>
-          : {};
-        const externalQuery: string | undefined =
-          typeof args.external_query === 'string' && args.external_query.trim().length > 0
-            ? args.external_query.trim()
-            : undefined;
+        domain = typeof args.domain === 'string' ? args.domain : 'outros';
+        intent = typeof args.intent === 'string' ? args.intent : null;
+        plan = normalizePlan(args);
+        questionType = plan.question_type;
 
-        send('sql', { sql: generatedSql, domain, intent, step_type: stepType, external_source_id: externalSourceId ?? null });
+        if (plan.steps.length === 0) {
+          status = 'llm_error';
+          errorMessage = 'Plano sem steps válidos';
+          send('error', { message: errorMessage, status, plan_warnings: plan.warnings });
+          return;
+        }
 
-        // ---- 1. Internal step (SQL) — pula em step_type='external' ------------
-        if (stepType !== 'external' && generatedSql) {
-          send('status', { phase: 'querying', message: 'Consultando banco de dados...' });
+        const internalSteps = plan.steps.filter((s) => s.step_type === 'internal');
 
-          const { data: rpcData, error: rpcErr } = await supabase.rpc('execute_assistant_query', {
-            p_sql: generatedSql,
+        // SQL "principal" usado em logs/insights = primeiro step internal (compat v3).
+        // Se há vários, concatenamos com comentário para visibilidade no log.
+        generatedSql = internalSteps.length
+          ? internalSteps.map((s) => `-- step ${s.id}: ${s.sub_question}\n${s.sql}`).join('\n\n;\n\n')
+          : null;
+
+        send('plan', {
+          domain,
+          intent,
+          question_type: questionType,
+          final_calculation: plan.final_calculation,
+          assumptions: plan.assumptions,
+          warnings: plan.warnings,
+          steps: plan.steps.map((s) => ({
+            id: s.id,
+            sub_question: s.sub_question,
+            step_type: s.step_type,
+            sql: s.sql ?? null,
+            external_source_id: s.external_source_id ?? null,
+          })),
+        });
+
+        // Compat: emit `sql` event como antes para clientes legados.
+        if (generatedSql) {
+          send('sql', { sql: generatedSql, domain, intent });
+        }
+
+        if (plan.warnings.length) {
+          for (const w of plan.warnings) planLimitations.push(`Plano ajustado: ${w}`);
+        }
+
+        // ---- Loop dos steps -------------------------------------------------
+        for (const step of plan.steps) {
+          send('step_start', {
+            id: step.id,
+            sub_question: step.sub_question,
+            step_type: step.step_type,
           });
 
-          if (rpcErr) {
-            const msg = (rpcErr.message || '').toLowerCase();
-            if (msg.includes('proibido') || msg.includes('apenas') || msg.includes('multiplas') || msg.includes('blocos') || msg.includes('esquemas')) status = 'sql_blocked';
-            else if (msg.includes('timeout') || msg.includes('canceling statement')) status = 'timeout';
-            else status = 'sql_error';
-            errorMessage = rpcErr.message;
-          } else {
-            rows = Array.isArray(rpcData) ? (rpcData as Record<string, unknown>[]) : [];
-            rowsReturned = rows.length;
+          if (step.step_type === 'internal' && step.sql) {
+            send('status', { phase: 'querying', message: `Consultando banco (step ${step.id})...` });
+            const { data: rpcData, error: rpcErr } = await supabase.rpc('execute_assistant_query', {
+              p_sql: step.sql,
+            });
+
+            if (rpcErr) {
+              const msg = (rpcErr.message || '').toLowerCase();
+              const stepStatus: typeof status =
+                msg.includes('proibido') || msg.includes('apenas') || msg.includes('multiplas') || msg.includes('blocos') || msg.includes('esquemas')
+                  ? 'sql_blocked'
+                  : msg.includes('timeout') || msg.includes('canceling statement')
+                  ? 'timeout'
+                  : 'sql_error';
+
+              formatterSteps.push({
+                id: step.id,
+                sub_question: step.sub_question,
+                step_type: 'internal',
+                rows: [],
+                rows_returned: 0,
+                error: rpcErr.message,
+              });
+              send('step_result', {
+                id: step.id,
+                step_type: 'internal',
+                error: rpcErr.message,
+                status: stepStatus,
+              });
+
+              // Falha do PRIMEIRO step internal = falha da resposta. Falha de
+              // step subsequente = degradação (Formatter informa "step X falhou").
+              if (rows.length === 0 && rowsReturned === 0 && status === 'success') {
+                status = stepStatus;
+                errorMessage = rpcErr.message;
+                break;
+              }
+              continue;
+            }
+
+            const stepRows = Array.isArray(rpcData) ? (rpcData as Record<string, unknown>[]) : [];
+            formatterSteps.push({
+              id: step.id,
+              sub_question: step.sub_question,
+              step_type: 'internal',
+              rows: stepRows,
+              rows_returned: stepRows.length,
+            });
+            // Linhas "principais" para insights/analysis = primeiro internal step.
+            if (rows.length === 0 && rowsReturned === 0) {
+              rows = stepRows;
+              rowsReturned = stepRows.length;
+            }
+            send('step_result', {
+              id: step.id,
+              step_type: 'internal',
+              rows_returned: stepRows.length,
+              preview: stepRows.slice(0, 30),
+            });
+            continue;
           }
-        } else if (stepType === 'external') {
-          // Em external puro, não há SQL — segue para a busca externa abaixo.
-          rows = [];
-          rowsReturned = 0;
+
+          if (step.step_type === 'external' && step.external_source_id) {
+            send('status', { phase: 'researching', message: `Buscando dado externo (step ${step.id})...` });
+            externalCalls += 1;
+            externalSourcesUsed.push(step.external_source_id);
+
+            const isWeb = inferExternalKind(step) === 'web';
+            const result = await dispatchExternalStep(
+              {
+                source_id: step.external_source_id,
+                params: step.external_params,
+                query: step.external_query,
+              },
+              isWeb
+                ? { perplexityFnUrl: PERPLEXITY_FN_URL, authHeader }
+                : {},
+            );
+
+            if (result.cached) externalCacheHits += 1;
+            externalCostCents += result.cost_cents;
+
+            if (result.evidence) {
+              const ev = result.evidence;
+              evidences.push({
+                source_id: ev.source_id,
+                publisher: ev.publisher,
+                claim: ev.claim,
+                url: ev.url,
+                access_date: ev.access_date,
+                published_at: ev.published_at,
+                numeric_value: ev.numeric_value,
+                numeric_unit: ev.numeric_unit,
+                tier: ev.tier,
+                warnings: ev.warnings,
+              });
+              formatterSteps.push({
+                id: step.id,
+                sub_question: step.sub_question,
+                step_type: 'external',
+                external_source_id: step.external_source_id,
+              });
+              send('step_result', {
+                id: step.id,
+                step_type: 'external',
+                external_source_id: ev.source_id,
+                publisher: ev.publisher,
+                claim: ev.claim,
+                url: ev.url,
+                tier: ev.tier,
+                cached: result.cached,
+              });
+              // Compat: também emite o evento `evidence` legado.
+              send('evidence', {
+                source_id: ev.source_id,
+                publisher: ev.publisher,
+                claim: ev.claim,
+                url: ev.url,
+                tier: ev.tier,
+                cached: result.cached,
+              });
+            } else {
+              const errMsg = result.error ?? 'fonte externa indisponível';
+              formatterSteps.push({
+                id: step.id,
+                sub_question: step.sub_question,
+                step_type: 'external',
+                external_source_id: step.external_source_id,
+                error: errMsg,
+              });
+              send('step_result', {
+                id: step.id,
+                step_type: 'external',
+                external_source_id: step.external_source_id,
+                error: errMsg,
+              });
+              send('evidence_error', {
+                source_id: step.external_source_id,
+                error: errMsg,
+              });
+              planLimitations.push(`Step ${step.id} (externo): ${errMsg}`);
+            }
+          }
         }
 
+        // Compat: emit `rows` agregado depois dos steps internos.
         send('rows', { rows_returned: rowsReturned, preview: rows.slice(0, 50) });
-
-        // ---- 2. External step (mercado/regulação) — limite hard de 1 fonte ---
-        if (
-          status === 'success' &&
-          stepType !== 'internal' &&
-          externalSourceId
-        ) {
-          send('status', { phase: 'researching', message: 'Buscando dado de mercado...' });
-          externalCalls += 1;
-          externalSourcesUsed.push(externalSourceId);
-
-          const isWeb = externalKind === 'web' || (!externalKind && !externalParams.cnpj && !externalParams.n);
-          const result = await dispatchExternalStep(
-            {
-              source_id: externalSourceId,
-              params: externalParams,
-              query: externalQuery,
-            },
-            isWeb
-              ? { perplexityFnUrl: PERPLEXITY_FN_URL, authHeader: authHeader }
-              : {},
-          );
-
-          if (result.cached) externalCacheHits += 1;
-          externalCostCents += result.cost_cents;
-
-          if (result.evidence) {
-            const ev = result.evidence;
-            evidences.push({
-              source_id: ev.source_id,
-              publisher: ev.publisher,
-              claim: ev.claim,
-              url: ev.url,
-              access_date: ev.access_date,
-              published_at: ev.published_at,
-              numeric_value: ev.numeric_value,
-              numeric_unit: ev.numeric_unit,
-              tier: ev.tier,
-              warnings: ev.warnings,
-            });
-            send('evidence', {
-              source_id: ev.source_id,
-              publisher: ev.publisher,
-              claim: ev.claim,
-              url: ev.url,
-              tier: ev.tier,
-              cached: result.cached,
-            });
-          } else if (result.error) {
-            // Falha externa não derruba a sessão — degrada via Formatter.
-            send('evidence_error', {
-              source_id: externalSourceId,
-              error: result.error,
-            });
-          }
-        }
 
         if (status === 'success') {
           analysis = buildAnalysis({ rows, rowsReturned, domain, sql: generatedSql, status });
+          if (planLimitations.length) analysis.limitations.push(...planLimitations);
           send('analysis', {
             insights: analysis.insights,
             data_quality: analysis.dataQuality,
@@ -418,6 +656,9 @@ Deno.serve(async (req) => {
                 }
               : null,
             evidences: evidences.length ? evidences : null,
+            steps: formatterSteps.length ? formatterSteps : null,
+            finalCalculation: plan?.final_calculation ?? null,
+            assumptions: plan?.assumptions ?? null,
           });
 
           const formatResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
@@ -507,7 +748,15 @@ Deno.serve(async (req) => {
             sql: generatedSql,
             domain,
             status,
-            step_type: stepType,
+            question_type: questionType,
+            steps: formatterSteps.length
+              ? formatterSteps.map((s) => ({
+                  ...s,
+                  rows: s.rows ? s.rows.slice(0, 30) : s.rows,
+                }))
+              : null,
+            final_calculation: plan?.final_calculation ?? null,
+            assumptions: plan?.assumptions ?? null,
             insights: analysis?.insights ?? null,
             data_quality: analysis?.dataQuality ?? null,
             visualizations: analysis?.visualizations ?? null,
@@ -533,7 +782,15 @@ Deno.serve(async (req) => {
           domain,
           intent,
           status,
-          step_type: stepType,
+          question_type: questionType,
+          steps: formatterSteps.length
+            ? formatterSteps.map((s) => ({
+                ...s,
+                rows: s.rows ? s.rows.slice(0, 30) : s.rows,
+              }))
+            : null,
+          final_calculation: plan?.final_calculation ?? null,
+          assumptions: plan?.assumptions ?? null,
           log_id: logId,
           latency_ms: Date.now() - startedAt,
           insights: analysis?.insights ?? null,
@@ -581,8 +838,9 @@ async function runNonStreaming(opts: {
   userId: string;
   question: string;
   conversationId: string | null;
+  authHeader: string;
 }): Promise<Response> {
-  const { supabase, userId, question } = opts;
+  const { supabase, userId, question, authHeader } = opts;
   let { conversationId } = opts;
   const startedAt = Date.now();
   let generatedSql: string | null = null;
@@ -595,6 +853,15 @@ async function runNonStreaming(opts: {
   let tokensOut = 0;
   let finalAnswer = '';
   let rows: Record<string, unknown>[] = [];
+  let plan: NormalizedPlan | null = null;
+  let questionType: string | null = null;
+  const evidences: FormatterEvidence[] = [];
+  const formatterSteps: FormatterStep[] = [];
+  let externalCalls = 0;
+  let externalCacheHits = 0;
+  let externalCostCents = 0;
+  const externalSourcesUsed: string[] = [];
+  const planLimitations: string[] = [];
 
   try {
     if (!conversationId) {
@@ -634,8 +901,8 @@ async function runNonStreaming(opts: {
             role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content,
           })),
         ],
-        tools: [TOOL_SCHEMA],
-        tool_choice: { type: 'function', function: { name: 'generate_query' } },
+        tools: [PLAN_TOOL],
+        tool_choice: { type: 'function', function: { name: 'plan_query' } },
       }),
     });
 
@@ -647,35 +914,125 @@ async function runNonStreaming(opts: {
     tokensIn += llmData?.usage?.prompt_tokens ?? 0;
     tokensOut += llmData?.usage?.completion_tokens ?? 0;
     const toolCall = llmData?.choices?.[0]?.message?.tool_calls?.[0];
-    if (!toolCall?.function?.arguments) throw new Error('Modelo não retornou consulta');
+    if (!toolCall?.function?.arguments) throw new Error('Modelo não retornou plano');
     const args = JSON.parse(toolCall.function.arguments);
-    generatedSql = (args.sql ?? '').toString();
-    domain = (args.domain ?? 'outros').toString();
-    intent = (args.intent ?? null);
-    const stepType: 'internal' | 'external' | 'mixed' =
-      args.step_type === 'external' || args.step_type === 'mixed' ? args.step_type : 'internal';
+    domain = typeof args.domain === 'string' ? args.domain : 'outros';
+    intent = typeof args.intent === 'string' ? args.intent : null;
+    plan = normalizePlan(args);
+    questionType = plan.question_type;
 
-    let rpcData: unknown = [];
-    let rpcErr: { message?: string } | null = null;
-    if (stepType !== 'external' && generatedSql) {
-      const r = await supabase.rpc('execute_assistant_query', { p_sql: generatedSql });
-      rpcData = r.data;
-      rpcErr = r.error;
+    if (plan.steps.length === 0) {
+      return jsonResponse(
+        { error: 'Plano sem steps válidos', status: 'llm_error', plan_warnings: plan.warnings },
+        502,
+      );
     }
-    if (rpcErr) {
-      const msg = (rpcErr.message || '').toLowerCase();
-      if (msg.includes('proibido') || msg.includes('apenas')) status = 'sql_blocked';
-      else if (msg.includes('timeout')) status = 'timeout';
-      else status = 'sql_error';
-      errorMessage = rpcErr.message;
-    } else {
-      rows = Array.isArray(rpcData) ? (rpcData as Record<string, unknown>[]) : [];
-      rowsReturned = rows.length;
+
+    if (plan.warnings.length) {
+      for (const w of plan.warnings) planLimitations.push(`Plano ajustado: ${w}`);
+    }
+
+    const internalSteps = plan.steps.filter((s) => s.step_type === 'internal');
+    generatedSql = internalSteps.length
+      ? internalSteps.map((s) => `-- step ${s.id}: ${s.sub_question}\n${s.sql}`).join('\n\n;\n\n')
+      : null;
+
+    for (const step of plan.steps) {
+      if (step.step_type === 'internal' && step.sql) {
+        const r = await supabase.rpc('execute_assistant_query', { p_sql: step.sql });
+        if (r.error) {
+          const msg = (r.error.message || '').toLowerCase();
+          const stepStatus: typeof status =
+            msg.includes('proibido') || msg.includes('apenas')
+              ? 'sql_blocked'
+              : msg.includes('timeout')
+              ? 'timeout'
+              : 'sql_error';
+
+          formatterSteps.push({
+            id: step.id,
+            sub_question: step.sub_question,
+            step_type: 'internal',
+            rows: [],
+            rows_returned: 0,
+            error: r.error.message,
+          });
+          if (rows.length === 0 && rowsReturned === 0 && status === 'success') {
+            status = stepStatus;
+            errorMessage = r.error.message;
+            break;
+          }
+          continue;
+        }
+        const stepRows = Array.isArray(r.data) ? (r.data as Record<string, unknown>[]) : [];
+        formatterSteps.push({
+          id: step.id,
+          sub_question: step.sub_question,
+          step_type: 'internal',
+          rows: stepRows,
+          rows_returned: stepRows.length,
+        });
+        if (rows.length === 0 && rowsReturned === 0) {
+          rows = stepRows;
+          rowsReturned = stepRows.length;
+        }
+        continue;
+      }
+
+      if (step.step_type === 'external' && step.external_source_id) {
+        externalCalls += 1;
+        externalSourcesUsed.push(step.external_source_id);
+        const isWeb = inferExternalKind(step) === 'web';
+        const result = await dispatchExternalStep(
+          {
+            source_id: step.external_source_id,
+            params: step.external_params,
+            query: step.external_query,
+          },
+          isWeb ? { perplexityFnUrl: PERPLEXITY_FN_URL, authHeader } : {},
+        );
+
+        if (result.cached) externalCacheHits += 1;
+        externalCostCents += result.cost_cents;
+
+        if (result.evidence) {
+          const ev = result.evidence;
+          evidences.push({
+            source_id: ev.source_id,
+            publisher: ev.publisher,
+            claim: ev.claim,
+            url: ev.url,
+            access_date: ev.access_date,
+            published_at: ev.published_at,
+            numeric_value: ev.numeric_value,
+            numeric_unit: ev.numeric_unit,
+            tier: ev.tier,
+            warnings: ev.warnings,
+          });
+          formatterSteps.push({
+            id: step.id,
+            sub_question: step.sub_question,
+            step_type: 'external',
+            external_source_id: step.external_source_id,
+          });
+        } else {
+          const errMsg = result.error ?? 'fonte externa indisponível';
+          formatterSteps.push({
+            id: step.id,
+            sub_question: step.sub_question,
+            step_type: 'external',
+            external_source_id: step.external_source_id,
+            error: errMsg,
+          });
+          planLimitations.push(`Step ${step.id} (externo): ${errMsg}`);
+        }
+      }
     }
 
     let analysis: ReturnType<typeof buildAnalysis> | null = null;
     if (status === 'success') {
       analysis = buildAnalysis({ rows, rowsReturned, domain, sql: generatedSql, status });
+      if (planLimitations.length) analysis.limitations.push(...planLimitations);
     }
 
     if (status !== 'success') {
@@ -696,6 +1053,10 @@ async function runNonStreaming(opts: {
               visualizations: analysis.visualizations,
             }
           : null,
+        evidences: evidences.length ? evidences : null,
+        steps: formatterSteps.length ? formatterSteps : null,
+        finalCalculation: plan?.final_calculation ?? null,
+        assumptions: plan?.assumptions ?? null,
       });
 
       const formatResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
@@ -722,6 +1083,10 @@ async function runNonStreaming(opts: {
         generated_sql: generatedSql, domain, rows_returned: rowsReturned,
         latency_ms: Date.now() - startedAt, tokens_input: tokensIn, tokens_output: tokensOut,
         model: MODEL, status, error_message: errorMessage, answer_summary: finalAnswer.slice(0, 280),
+        external_calls_count: externalCalls,
+        external_cache_hits: externalCacheHits,
+        external_cost_cents: externalCostCents,
+        external_sources_used: externalSourcesUsed.length ? externalSourcesUsed : null,
       })
       .select('id')
       .single();
@@ -735,12 +1100,22 @@ async function runNonStreaming(opts: {
         sql: generatedSql,
         domain,
         status,
+        question_type: questionType,
+        steps: formatterSteps.length
+          ? formatterSteps.map((s) => ({
+              ...s,
+              rows: s.rows ? s.rows.slice(0, 30) : s.rows,
+            }))
+          : null,
+        final_calculation: plan?.final_calculation ?? null,
+        assumptions: plan?.assumptions ?? null,
         insights: analysis?.insights ?? null,
         data_quality: analysis?.dataQuality ?? null,
         visualizations: analysis?.visualizations ?? null,
         suggested_questions: analysis?.followUps ?? null,
         confidence: analysis?.confidence ?? null,
         limitations: analysis?.limitations ?? null,
+        evidences: evidences.length ? evidences : null,
       },
       log_id: logRow?.id ?? null,
     });
@@ -752,12 +1127,22 @@ async function runNonStreaming(opts: {
       rows: rows.slice(0, 50), rows_returned: rowsReturned,
       sql: generatedSql, domain, intent, status, log_id: logRow?.id ?? null,
       latency_ms: Date.now() - startedAt,
+      question_type: questionType,
+      steps: formatterSteps.length
+        ? formatterSteps.map((s) => ({
+            ...s,
+            rows: s.rows ? s.rows.slice(0, 30) : s.rows,
+          }))
+        : null,
+      final_calculation: plan?.final_calculation ?? null,
+      assumptions: plan?.assumptions ?? null,
       insights: analysis?.insights ?? null,
       data_quality: analysis?.dataQuality ?? null,
       visualizations: analysis?.visualizations ?? null,
       suggested_questions: analysis?.followUps ?? null,
       confidence: analysis?.confidence ?? null,
       limitations: analysis?.limitations ?? null,
+      evidences: evidences.length ? evidences : null,
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);

--- a/supabase/functions/assistant-chat/index.ts
+++ b/supabase/functions/assistant-chat/index.ts
@@ -329,6 +329,11 @@ Deno.serve(async (req) => {
       let externalCostCents = 0;
       const externalSourcesUsed: string[] = [];
       const planLimitations: string[] = [];
+      // Marca quando o PRIMEIRO step internal já produziu resultado (mesmo
+      // que zero linhas). Sem essa flag, um first-step com 0 linhas seguido
+      // de um segundo step que falha seria tratado erroneamente como falha
+      // de primeiro step (e abortaria a resposta).
+      let mainInternalRecorded = false;
 
       try {
         if (!conversationId) {
@@ -499,7 +504,7 @@ Deno.serve(async (req) => {
 
               // Falha do PRIMEIRO step internal = falha da resposta. Falha de
               // step subsequente = degradação (Formatter informa "step X falhou").
-              if (rows.length === 0 && rowsReturned === 0 && status === 'success') {
+              if (!mainInternalRecorded && status === 'success') {
                 status = stepStatus;
                 errorMessage = rpcErr.message;
                 break;
@@ -515,10 +520,12 @@ Deno.serve(async (req) => {
               rows: stepRows,
               rows_returned: stepRows.length,
             });
-            // Linhas "principais" para insights/analysis = primeiro internal step.
-            if (rows.length === 0 && rowsReturned === 0) {
+            // Linhas "principais" para insights/analysis = primeiro internal step
+            // que executou (mesmo que tenha vindo vazio).
+            if (!mainInternalRecorded) {
               rows = stepRows;
               rowsReturned = stepRows.length;
+              mainInternalRecorded = true;
             }
             send('step_result', {
               id: step.id,
@@ -862,6 +869,9 @@ async function runNonStreaming(opts: {
   let externalCostCents = 0;
   const externalSourcesUsed: string[] = [];
   const planLimitations: string[] = [];
+  // Mesma flag explicitada do handler streaming — distingue "primeiro step
+  // ainda não rodou" de "primeiro step rodou e retornou zero linhas".
+  let mainInternalRecorded = false;
 
   try {
     if (!conversationId) {
@@ -957,7 +967,7 @@ async function runNonStreaming(opts: {
             rows_returned: 0,
             error: r.error.message,
           });
-          if (rows.length === 0 && rowsReturned === 0 && status === 'success') {
+          if (!mainInternalRecorded && status === 'success') {
             status = stepStatus;
             errorMessage = r.error.message;
             break;
@@ -972,9 +982,10 @@ async function runNonStreaming(opts: {
           rows: stepRows,
           rows_returned: stepRows.length,
         });
-        if (rows.length === 0 && rowsReturned === 0) {
+        if (!mainInternalRecorded) {
           rows = stepRows;
           rowsReturned = stepRows.length;
+          mainInternalRecorded = true;
         }
         continue;
       }


### PR DESCRIPTION
## Summary

Refactors the assistant chat function from a single-step query model (v3) to a multi-step planning architecture (v4). The Planner now produces an ordered list of 1-3 steps (internal SQL or external data sources), which the orchestrator executes sequentially, and the Formatter crosses results via `final_calculation`.

## Key Changes

- **Tool schema redesign**: Replaced `generate_query` with `plan_query` that returns a structured plan with multiple steps instead of a single query
  - Each step is typed as `internal` (SQL) or `external` (BCB/Receita/Perplexity)
  - Hard limit of 2 external steps per plan
  - Added `question_type`, `final_calculation`, and `assumptions` fields

- **Plan validation**: Introduced `normalizePlan()` function to validate and normalize LLM output
  - Filters invalid steps (missing SQL, invalid external sources)
  - Tracks warnings for degraded execution paths
  - Infers `external_kind` (fetch vs web) when LLM omits it

- **Step-by-step execution**: Refactored both streaming and non-streaming paths to loop through plan steps
  - Internal steps execute SQL queries via RPC
  - External steps dispatch to market data or Perplexity APIs
  - Failures in subsequent steps degrade gracefully (don't break the response)
  - First internal step failure still terminates execution

- **Enhanced telemetry**: Added tracking for:
  - `formatterSteps`: structured results from each step (rows, errors, evidence)
  - `planLimitations`: warnings about plan adjustments
  - External call metrics (count, cache hits, cost)
  - `question_type` classification

- **Backward compatibility**: 
  - Emits legacy `sql` and `evidence` events for older clients
  - Aggregates first internal step rows for `rows` event
  - Maintains same response structure with new fields nested

- **Prompt updates**: Updated `PLANNER_EXTERNAL_DELTA` to document multi-step planning rules, step independence, and decision heuristics for internal vs external classification

## Implementation Details

- `PlanStep` interface defines the structure of each step with conditional required fields
- `NormalizedPlan` wraps validated steps with warnings and metadata
- `inferExternalKind()` heuristic: checks params (cnpj/n → fetch) or query string (→ web), falls back to source_id prefix
- Plan limitations are appended to analysis limitations for final response
- Both `runStreaming` and `runNonStreaming` paths updated in parallel to maintain feature parity

https://claude.ai/code/session_01PzvFGqgLWdvV5k76bfNVZ8