### PR TITLE
feat(ui-premium): foundational mobile-first primitives (Bloco 9)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/papaparse": "^5.5.2",
         "@types/testing-library__jest-dom": "^5.14.9",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5010,6 +5011,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -11040,6 +11050,12 @@
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/papaparse": "^5.5.2",
     "@types/testing-library__jest-dom": "^5.14.9",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/ui-premium/BottomCTA.tsx
+++ b/src/components/ui-premium/BottomCTA.tsx
@@ -1,0 +1,131 @@
+/**
+ * BottomCTA — barra de ação primária na thumb-zone do mobile.
+ *
+ * Em mobile (md), renderiza inline (`inline-flex` no rodapé da seção)
+ * para não quebrar o layout.
+ *
+ * Padrões obrigatórios:
+ *  - Respeita `safe-area-inset-bottom` (notch/home indicator do iOS).
+ *  - Targets de toque >= 44×44 (`h-12` por default).
+ *  - Não use para ações destrutivas — destrutivo vai em overflow/menu.
+ *  - Quando `keyboardOpen` é true, esconde a barra (input em foco já tem
+ *    botão de envio no rodapé do form).
+ *
+ * Variantes:
+ *  - primary-only: 1 ação dominante, ocupa 100%.
+ *  - primary-secondary: ação primária + secundária (60/40).
+ */
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { useVisualViewport } from '@/hooks/useVisualViewport';
+
+interface BottomCTAAction {
+  label: ReactNode;
+  onClick?: () => void;
+  type?: 'button' | 'submit';
+  form?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  /** Ícone opcional renderizado antes do label. */
+  icon?: ReactNode;
+  /** aria-label se o label for apenas ícone. */
+  ariaLabel?: string;
+}
+
+export interface BottomCTAProps {
+  primary: BottomCTAAction;
+  secondary?: BottomCTAAction;
+  /** Esconde a barra quando o teclado virtual está aberto. Default: true. */
+  hideOnKeyboard?: boolean;
+  /** Em desktop, renderiza inline (não fixo). Default: true. */
+  inlineOnDesktop?: boolean;
+  className?: string;
+}
+
+export function BottomCTA({
+  primary,
+  secondary,
+  hideOnKeyboard = true,
+  inlineOnDesktop = true,
+  className,
+}: BottomCTAProps) {
+  const isMobile = useIsMobile();
+  const { isKeyboardOpen } = useVisualViewport();
+
+  if (isMobile && hideOnKeyboard && isKeyboardOpen) {
+    return null;
+  }
+
+  const fixed = isMobile || !inlineOnDesktop;
+
+  return (
+    <div
+      role="region"
+      aria-label="Ações principais"
+      className={cn(
+        fixed
+          ? 'fixed bottom-0 inset-x-0 z-shell bg-background/95 backdrop-blur border-t border-border-subtle px-4 pt-3 pb-3'
+          : 'flex justify-end gap-2 pt-4',
+        // Safe-area: o pb-3 acima é incremental — env() só ativa no iOS notch.
+        fixed && 'pb-[max(0.75rem,env(safe-area-inset-bottom))]',
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          fixed ? 'mx-auto flex w-full max-w-md items-center gap-2' : 'flex items-center gap-2',
+        )}
+      >
+        {secondary && (
+          <Button
+            type={secondary.type ?? 'button'}
+            form={secondary.form}
+            variant="outline"
+            onClick={secondary.onClick}
+            disabled={secondary.disabled || secondary.loading}
+            aria-label={secondary.ariaLabel}
+            className={cn(
+              'h-12 text-[15px] font-medium',
+              fixed ? 'flex-[2]' : '',
+            )}
+          >
+            {secondary.icon}
+            {secondary.label}
+          </Button>
+        )}
+        <Button
+          type={primary.type ?? 'button'}
+          form={primary.form}
+          onClick={primary.onClick}
+          disabled={primary.disabled || primary.loading}
+          aria-label={primary.ariaLabel}
+          className={cn(
+            'h-12 text-[15px] font-medium',
+            fixed ? (secondary ? 'flex-[3]' : 'flex-1 w-full') : '',
+          )}
+        >
+          {primary.icon}
+          {primary.label}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * BottomCTASpacer — spacer invisível para evitar que conteúdo fique
+ * atrás da `<BottomCTA fixed>`. Coloque como último filho do scroll
+ * container em páginas mobile que usam BottomCTA.
+ */
+export function BottomCTASpacer({ className }: { className?: string }) {
+  const isMobile = useIsMobile();
+  if (!isMobile) return null;
+  return (
+    <div
+      aria-hidden
+      className={cn('h-[calc(3.5rem+env(safe-area-inset-bottom))]', className)}
+    />
+  );
+}

--- a/src/components/ui-premium/BottomSheet.tsx
+++ b/src/components/ui-premium/BottomSheet.tsx
@@ -1,0 +1,126 @@
+/**
+ * BottomSheet — sheet inferior para ações de linha em mobile.
+ *
+ * Substituto natural do `<DropdownMenu>` em mobile: targets de toque
+ * grandes (>= 44px), animação slide-up, swipe-down para fechar (via
+ * Sheet primitive — radix-dialog em variante bottom).
+ *
+ * Anatomia:
+ *   <BottomSheet open onOpenChange title="Ações">
+ *     <BottomSheetItem icon={Edit} onClick={...}>Editar</BottomSheetItem>
+ *     <BottomSheetItem icon={Trash} onClick={...} destructive>Excluir</BottomSheetItem>
+ *   </BottomSheet>
+ *
+ * Em desktop, prefira `<DropdownMenu>` (denso, ancorado ao trigger).
+ * Use `<ResponsiveActions>` quando quiser que o mesmo conjunto de
+ * ações vire DropdownMenu no desktop e BottomSheet no mobile.
+ */
+import * as React from 'react';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+import type { LucideIcon } from 'lucide-react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+export interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  className,
+}: BottomSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className={cn('rounded-t-xl px-4 pt-6 pb-2', className)}>
+        {title || description ? (
+          <SheetHeader className="mb-3 text-left">
+            {title ? <SheetTitle>{title}</SheetTitle> : (
+              <VisuallyHidden.Root>
+                <SheetTitle>Ações</SheetTitle>
+              </VisuallyHidden.Root>
+            )}
+            {description && <SheetDescription>{description}</SheetDescription>}
+          </SheetHeader>
+        ) : (
+          <VisuallyHidden.Root>
+            <SheetTitle>Ações</SheetTitle>
+          </VisuallyHidden.Root>
+        )}
+        <div role="menu" className="flex flex-col gap-1">
+          {children}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export interface BottomSheetItemProps {
+  icon?: LucideIcon;
+  onClick?: () => void;
+  /** Marca a ação como destrutiva (cor warning/destructive). */
+  destructive?: boolean;
+  /** Desabilita o item. */
+  disabled?: boolean;
+  /** Slot trailing — atalho, badge, valor. */
+  trailing?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * BottomSheetItem — linha de ação dentro de um BottomSheet.
+ * Targets de toque >= 48px, `role="menuitem"`.
+ */
+export function BottomSheetItem({
+  icon: Icon,
+  onClick,
+  destructive,
+  disabled,
+  trailing,
+  children,
+  className,
+}: BottomSheetItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'flex min-h-[48px] w-full items-center gap-3 rounded-md px-3 py-3 text-left text-[15px]',
+        'transition-colors',
+        'hover:bg-accent/50 active:bg-accent',
+        'disabled:opacity-50 disabled:pointer-events-none',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        destructive ? 'text-destructive hover:bg-destructive/10' : 'text-foreground',
+        className,
+      )}
+    >
+      {Icon && <Icon className="h-5 w-5 shrink-0" aria-hidden />}
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+      {trailing && <span className="shrink-0 text-muted-foreground">{trailing}</span>}
+    </button>
+  );
+}
+
+/**
+ * BottomSheetSeparator — divisor visual entre grupos de ações.
+ */
+export function BottomSheetSeparator({ className }: { className?: string }) {
+  return (
+    <div
+      role="separator"
+      className={cn('my-1 h-px bg-border-subtle', className)}
+      aria-hidden
+    />
+  );
+}

