### PR TITLE
feat(cockpit): aprovação tácita rastreável e ajustes de detecção (#18)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,6 +324,29 @@ docErrors.capture(error, { action: 'delete' });
 
 Para padrões detalhados de segurança, checklists obrigatórios antes de iniciar novos módulos e templates de RPCs de transição de estado, consulte **[docs/SECURITY_PATTERNS.md](./SECURITY_PATTERNS.md)**.
 
+## Cockpit de Decisão (JTBD)
+
+O *Cockpit de Decisão* responde, no topo de cada superfície, a única pergunta que importa: **"o que eu preciso fazer agora?"**. O padrão evita que o usuário tenha que navegar 3 níveis para descobrir o que está bloqueado.
+
+### Camadas
+
+| Camada | Onde mora | Função |
+| --- | --- | --- |
+| **Hook agregador** | `src/hooks/useNextActions.ts` | Combina `usePendencias`, `useClientDashboard` e `useFormalizacoes` em uma lista ranqueada (atraso > tácita > pagamento > aprovação), corta em 3 itens. Função pura `rankNextActions()` é testável isoladamente. |
+| **Bloco de UI** | `src/components/cockpit/NextActionsBlock.tsx` | Renderiza ≤3 cards com `StatusBadge` + CTA primário. Estado vazio é "Tudo em dia" (não some — preserva canal de confiança). Mobile-first: CTAs com `min-height: 44px`. |
+| **Tracking** | `src/lib/amplitude.ts` | Eventos `next_action_displayed` e `next_action_clicked` com payload `{ type, urgency, owner }`. Disparados pelo `NextActionsBlock` no mount e nos cliques. |
+| **Painel staff** | `src/pages/PainelObras.tsx` | `MetricRail` no topo + dot semântico na primeira coluna ("Sinal"). KPIs filtram a tabela via `useSearchParams`. Cor vermelha apenas no dot — nunca na linha inteira. |
+
+### Aprovação tácita rastreável
+
+A aprovação tácita do projeto executivo (cliente silente além do prazo contratual) é tratada como evento jurídico — não pode depender do front-end:
+
+1. **Trigger DB** `log_executive_tacit_approval` (`supabase/migrations/20260504061500_executive_tacit_approval_event.sql`) detecta `project_documents.status='approved' AND approved_by IS NULL` para `document_type='executive_project'` e insere `domain_events` row com `event_type='executive.tacit_approval'` carregando `{ document_id, document_hash, deadline_iso, days_silent, document_version, document_name }`.
+2. **Banner UI** `TacitApprovalNotice` em `src/pages/Executivo.tsx` consome `approved_at`/`checksum`/`created_at` do documento e exibe o texto humano: *"Aprovação automática registrada em DD/MM às HH:MM porque o prazo contratual de X dias venceu sem manifestação."* Mobile e desktop recebem o mesmo payload (paridade obrigatória).
+3. **`EVENT_TYPES.EXECUTIVE_TACIT_APPROVAL`** (`src/hooks/useDomainEvents.ts`) padroniza o tipo do evento para a `ActivityTimeline` e auditorias futuras.
+
+> **Regra de ouro:** quando a operação tem implicação jurídica (tácita, formalização, NC), a fonte da verdade é o trigger DB, não o front. Componentes apenas refletem o que o banco já registrou.
+
 ## Próximos Passos
 
 1. Migrar hooks legados para TanStack Query pattern

--- a/src/hooks/useDomainEvents.ts
+++ b/src/hooks/useDomainEvents.ts
@@ -18,6 +18,9 @@ export const EVENT_TYPES = {
   DOCUMENT_UPLOADED: 'document.uploaded',
   DOCUMENT_VERSION_UPLOADED: 'document.version_uploaded',
   DOCUMENT_APPROVED: 'document.approved',
+
+  // Executive project — tacit approval (sem manifestação no prazo contratual)
+  EXECUTIVE_TACIT_APPROVAL: 'executive.tacit_approval',
   
   // Payments
   PAYMENT_CREATED: 'payment.created',

--- a/src/pages/Executivo.tsx
+++ b/src/pages/Executivo.tsx
@@ -13,7 +13,7 @@ import { ExecutivoVersionsModal } from "@/components/executivo/ExecutivoVersions
 import { RelatedDocPDFModal } from "@/components/executivo/RelatedDocPDFModal";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ProjectSubNav } from "@/components/layout/ProjectSubNav";
-import { format, parseISO } from "date-fns";
+import { differenceInCalendarDays, format, parseISO } from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 // ── Tacit Approval Banner ──────────────────────────────────────────────
@@ -203,6 +203,29 @@ const Executivo = () => {
   const artDoc = getLatestByCategory('art_rrt')[0];
   const planoReformaDoc = getLatestByCategory('plano_reforma')[0];
 
+  // Aprovação tácita = aprovado sem actor humano (approved_by IS NULL).
+  // Aprovação manual também marca approved_at, então não basta olhar status.
+  const isTacitApproval = useMemo(() => {
+    if (!executivoDoc) return false;
+    return executivoDoc.status === 'approved'
+      && !!executivoDoc.approved_at
+      && !executivoDoc.approved_by;
+  }, [executivoDoc]);
+
+  // Proxy de "dias silentes": intervalo entre upload e aprovação tácita —
+  // mesmo cálculo usado pelo trigger DB log_executive_tacit_approval para
+  // garantir paridade visual com o domain_event registrado.
+  const tacitDaysSilent = useMemo(() => {
+    if (!isTacitApproval || !executivoDoc?.created_at || !executivoDoc?.approved_at) {
+      return null;
+    }
+    const days = differenceInCalendarDays(
+      parseISO(executivoDoc.approved_at),
+      parseISO(executivoDoc.created_at),
+    );
+    return days > 0 ? days : null;
+  }, [isTacitApproval, executivoDoc?.created_at, executivoDoc?.approved_at]);
+
   const loading = projectLoading || docsLoading;
 
   const [artModalOpen, setArtModalOpen] = useState(false);
@@ -339,11 +362,12 @@ const Executivo = () => {
             {/* Desktop: Two-column layout */}
             <div className="hidden lg:grid lg:grid-cols-[1fr_340px] lg:gap-6">
               <div className="space-y-4">
-                {executivoDoc.status === 'approved' && (
+                {isTacitApproval && (
                   <TacitApprovalNotice
                     formalizacoesPath={paths.formalizacoes}
                     registeredAt={executivoDoc.approved_at}
                     documentHash={executivoDoc.checksum}
+                    daysSilent={tacitDaysSilent}
                   />
                 )}
                 <div className="h-[calc(100vh-260px)]">
@@ -375,8 +399,13 @@ const Executivo = () => {
 
             {/* Mobile/Tablet: Stack layout */}
             <div className="lg:hidden flex flex-col gap-3">
-              {executivoDoc.status === 'approved' && (
-                <TacitApprovalNotice formalizacoesPath={paths.formalizacoes} />
+              {isTacitApproval && (
+                <TacitApprovalNotice
+                  formalizacoesPath={paths.formalizacoes}
+                  registeredAt={executivoDoc.approved_at}
+                  documentHash={executivoDoc.checksum}
+                  daysSilent={tacitDaysSilent}
+                />
               )}
               <div>
                 <PDFViewer url={executivoDoc.url!} title="Projeto Executivo" />

--- a/supabase/migrations/20260504061500_executive_tacit_approval_event.sql
+++ b/supabase/migrations/20260504061500_executive_tacit_approval_event.sql
@@ -1,0 +1,109 @@
+-- Bloco 1 — Decisão e JTBD: aprovação tácita rastreável
+--
+-- Contexto: quando um project_documents do tipo 'executive_project' transita
+-- para status 'approved' sem actor humano (approved_by IS NULL), inferimos
+-- aprovação tácita: o prazo contratual venceu sem manifestação do cliente.
+-- Para rastreabilidade jurídica, registramos imediatamente um domain_event
+-- imutável com hash do PDF, timestamp e o intervalo silencioso, alimentando a
+-- ActivityTimeline e auditorias futuras.
+--
+-- Observação: a detecção de tácita é feita via INSERT/UPDATE trigger no nível
+-- do banco (SECURITY DEFINER) — o front-end não pode garantir registro único
+-- e à prova de race conditions; a fonte da verdade tem que ser o DB.
+
+CREATE OR REPLACE FUNCTION public.log_executive_tacit_approval()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id UUID;
+  v_days_silent INTEGER;
+  v_payload JSONB;
+BEGIN
+  -- Só dispara para projeto executivo aprovado tacitamente (sem actor humano)
+  IF NEW.document_type <> 'executive_project' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Detectar transição para 'approved' tácito
+  IF NEW.status <> 'approved' OR NEW.approved_at IS NULL OR NEW.approved_by IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Em UPDATE, ignorar quando o status já era 'approved' (idempotência)
+  IF TG_OP = 'UPDATE'
+     AND OLD.status = 'approved'
+     AND OLD.approved_at IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Achar a org dona do projeto. Em caso de schema legado sem coluna
+  -- customer_org_id, caímos para projects.created_by (mesmo critério usado
+  -- pelo trigger de pending_items para parcelas).
+  BEGIN
+    SELECT p.customer_org_id INTO v_org_id
+    FROM public.projects p
+    WHERE p.id = NEW.project_id;
+  EXCEPTION WHEN undefined_column THEN
+    SELECT p.created_by INTO v_org_id
+    FROM public.projects p
+    WHERE p.id = NEW.project_id;
+  END;
+
+  IF v_org_id IS NULL THEN
+    SELECT p.created_by INTO v_org_id
+    FROM public.projects p
+    WHERE p.id = NEW.project_id;
+  END IF;
+
+  -- Dias silentes = upload (created_at) → tácita (approved_at). Usamos como
+  -- proxy do prazo contratual quando o documento não carrega o deadline
+  -- explícito. Frontend pode sobrescrever exibindo o valor contratual real.
+  v_days_silent := GREATEST(
+    0,
+    DATE_PART('day', NEW.approved_at - NEW.created_at)::INTEGER
+  );
+
+  v_payload := jsonb_build_object(
+    'document_id', NEW.id,
+    'document_hash', NEW.checksum,
+    'deadline_iso', NEW.approved_at,
+    'days_silent', v_days_silent,
+    'document_version', NEW.version,
+    'document_name', NEW.name
+  );
+
+  -- Registro imutável; eventos são auditáveis e não permitem update/delete
+  -- (RLS de domain_events). Falhas aqui não devem bloquear a aprovação —
+  -- engolimos a exceção com aviso para não quebrar o fluxo do staff.
+  BEGIN
+    PERFORM public.log_domain_event(
+      v_org_id,
+      NEW.project_id,
+      'project_document',
+      NEW.id,
+      'executive.tacit_approval',
+      v_payload,
+      NULL,
+      'tacit-approval-trigger'
+    );
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'log_executive_tacit_approval failed: %', SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_executive_document_tacit_approval ON public.project_documents;
+
+CREATE TRIGGER on_executive_document_tacit_approval
+  AFTER INSERT OR UPDATE OF status, approved_at, approved_by
+  ON public.project_documents
+  FOR EACH ROW
+  EXECUTE FUNCTION public.log_executive_tacit_approval();
+
+COMMENT ON FUNCTION public.log_executive_tacit_approval() IS
+  'Bloco 1 / Issue #18: registra domain_event executive.tacit_approval quando um project executive é aprovado sem actor humano (approved_by IS NULL).';


### PR DESCRIPTION
- Adiciona EVENT_TYPES.EXECUTIVE_TACIT_APPROVAL e migração com trigger DB
  log_executive_tacit_approval que emite domain_events imutáveis quando
  project_documents do tipo executive_project é aprovado sem actor humano
  (approved_by IS NULL). Payload carrega document_id, hash, deadline e
  days_silent — fonte da verdade para auditoria e ActivityTimeline.
- Corrige Executivo.tsx: detecção tácita agora exige !approved_by (antes
  o banner aparecia para qualquer aprovação). Mobile recebe o mesmo
  payload do desktop (registeredAt, documentHash, daysSilent) — paridade
  obrigatória prevista no Bloco 1.
- docs/ARCHITECTURE.md: nova seção "Cockpit de Decisão (JTBD)" cobrindo
  hook agregador, bloco UI, tracking, painel staff e padrão da tácita
  rastreável.