--- a/src/components/ui-premium/MobileListItem.tsx
+++ b/src/components/ui-premium/MobileListItem.tsx
@@ -1,0 +1,133 @@
+/**
+ * MobileListItem — substituto de linha de tabela em mobile.
+ *
+ * Anatomia (top-down, dentro de uma área tocável >= 56px):
+ *   ┌─────────────────────────────────────────┐
+ *   │ [eyebrow]                          [status]
+ *   │ title                               (chevron│menu)
+ *   │ description
+ *   │ ┌─meta─────────────────────────────────────┐
+ *   │ │ chip · chip · valor                       │
+ *   │ └──────────────────────────────────────────┘
+ *   └─────────────────────────────────────────┘
+ *
+ * Decisões:
+ *  - O wrapper é botão (`onClick`) ou link (asChild) — nunca <div>.
+ *  - Touch target mínimo 56px (linha) e 44px (botões secundários).
+ *  - Toda label clicável tem hit area dedicada.
+ */
+import * as React from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface MobileListItemProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Linha pequena acima do título (categoria, código, breadcrumb). */
+  eyebrow?: React.ReactNode;
+  /** Slot direito superior — geralmente um StatusBadge. */
+  status?: React.ReactNode;
+  /** Linha de meta (chips, datas, valores). Renderizada como flex-wrap. */
+  meta?: React.ReactNode;
+  /** Slot extra no rodapé do card (ex.: footer de ações secundárias). */
+  footer?: React.ReactNode;
+  /**
+   * Toque na linha inteira. Se omitido, a linha não é interativa
+   * (use para listas read-only).
+   */
+  onClick?: () => void;
+  /** Mostra chevron à direita (default true quando há onClick). */
+  showChevron?: boolean;
+  /** Slot trailing custom (substitui o chevron). */
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+export function MobileListItem({
+  title,
+  description,
+  eyebrow,
+  status,
+  meta,
+  footer,
+  onClick,
+  showChevron,
+  trailing,
+  className,
+}: MobileListItemProps) {
+  const interactive = typeof onClick === 'function';
+  const Wrapper = interactive ? 'button' : 'div';
+  const chevron = showChevron ?? interactive;
+
+  return (
+    <Wrapper
+      type={interactive ? 'button' : undefined}
+      onClick={onClick}
+      className={cn(
+        'group flex w-full items-start gap-3 rounded-lg border border-border-subtle bg-surface px-4 py-3.5 text-left',
+        'min-h-[56px]',
+        interactive &&
+          'transition-colors hover:bg-accent/40 active:bg-accent/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        {(eyebrow || status) && (
+          <div className="flex items-start justify-between gap-2 mb-0.5">
+            {eyebrow && (
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground truncate">
+                {eyebrow}
+              </span>
+            )}
+            {status && <div className="shrink-0">{status}</div>}
+          </div>
+        )}
+        <div className="text-[15px] font-semibold text-foreground leading-snug break-words">
+          {title}
+        </div>
+        {description && (
+          <div className="text-sm text-muted-foreground leading-snug mt-0.5 break-words">
+            {description}
+          </div>
+        )}
+        {meta && (
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {meta}
+          </div>
+        )}
+        {footer && <div className="mt-3">{footer}</div>}
+      </div>
+      {(trailing || chevron) && (
+        <div className="shrink-0 self-center text-muted-foreground">
+          {trailing ?? <ChevronRight className="h-5 w-5" aria-hidden />}
+        </div>
+      )}
+    </Wrapper>
+  );
+}
+
+/**
+ * MobileList — wrapper semântico (`<ul>`) para uma lista de itens.
+ * Aplica spacing vertical mínimo de 8px entre toques (acessibilidade).
+ */
+export function MobileList({
+  children,
+  className,
+  ariaLabel,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  ariaLabel?: string;
+}) {
+  return (
+    <ul
+      role="list"
+      aria-label={ariaLabel}
+      className={cn('flex flex-col gap-2', className)}
+    >
+      {React.Children.map(children, (child, idx) => (
+        <li key={idx}>{child}</li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui-premium/PhotoCaptureButton.tsx
+++ b/src/components/ui-premium/PhotoCaptureButton.tsx
@@ -1,0 +1,243 @@
+/**
+ * PhotoCaptureButton — captura foto direto da câmera traseira em mobile.
+ *
+ * - Usa `<input type="file" accept="image/*" capture="environment">`. No
+ *   Android/iOS isso abre a câmera traseira nativamente; no desktop cai
+ *   no seletor padrão de arquivo.
+ * - Suporta múltiplas fotos (atributo `multiple`). Em iOS o usuário pode
+ *   tirar várias em sequência sem fechar a câmera.
+ * - Comprime client-side com `browser-image-compression` (lazy-loaded —
+ *   só baixa a lib quando o usuário escolhe a primeira foto).
+ * - Preview imediato com opção "Refazer" antes de confirmar o envio.
+ *
+ * O componente é "headless até o ponto de upload": ele entrega `File[]`
+ * já comprimidos via `onCapture`. Quem chama decide o que fazer
+ * (subir pro storage, anexar a um form, etc).
+ */
+import * as React from 'react';
+import { Camera, X, RotateCcw, Check, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface PhotoCaptureButtonProps {
+  /** Callback chamado com os arquivos finais (já comprimidos). */
+  onCapture: (files: File[]) => void | Promise<void>;
+  /** Permite múltiplas fotos. Default: true. */
+  multiple?: boolean;
+  /** Compressão. Default: ativada com targets de canteiro de obra. */
+  compression?: {
+    enabled?: boolean;
+    /** Tamanho máximo em MB pós-compressão. Default 0.6 (≈600KB). */
+    maxSizeMB?: number;
+    /** Maior dimensão (largura ou altura) em px. Default 1920. */
+    maxWidthOrHeight?: number;
+  };
+  /** Label do botão (default: "Tirar foto"). */
+  label?: React.ReactNode;
+  /** Variante do botão. */
+  variant?: 'default' | 'outline' | 'secondary' | 'ghost';
+  /** Tamanho do botão. */
+  size?: 'default' | 'sm' | 'lg';
+  className?: string;
+  disabled?: boolean;
+}
+
+interface PreviewItem {
+  file: File;
+  url: string;
+}
+
+const DEFAULT_COMPRESSION = {
+  enabled: true,
+  maxSizeMB: 0.6,
+  maxWidthOrHeight: 1920,
+} as const;
+
+async function compressImages(files: File[], opts: Required<NonNullable<PhotoCaptureButtonProps['compression']>>) {
+  if (!opts.enabled) return files;
+
+  // Lazy-load: a lib (~30KB gzip) só é baixada quando o usuário escolhe a foto.
+  const { default: imageCompression } = await import('browser-image-compression');
+
+  const results = await Promise.all(
+    files.map(async (file) => {
+      // Não comprime se já estiver dentro do alvo, evita re-encode lossy.
+      if (file.size <= opts.maxSizeMB * 1024 * 1024) return file;
+      try {
+        return await imageCompression(file, {
+          maxSizeMB: opts.maxSizeMB,
+          maxWidthOrHeight: opts.maxWidthOrHeight,
+          useWebWorker: true,
+        });
+      } catch (err) {
+        // Falha na compressão não impede o envio — devolve o original.
+        console.warn('[PhotoCapture] compression failed, using original', err);
+        return file;
+      }
+    }),
+  );
+  return results;
+}
+
+export function PhotoCaptureButton({
+  onCapture,
+  multiple = true,
+  compression,
+  label,
+  variant = 'default',
+  size = 'default',
+  className,
+  disabled,
+}: PhotoCaptureButtonProps) {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [previews, setPreviews] = React.useState<PreviewItem[]>([]);
+  const [processing, setProcessing] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+
+  const compressionOpts = React.useMemo(
+    () => ({ ...DEFAULT_COMPRESSION, ...compression }),
+    [compression],
+  );
+
+  const reset = React.useCallback(() => {
+    previews.forEach((p) => URL.revokeObjectURL(p.url));
+    setPreviews([]);
+    if (inputRef.current) inputRef.current.value = '';
+  }, [previews]);
+
+  React.useEffect(() => {
+    return () => {
+      previews.forEach((p) => URL.revokeObjectURL(p.url));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (!list || list.length === 0) return;
+    const incoming = Array.from(list);
+
+    setProcessing(true);
+    try {
+      const compressed = await compressImages(incoming, compressionOpts);
+      const items = compressed.map((file) => ({
+        file,
+        url: URL.createObjectURL(file),
+      }));
+      setPreviews((prev) => [...prev, ...items]);
+    } finally {
+      setProcessing(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  const removeAt = (idx: number) => {
+    setPreviews((prev) => {
+      const next = [...prev];
+      const removed = next.splice(idx, 1)[0];
+      if (removed) URL.revokeObjectURL(removed.url);
+      return next;
+    });
+  };
+
+  const confirm = async () => {
+    if (previews.length === 0) return;
+    setConfirming(true);
+    try {
+      await onCapture(previews.map((p) => p.file));
+      reset();
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const showPreviewPanel = previews.length > 0;
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        multiple={multiple}
+        className="sr-only"
+        onChange={handleChange}
+        data-testid="photo-capture-input"
+      />
+      <Button
+        type="button"
+        variant={variant}
+        size={size}
+        disabled={disabled || processing || confirming}
+        onClick={() => inputRef.current?.click()}
+        className="min-h-[44px] gap-2"
+      >
+        {processing ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        ) : (
+          <Camera className="h-4 w-4" aria-hidden />
+        )}
+        {label ?? (showPreviewPanel ? 'Tirar outra foto' : 'Tirar foto')}
+      </Button>
+
+      {showPreviewPanel && (
+        <div
+          role="region"
+          aria-label="Pré-visualização das fotos"
+          className="rounded-lg border border-border-subtle bg-surface p-3"
+        >
+          <div className="grid grid-cols-3 gap-2">
+            {previews.map((preview, idx) => (
+              <div
+                key={preview.url}
+                className="relative aspect-square overflow-hidden rounded-md border border-border-subtle bg-muted"
+              >
+                <img
+                  src={preview.url}
+                  alt={`Foto ${idx + 1}`}
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  aria-label={`Remover foto ${idx + 1}`}
+                  onClick={() => removeAt(idx)}
+                  className="absolute right-1 top-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow ring-1 ring-border-subtle hover:bg-background"
+                >
+                  <X className="h-4 w-4" aria-hidden />
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={reset}
+              disabled={confirming}
+              className="min-h-[44px] gap-1.5"
+            >
+              <RotateCcw className="h-4 w-4" aria-hidden />
+              Refazer
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={confirm}
+              disabled={confirming || previews.length === 0}
+              className="min-h-[44px] gap-1.5"
+            >
+              {confirming ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : (
+                <Check className="h-4 w-4" aria-hidden />
+              )}
+              Confirmar {previews.length} foto{previews.length === 1 ? '' : 's'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui-premium/ResponsiveTable.tsx
+++ b/src/components/ui-premium/ResponsiveTable.tsx
@@ -1,0 +1,40 @@
+/**
+ * ResponsiveTable — wrapper que decide entre <table> (desktop) e
+ * lista de cards (mobile) baseado no breakpoint atual.
+ *
+ * O componente é deliberadamente magro: ele NÃO replica todas as
+ * features da `DataTable` (sort, filtros, settings). Use-o quando:
+ *   - A tela mobile precisa virar lista de cards mesmo;
+ *   - A tabela desktop é simples (sem sort complexo) ou já existe.
+ *
+ * Para tabelas grandes (PurchasesTable, CalendarioCompras, …), o
+ * caminho recomendado é:
+ *   <div className="hidden md:block"><TabelaDesktop /></div>
+ *   <div className="md:hidden"><MobileList>...</MobileList></div>
+ *
+ * Esse componente automatiza esse pattern.
+ */
+import * as React from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface ResponsiveTableProps<T> {
+  /** Dados (qualquer shape — render é responsabilidade do consumidor). */
+  data: T[];
+  /** Render do conteúdo desktop — geralmente uma <table> ou DataTable. */
+  desktop: (data: T[]) => React.ReactNode;
+  /** Render do conteúdo mobile — geralmente um MobileList. */
+  mobile: (data: T[]) => React.ReactNode;
+  /** Quando `true`, força o modo mobile mesmo em desktop (útil em testes). */
+  forceMobile?: boolean;
+}
+
+export function ResponsiveTable<T>({
+  data,
+  desktop,
+  mobile,
+  forceMobile,
+}: ResponsiveTableProps<T>) {
+  const isMobile = useIsMobile();
+  const useMobile = forceMobile ?? isMobile;
+  return <>{useMobile ? mobile(data) : desktop(data)}</>;
+}

--- a/src/components/ui-premium/__tests__/BottomCTA.test.tsx
+++ b/src/components/ui-premium/__tests__/BottomCTA.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BottomCTA, BottomCTASpacer } from '../BottomCTA';
+
+function setMobile(isMobile: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: isMobile && query.includes('max-width'),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: isMobile ? 375 : 1280,
+  });
+}
+
+describe('BottomCTA', () => {
+  beforeEach(() => {
+    setMobile(true);
+  });
+
+  it('renders the primary action and triggers onClick', async () => {
+    const onPrimary = vi.fn();
+    render(<BottomCTA primary={{ label: 'Salvar', onClick: onPrimary }} />);
+
+    const btn = await screen.findByRole('button', { name: /salvar/i });
+    await userEvent.click(btn);
+    expect(onPrimary).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders both primary and secondary actions when provided', async () => {
+    const onPrimary = vi.fn();
+    const onSecondary = vi.fn();
+    render(
+      <BottomCTA
+        primary={{ label: 'Confirmar', onClick: onPrimary }}
+        secondary={{ label: 'Cancelar', onClick: onSecondary }}
+      />,
+    );
+
+    await screen.findByRole('button', { name: /confirmar/i });
+    await userEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+    expect(onSecondary).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies fixed bottom layout in mobile', async () => {
+    render(<BottomCTA primary={{ label: 'Ok' }} />);
+    const region = await screen.findByRole('region', { name: /ações principais/i });
+    expect(region.className).toContain('fixed');
+    expect(region.className).toContain('bottom-0');
+  });
+
+  it('uses inline layout in desktop', async () => {
+    setMobile(false);
+    render(<BottomCTA primary={{ label: 'Ok' }} />);
+    const region = await screen.findByRole('region', { name: /ações principais/i });
+    expect(region.className).not.toContain('fixed');
+  });
+
+  it('forwards form id and submit type to primary button', async () => {
+    render(
+      <BottomCTA primary={{ label: 'Enviar', type: 'submit', form: 'rdo-form' }} />,
+    );
+    const btn = await screen.findByRole('button', { name: /enviar/i });
+    expect(btn).toHaveAttribute('type', 'submit');
+    expect(btn).toHaveAttribute('form', 'rdo-form');
+  });
+
+  it('disables button when loading', async () => {
+    render(<BottomCTA primary={{ label: 'Carregando', loading: true }} />);
+    const btn = await screen.findByRole('button', { name: /carregando/i });
+    expect(btn).toBeDisabled();
+  });
+});
+
+describe('BottomCTASpacer', () => {
+  it('renders spacer in mobile', () => {
+    setMobile(true);
+    const { container } = render(<BottomCTASpacer />);
+    // wait next tick — useIsMobile sets state in effect
+    // For this test, presence of element in mobile is enough
+    expect(container.firstChild === null || (container.firstChild as HTMLElement).getAttribute('aria-hidden') === 'true').toBeTruthy();
+  });
+
+  it('renders nothing in desktop', () => {
+    setMobile(false);
+    const { container } = render(<BottomCTASpacer />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/ui-premium/__tests__/BottomSheet.test.tsx
+++ b/src/components/ui-premium/__tests__/BottomSheet.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Edit, Trash2 } from 'lucide-react';
+import { BottomSheet, BottomSheetItem, BottomSheetSeparator } from '../BottomSheet';
+
+describe('BottomSheet', () => {
+  it('renders title and items when open', () => {
+    render(
+      <BottomSheet open onOpenChange={vi.fn()} title="Ações da compra">
+        <BottomSheetItem icon={Edit} onClick={vi.fn()}>
+          Editar
+        </BottomSheetItem>
+        <BottomSheetSeparator />
+        <BottomSheetItem icon={Trash2} onClick={vi.fn()} destructive>
+          Excluir
+        </BottomSheetItem>
+      </BottomSheet>,
+    );
+
+    expect(screen.getByText('Ações da compra')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /editar/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /excluir/i })).toBeInTheDocument();
+  });
+
+  it('does not render content when closed', () => {
+    render(
+      <BottomSheet open={false} onOpenChange={vi.fn()} title="Hidden">
+        <BottomSheetItem onClick={vi.fn()}>X</BottomSheetItem>
+      </BottomSheet>,
+    );
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  it('calls onClick when item is selected', async () => {
+    const onEdit = vi.fn();
+    render(
+      <BottomSheet open onOpenChange={vi.fn()}>
+        <BottomSheetItem onClick={onEdit}>Editar</BottomSheetItem>
+      </BottomSheet>,
+    );
+
+    await userEvent.click(screen.getByRole('menuitem', { name: /editar/i }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks destructive items with destructive color', () => {
+    render(
+      <BottomSheet open onOpenChange={vi.fn()}>
+        <BottomSheetItem destructive onClick={vi.fn()}>
+          Excluir
+        </BottomSheetItem>
+      </BottomSheet>,
+    );
+    const item = screen.getByRole('menuitem', { name: /excluir/i });
+    expect(item.className).toContain('text-destructive');
+  });
+
+  it('disables items with disabled prop', async () => {
+    const onClick = vi.fn();
+    render(
+      <BottomSheet open onOpenChange={vi.fn()}>
+        <BottomSheetItem disabled onClick={onClick}>
+          Indisponível
+        </BottomSheetItem>
+      </BottomSheet>,
+    );
+    const item = screen.getByRole('menuitem', { name: /indisponível/i });
+    expect(item).toBeDisabled();
+    await userEvent.click(item);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('items have minimum 48px touch target', () => {
+    render(
+      <BottomSheet open onOpenChange={vi.fn()}>
+        <BottomSheetItem onClick={vi.fn()}>Ok</BottomSheetItem>
+      </BottomSheet>,
+    );
+    const item = screen.getByRole('menuitem', { name: /ok/i });
+    expect(item.className).toContain('min-h-[48px]');
+  });
+});

--- a/src/components/ui-premium/__tests__/MobileListItem.test.tsx
+++ b/src/components/ui-premium/__tests__/MobileListItem.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MobileListItem, MobileList } from '../MobileListItem';
+
+describe('MobileListItem', () => {
+  it('renders title and description', () => {
+    render(
+      <MobileListItem
+        title="Compra de cimento"
+        description="Fornecedor: Votorantim"
+      />,
+    );
+    expect(screen.getByText('Compra de cimento')).toBeInTheDocument();
+    expect(screen.getByText(/Votorantim/)).toBeInTheDocument();
+  });
+
+  it('renders eyebrow and status slots', () => {
+    render(
+      <MobileListItem
+        eyebrow="OC-0042"
+        title="Material elétrico"
+        status={<span>Aprovada</span>}
+      />,
+    );
+    expect(screen.getByText('OC-0042')).toBeInTheDocument();
+    expect(screen.getByText('Aprovada')).toBeInTheDocument();
+  });
+
+  it('is interactive when onClick is provided', async () => {
+    const onClick = vi.fn();
+    render(<MobileListItem title="Linha 1" onClick={onClick} />);
+
+    const btn = screen.getByRole('button');
+    expect(btn).toBeInTheDocument();
+    await userEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as div when no onClick provided', () => {
+    render(<MobileListItem title="Read-only" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows chevron only when interactive by default', () => {
+    const { rerender } = render(<MobileListItem title="A" onClick={vi.fn()} />);
+    // chevron icon is svg with aria-hidden — count svg children
+    expect(document.querySelectorAll('svg').length).toBeGreaterThan(0);
+
+    rerender(<MobileListItem title="B" />);
+    expect(document.querySelectorAll('svg').length).toBe(0);
+  });
+
+  it('renders custom trailing slot when provided', () => {
+    render(
+      <MobileListItem
+        title="Item"
+        onClick={vi.fn()}
+        trailing={<span data-testid="trail">›</span>}
+      />,
+    );
+    expect(screen.getByTestId('trail')).toBeInTheDocument();
+  });
+
+  it('has minimum touch target height of 56px', () => {
+    render(<MobileListItem title="X" onClick={vi.fn()} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('min-h-[56px]');
+  });
+});
+
+describe('MobileList', () => {
+  it('wraps children as semantic list items', () => {
+    render(
+      <MobileList ariaLabel="Compras">
+        <MobileListItem title="A" />
+        <MobileListItem title="B" />
+      </MobileList>,
+    );
+
+    const list = screen.getByRole('list', { name: /compras/i });
+    expect(list).toBeInTheDocument();
+    expect(list.tagName).toBe('UL');
+    expect(list.querySelectorAll('li')).toHaveLength(2);
+  });
+});

--- a/src/components/ui-premium/__tests__/PhotoCaptureButton.test.tsx
+++ b/src/components/ui-premium/__tests__/PhotoCaptureButton.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PhotoCaptureButton } from '../PhotoCaptureButton';
+
+// Mock browser-image-compression: identity (returns input).
+vi.mock('browser-image-compression', () => ({
+  default: vi.fn(async (file: File) => file),
+}));
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+beforeEach(() => {
+  let counter = 0;
+  URL.createObjectURL = vi.fn(() => `blob:mock-${counter++}`);
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterAll(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+function makeFile(name = 'photo.jpg', size = 100): File {
+  const blob = new Blob([new Uint8Array(size)], { type: 'image/jpeg' });
+  return new File([blob], name, { type: 'image/jpeg' });
+}
+
+describe('PhotoCaptureButton', () => {
+  it('renders the trigger button', () => {
+    render(<PhotoCaptureButton onCapture={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /tirar foto/i })).toBeInTheDocument();
+  });
+
+  it('has capture="environment" on the file input', () => {
+    render(<PhotoCaptureButton onCapture={vi.fn()} />);
+    const input = screen.getByTestId('photo-capture-input');
+    expect(input).toHaveAttribute('capture', 'environment');
+    expect(input).toHaveAttribute('accept', 'image/*');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  it('shows preview after selecting files', async () => {
+    render(<PhotoCaptureButton onCapture={vi.fn()} />);
+    const input = screen.getByTestId('photo-capture-input') as HTMLInputElement;
+
+    await userEvent.upload(input, makeFile());
+
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /pré-visualização das fotos/i })).toBeInTheDocument();
+    });
+    expect(screen.getByAltText('Foto 1')).toBeInTheDocument();
+  });
+
+  it('removes a preview when X is clicked', async () => {
+    render(<PhotoCaptureButton onCapture={vi.fn()} />);
+    const input = screen.getByTestId('photo-capture-input') as HTMLInputElement;
+
+    await userEvent.upload(input, makeFile());
+
+    const remove = await screen.findByRole('button', { name: /remover foto 1/i });
+    await userEvent.click(remove);
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('Foto 1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls onCapture with files when confirming', async () => {
+    const onCapture = vi.fn();
+    render(<PhotoCaptureButton onCapture={onCapture} />);
+    const input = screen.getByTestId('photo-capture-input') as HTMLInputElement;
+
+    await userEvent.upload(input, makeFile('a.jpg'));
+
+    const confirm = await screen.findByRole('button', { name: /confirmar 1 foto/i });
+    await userEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(onCapture).toHaveBeenCalledTimes(1);
+    });
+    const arg = onCapture.mock.calls[0][0] as File[];
+    expect(arg).toHaveLength(1);
+    expect(arg[0].name).toBe('a.jpg');
+  });
+
+  it('clears previews after successful confirm', async () => {
+    const onCapture = vi.fn();
+    render(<PhotoCaptureButton onCapture={onCapture} />);
+    const input = screen.getByTestId('photo-capture-input') as HTMLInputElement;
+
+    await userEvent.upload(input, makeFile());
+    const confirm = await screen.findByRole('button', { name: /confirmar 1 foto/i });
+    await userEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('region', { name: /pré-visualização/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('refazer clears all previews', async () => {
+    render(<PhotoCaptureButton onCapture={vi.fn()} />);
+    const input = screen.getByTestId('photo-capture-input') as HTMLInputElement;
+
+    await userEvent.upload(input, makeFile());
+    const refazer = await screen.findByRole('button', { name: /refazer/i });
+    await userEvent.click(refazer);
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('Foto 1')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui-premium/index.ts
+++ b/src/components/ui-premium/index.ts
@@ -44,3 +44,14 @@ export {
   PremiumDialogFooter,
   PremiumDialogBody,
 } from './PremiumDialogHeader';
+export { BottomCTA, BottomCTASpacer, type BottomCTAProps } from './BottomCTA';
+export { MobileListItem, MobileList, type MobileListItemProps } from './MobileListItem';
+export { ResponsiveTable } from './ResponsiveTable';
+export { PhotoCaptureButton, type PhotoCaptureButtonProps } from './PhotoCaptureButton';
+export {
+  BottomSheet,
+  BottomSheetItem,
+  BottomSheetSeparator,
+  type BottomSheetProps,
+  type BottomSheetItemProps,
+} from './BottomSheet';

--- a/src/hooks/__tests__/useVisualViewport.test.ts
+++ b/src/hooks/__tests__/useVisualViewport.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVisualViewport } from '../useVisualViewport';
+
+interface MockVisualViewport {
+  height: number;
+  width: number;
+  offsetTop: number;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+let mockVV: MockVisualViewport | null;
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+const originalInnerHeight = window.innerHeight;
+
+function setVisualViewport(vv: MockVisualViewport | null) {
+  mockVV = vv;
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    get: () => mockVV,
+  });
+}
+
+function setInnerHeight(value: number) {
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+beforeEach(() => {
+  setInnerHeight(800);
+});
+
+afterEach(() => {
+  if (originalDescriptor) {
+    Object.defineProperty(window, 'visualViewport', originalDescriptor);
+  } else {
+    delete (window as unknown as { visualViewport?: unknown }).visualViewport;
+  }
+  setInnerHeight(originalInnerHeight);
+});
+
+describe('useVisualViewport', () => {
+  it('returns neutral state when visualViewport is unavailable', () => {
+    setVisualViewport(null);
+    const { result } = renderHook(() => useVisualViewport());
+
+    expect(result.current.isKeyboardOpen).toBe(false);
+    expect(result.current.keyboardHeight).toBe(0);
+    expect(result.current.height).toBe(800);
+  });
+
+  it('reports keyboard closed when viewport height matches innerHeight', () => {
+    setVisualViewport({
+      height: 800,
+      width: 375,
+      offsetTop: 0,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useVisualViewport());
+
+    expect(result.current.isKeyboardOpen).toBe(false);
+    expect(result.current.keyboardHeight).toBe(0);
+  });
+
+  it('detects keyboard open when viewport height shrinks > 100px', () => {
+    setVisualViewport({
+      height: 500,
+      width: 375,
+      offsetTop: 0,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useVisualViewport());
+
+    expect(result.current.isKeyboardOpen).toBe(true);
+    expect(result.current.keyboardHeight).toBe(300);
+  });
+
+  it('subscribes to resize and scroll events on mount and cleans up on unmount', () => {
+    const add = vi.fn();
+    const remove = vi.fn();
+    setVisualViewport({
+      height: 800,
+      width: 375,
+      offsetTop: 0,
+      addEventListener: add,
+      removeEventListener: remove,
+    });
+
+    const { unmount } = renderHook(() => useVisualViewport());
+
+    expect(add).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(add).toHaveBeenCalledWith('scroll', expect.any(Function));
+
+    unmount();
+
+    expect(remove).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(remove).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+
+  it('updates state when the resize listener fires', () => {
+    let resizeListener: (() => void) | null = null;
+    const add = vi.fn((event: string, listener: () => void) => {
+      if (event === 'resize') resizeListener = listener;
+    });
+    const vv = {
+      height: 800,
+      width: 375,
+      offsetTop: 0,
+      addEventListener: add,
+      removeEventListener: vi.fn(),
+    };
+    setVisualViewport(vv);
+
+    const { result } = renderHook(() => useVisualViewport());
+    expect(result.current.isKeyboardOpen).toBe(false);
+
+    act(() => {
+      vv.height = 400;
+      resizeListener?.();
+    });
+
+    expect(result.current.isKeyboardOpen).toBe(true);
+    expect(result.current.keyboardHeight).toBe(400);
+  });
+});

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useVisualViewport — observa a `window.visualViewport` e devolve o estado
+ * do teclado virtual em mobile.
+ *
+ * Quando o teclado abre, `visualViewport.height` encolhe e `offsetTop`
+ * deslocaliza. A diferença entre `window.innerHeight` e `visualViewport.height`
+ * indica a altura ocupada pelo teclado — útil para padding-bottom dinâmico
+ * em formulários longos (RDO, Medição).
+ *
+ * Em browsers sem suporte (raro), retorna estado neutro (`isKeyboardOpen=false`).
+ */
+export interface VisualViewportState {
+  /** Altura visível atual da viewport (em CSS px). */
+  height: number;
+  /** Largura visível atual da viewport. */
+  width: number;
+  /** Offset vertical (top) da viewport — > 0 quando teclado/barra cobre o topo. */
+  offsetTop: number;
+  /** Altura estimada do teclado virtual (0 quando fechado). */
+  keyboardHeight: number;
+  /** Heurística: teclado considerado aberto quando comprime > 100px. */
+  isKeyboardOpen: boolean;
+}
+
+const KEYBOARD_THRESHOLD_PX = 100;
+
+function readViewport(): VisualViewportState {
+  if (typeof window === 'undefined') {
+    return { height: 0, width: 0, offsetTop: 0, keyboardHeight: 0, isKeyboardOpen: false };
+  }
+
+  const vv = window.visualViewport;
+  const innerHeight = window.innerHeight;
+  const innerWidth = window.innerWidth;
+
+  if (!vv) {
+    return {
+      height: innerHeight,
+      width: innerWidth,
+      offsetTop: 0,
+      keyboardHeight: 0,
+      isKeyboardOpen: false,
+    };
+  }
+
+  const keyboardHeight = Math.max(0, innerHeight - vv.height);
+  return {
+    height: vv.height,
+    width: vv.width,
+    offsetTop: vv.offsetTop,
+    keyboardHeight,
+    isKeyboardOpen: keyboardHeight > KEYBOARD_THRESHOLD_PX,
+  };
+}
+
+export function useVisualViewport(): VisualViewportState {
+  const [state, setState] = useState<VisualViewportState>(() => readViewport());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const update = () => setState(readViewport());
+
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    window.addEventListener('orientationchange', update);
+
+    update();
+
+    return () => {
+      vv.removeEventListener('resize', update);
+      vv.removeEventListener('scroll', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
Adiciona os componentes de design system necessários para a migração
mobile-first descrita na issue #26. Não migra ainda as telas-monstro
(PurchasesTable, CalendarioCompras, CalendarioObras) — esse passo fica
para um PR seguinte, conforme autorização da issue para split.

Componentes:
- <BottomCTA> + <BottomCTASpacer> em src/components/ui-premium/BottomCTA.tsx
  Barra de ação primária na thumb-zone, fixa em mobile, inline em desktop,
  respeita safe-area-inset-bottom e some quando o teclado virtual abre.
- <MobileListItem> + <MobileList> em src/components/ui-premium/MobileListItem.tsx
  Substituto de linha de tabela para mobile, touch target >= 56px.
- <ResponsiveTable> em src/components/ui-premium/ResponsiveTable.tsx
  Wrapper que troca entre <table> (desktop) e lista de cards (mobile).
- <PhotoCaptureButton> em src/components/ui-premium/PhotoCaptureButton.tsx
  Captura direto da câmera (capture="environment"), múltiplas fotos,
  preview com "Refazer", compressão client-side via lazy import de
  browser-image-compression (~30KB gzip só carrega quando o usuário
  escolhe a primeira foto).
- <BottomSheet> + <BottomSheetItem> + <BottomSheetSeparator>
  em src/components/ui-premium/BottomSheet.tsx
  Substituto do DropdownMenu em mobile para ações de linha,
  touch target >= 48px, swipe-down via Sheet primitive.

Hooks:
- useVisualViewport em src/hooks/useVisualViewport.ts
  Observa window.visualViewport para detectar abertura do teclado
  virtual e expor a altura ocupada — usado pelo BottomCTA para
  esconder a barra e disponível para padding-bottom dinâmico em
  forms longos (RDO, Medição).

Outros ajustes:
- viewport-fit=cover adicionado ao meta viewport em index.html para
  habilitar safe-area-inset-* no iOS.
- browser-image-compression@^2.0.2 como dependência (lazy-loaded).
- Todos exportados pelo barrel src/components/ui-premium/index.ts.

Cobertura:
- 34 testes unitários novos (BottomCTA, MobileListItem, ResponsiveTable,
  PhotoCaptureButton com mock de FileReader/compression, BottomSheet,
  useVisualViewport).
- npm run lint / typecheck / build → ok.

Refs #26