### PR TITLE
Bloco 3 — Design system: foundations + ESLint guards + sample refactors

### DIFF
--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -95,12 +95,92 @@ import { StatusBadge } from '@/components/ui-premium';
 | 20 px   | `w-5 h-5`           | KPIs, cabeçalhos       |
 | 24 px   | `w-6 h-6`           | Empty state hero       |
 
-## Elevação · radius · z-index
+## Elevação · radius
 
 - **Elevação**: `elevation-{xs,sm,md,lg,xl}` (`src/index.css`). Default em
   `SectionCard` é `elevation-xs`. Evite `shadow-sm/md/lg` solto.
 - **Radius**: `rounded-{sm,md,lg}` mapeiam a `--radius` (10px). Default de
   cards é `rounded-lg`; `rounded-xl/2xl` requer justificativa (hero, modal).
-- **Z-index**: nunca sobrescrever `z-*` em `*Content` de Dialog / Sheet /
-  Drawer / Popover etc. Use tokens (`z-modal`, `z-popover`, `z-alert`) de
-  `tailwind.config.ts`.
+
+## Z-index
+
+Escala em `tailwind.config.ts` → `theme.extend.zIndex`. Nunca sobrescrever
+`z-*` em `*Content` de Dialog / Sheet / Drawer / Popover etc. — ESLint
+sinaliza.
+
+| Token              | Valor | Camada                          |
+|--------------------|-------|---------------------------------|
+| `z-base`           | 0     | Fluxo normal                    |
+| `z-sticky`         | 10    | Headers/colunas sticky de tabela |
+| `z-raised`         | 20    | Hover, badges destacados        |
+| `z-docked`         | 30    | Cantos sticky de tabela         |
+| `z-shell`          | 40    | Sidebar, app shell              |
+| `z-header`         | 50    | Top bar fixa                    |
+| `z-modal`          | 100   | Backdrop de modal               |
+| `z-modal-content`  | 101   | Conteúdo do modal               |
+| `z-popover`        | 200   | Popover, dropdown, select       |
+| `z-toast`          | 250   | Toast notifications             |
+| `z-alert`          | 300   | Backdrop de alert dialog        |
+| `z-alert-content`  | 301   | Conteúdo do alert dialog        |
+| `z-max`            | 2147483647 | Escape hatch (raro)        |
+
+## Animação
+
+Definidas em `tailwind.config.ts` → `theme.extend.animation`. Todas usam
+`ease-out` (curva padrão BWild) e duração entre 200–500ms.
+
+| Classe                  | Duração | Uso                              |
+|-------------------------|---------|----------------------------------|
+| `animate-fade-in`       | 400ms   | Entrada padrão (opacity + Y)     |
+| `animate-fade-in-up`    | 500ms   | Entrada hero (Y maior)           |
+| `animate-fade-in-scale` | 400ms   | Entrada de cards / dialogs       |
+| `animate-slide-in-right`/ `-left` | 400ms | Painéis laterais leves      |
+| `animate-slide-in-from-right`/ `-left` | 250ms | Drawers / sheets       |
+| `animate-shimmer`       | 1.6s ∞  | Skeletons (com `bg-[length:200%_100%]`) |
+| `animate-accordion-down`/ `-up` | 200ms | Radix Accordion              |
+
+Diretrizes:
+
+- Entrada de página/seção: `animate-fade-in` ou `-fade-in-up`.
+- Drawer/sheet: `-slide-in-from-{right,left}` (curva mais rápida, 250ms).
+- Skeleton: `animate-shimmer` no container com gradiente.
+- Não introduza novas durações sem token — adicione em `theme.extend.animation`.
+
+## Espaçamento
+
+Use a escala padrão do Tailwind (`p-{0..96}`, `gap-{0..96}`) — múltiplos
+de `0.25rem` (4px). Sem overrides no `tailwind.config.ts`.
+
+Convenções por contexto:
+
+| Contexto                  | Espaçamento padrão       |
+|---------------------------|--------------------------|
+| `SectionCard` interno     | `p-5 md:p-6` (20/24px)   |
+| Header de página          | `py-4` + `gap-3`         |
+| Stack vertical de cards   | `space-y-4` ou `gap-4`   |
+| Inline (icon + label)     | `gap-1.5` ou `gap-2`     |
+| Form fields verticalmente | `space-y-4`              |
+
+`px-1.5`/`py-0.5` (6px / 2px) só em microbadges. Para `MetricCard` /
+`PageHeader` etc., respeite o padding interno do componente — não embrulhe
+em outro `p-*`.
+
+## Breakpoints
+
+Padrões Tailwind (mobile-first). `2xl` foi customizado para 1400px em
+`theme.container.screens` (afeta apenas `container`, não `2xl:` em geral).
+
+| Token  | min-width | Uso                              |
+|--------|-----------|----------------------------------|
+| `sm:`  | 640 px    | Phone landscape / tablet pequeno |
+| `md:`  | 768 px    | Tablet / breakpoint principal    |
+| `lg:`  | 1024 px   | Laptop                           |
+| `xl:`  | 1280 px   | Desktop                          |
+| `2xl:` | 1536 px   | Wide / `container` em 1400 px    |
+
+Diretrizes:
+
+- Componentes nascem mobile-first; aplique variantes só onde a UI muda.
+- Toolbars e tabelas geralmente alternam em `md:` (768).
+- Layouts de duas colunas ativam em `lg:` (1024).
+- Não use `sm:` para "pequena diferença" — confunde com mobile portrait.

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -1,127 +1,82 @@
 # Design Tokens — Portal BWild
 
-Referência única para tokens de design do Portal BWild. Todos os tokens vivem
-em `src/index.css` (variáveis HSL) e `tailwind.config.ts` (mapeamento Tailwind).
-Componentes do design system (`@/components/ui-premium` e
-`@/components/typography`) consomem estes tokens — **nunca** use cor literal,
-tamanho de texto solto ou primitivo legado fora dessas pastas.
+Tokens vivem em `src/index.css` (HSL) e `tailwind.config.ts`. Componentes
+em `@/components/ui-premium` e `@/components/typography` os consomem —
+fora dessas pastas, **não** use cor literal, tamanho de texto solto ou
+primitivo legado. ESLint sinaliza (severidade `warn`, ver `eslint.config.js`).
 
-> **Bloco 3 (issue #20)** — este documento é o produto de centralização do
-> Design System. ESLint enforça as regras correspondentes (severidade
-> temporária `warn`, ver `eslint.config.js`).
+## Cores
 
----
+| Token              | Uso                                  |
+|--------------------|--------------------------------------|
+| `primary`          | CTA principal (BWild blue)           |
+| `background` / `foreground` | Canvas / texto principal    |
+| `muted` / `muted-foreground` | Estados sem ação / secundário |
+| `border` / `border-subtle` | Divisórias / linhas internas |
+| `success`          | OK, concluído, em dia                |
+| `info`             | Em andamento, aguardando             |
+| `warning`          | Atenção, urgente                     |
+| `destructive`      | Erro, atrasado, crítico              |
 
-## 1. Cores semânticas
+Mapeamento literal → token (ESLint enforça):
 
-Use sempre o token semântico — nunca a cor literal Tailwind. Cores literais
-quebram dark mode e diluem a paleta primária BWild blue.
-
-| Token            | Light HSL          | Dark HSL           | Uso                                      |
-|------------------|--------------------|--------------------|------------------------------------------|
-| `primary`        | `204 100% 25%`     | `204 80% 35%`      | CTA principal, BWild blue dominante      |
-| `accent`         | `204 50% 95%`      | `204 40% 25%`      | Hover/selected sutil                     |
-| `background`     | `220 20% 98.5%`    | `220 14% 10%`      | Canvas da página                         |
-| `foreground`     | `222 25% 11%`      | `220 14% 96%`      | Texto principal                          |
-| `muted`          | `220 16% 95.5%`    | `220 14% 20%`      | Estados sem ação                         |
-| `muted-foreground` | `220 12% 38%`    | `220 9% 55%`       | Texto secundário                         |
-| `border`         | `220 14% 88%`      | —                  | Divisórias padrão                        |
-| `border-subtle`  | `220 16% 92%`      | —                  | Linhas internas (table rows)             |
-| `success`        | `152 65% 32%`      | `160 84% 45%`      | OK, concluído, em dia                    |
-| `info`           | `211 90% 38%`      | `204 80% 45%`      | Em andamento, aguardando                 |
-| `warning`        | `32 92% 42%`       | (escala dark)      | Atenção, urgente, aguardando cliente     |
-| `destructive`    | `0 72% 48%`        | (escala dark)      | Erro, atrasado, recusado, crítico        |
-
-### Mapeamento `cor literal → token semântico`
-
-ESLint sinaliza qualquer ocorrência fora de `src/components/ui/**`,
-`src/components/ui-premium/**` e `src/components/typography/**`.
-
-| Literal Tailwind   | Token semântico | Quando usar                       |
-|--------------------|-----------------|-----------------------------------|
-| `*-rose-*`         | `destructive`   | erro, bloqueio, atraso            |
-| `*-amber-*`        | `warning`       | atenção, urgente                  |
-| `*-emerald-*`      | `success`       | ok, concluído, em dia             |
-| `*-sky-*`          | `info`          | em andamento, informativo         |
-
-Exemplos:
+| Literal Tailwind | Token         |
+|------------------|---------------|
+| `*-rose-*`       | `destructive` |
+| `*-amber-*`      | `warning`     |
+| `*-emerald-*`    | `success`     |
+| `*-sky-*`        | `info`        |
 
 ```diff
 - <div className="bg-rose-500/10 text-rose-600 border-rose-500/20">
 + <div className="bg-destructive/10 text-destructive border-destructive/20">
-
-- <div className="bg-emerald-500/10 text-emerald-700 border-emerald-300/50">
-+ <div className="bg-success/10 text-success border-success/30">
 ```
 
----
+## Tipografia
 
-## 2. Tipografia
+Use `<Heading>` / `<Text>` de `@/components/typography`. Não use
+`text-2xl..text-7xl` solto.
 
-Toda hierarquia de texto vive na escala `src/index.css` e é exposta pelos
-componentes em `@/components/typography`. **Não** use `text-2xl..text-7xl`
-solto — ESLint sinaliza.
-
-| Componente         | Token CSS                | Tamanho mobile | Tamanho desktop | Weight     | Uso                            |
-|--------------------|--------------------------|----------------|-----------------|------------|--------------------------------|
-| `<Heading level="page">`    | `text-page-title`  | 16px           | 18px            | bold       | Título de página               |
-| `<Heading level="section">` | `text-section-title` | 16px         | 18px            | semibold   | Seção / subseção               |
-| `<Heading level="card">`    | `text-card-label`  | 14px           | 15px            | semibold   | Label de card                  |
-| `<Heading level="value">`   | `text-card-value`  | 20px           | 24px            | bold (tab) | Valor numérico (KPI)           |
-| `<Text variant="body">`     | `text-body`        | 14px           | 15px            | regular    | Corpo padrão                   |
-| `<Text variant="caption">`  | `text-caption`     | 13px           | 14px            | regular    | Legenda / texto secundário     |
-| `<Text variant="meta">`     | `text-meta`        | 11px           | 12px            | regular    | Timestamp, badges, microcopy   |
-
-Aliases legados (`text-h1`, `text-h2`, `text-h3`) ainda existem em
-`src/index.css` por compatibilidade — não os use em código novo.
+| Componente                  | Mobile / Desktop | Uso                |
+|-----------------------------|------------------|--------------------|
+| `<Heading level="page">`    | 16 / 18 px bold  | Título de página   |
+| `<Heading level="section">` | 16 / 18 px semi  | Seção              |
+| `<Heading level="card">`    | 14 / 15 px semi  | Label de card      |
+| `<Heading level="value">`   | 20 / 24 px bold  | KPI numérico       |
+| `<Text variant="body">`     | 14 / 15 px       | Corpo              |
+| `<Text variant="caption">`  | 13 / 14 px muted | Legenda            |
+| `<Text variant="meta">`     | 11 / 12 px muted | Timestamp / micro  |
 
 ```diff
-- <h1 className="text-h1 text-3xl md:text-5xl tracking-tight">Portal do Cliente</h1>
-+ <Heading level="page" className="tracking-tight">Portal do Cliente</Heading>
+- <h1 className="text-h1 text-3xl md:text-5xl">Portal do Cliente</h1>
++ <Heading level="page">Portal do Cliente</Heading>
 ```
 
----
+## Componentes premium
 
-## 3. Componentes do design system
-
-Substitutos canônicos para primitivos shadcn — bloqueados via
-`no-restricted-imports` (severidade `warn`).
-
-| Substituir                          | Por                                       | Razão                              |
-|-------------------------------------|-------------------------------------------|------------------------------------|
-| `@/components/ui/card` (Card)       | `SectionCard` de `@/components/ui-premium` | Superfície consistente (border-subtle + elevation-xs + radius-lg + header padronizado) |
-| `@/components/ui/badge` (Badge)     | `StatusBadge` de `@/components/ui-premium` | Tom semântico (`tone`) + dot + tamanhos calibrados |
-| `<h1 className="text-3xl ...">`     | `<Heading level="page">`                   | Escala única                       |
-| `bg-rose-500/10`                    | `bg-destructive/10`                        | Token semântico                    |
-
-Exemplo `Badge → StatusBadge`:
+| Substituir                      | Por                                       |
+|---------------------------------|-------------------------------------------|
+| `@/components/ui/card` (Card)   | `SectionCard` (`@/components/ui-premium`) |
+| `@/components/ui/badge` (Badge) | `StatusBadge` (`@/components/ui-premium`) |
 
 ```diff
 - <Badge variant="outline" className="bg-emerald-500/10 text-emerald-600">Ativo</Badge>
 + <StatusBadge tone="success">Ativo</StatusBadge>
 ```
 
----
+## Status tones
 
-## 4. Status tones (mapeamento de domínio)
-
-Centralizado em `src/lib/statusTone.ts` (PainelStatus) e
+Mapeamento centralizado em `src/lib/statusTone.ts` (PainelStatus) e
 `src/lib/statusTones.ts` (orçamento, severidade, fornecedor, etc.).
 
-| Domínio        | Status                | Tone        |
-|----------------|-----------------------|-------------|
-| PainelStatus   | `Aguardando`          | `info`      |
-| PainelStatus   | `Em dia`              | `success`   |
-| PainelStatus   | `Atrasado`            | `danger`    |
-| PainelStatus   | `Paralisada`          | `muted`     |
-| Severidade     | `low`                 | `neutral`   |
-| Severidade     | `medium`              | `info`      |
-| Severidade     | `high`                | `warning`   |
-| Severidade     | `critical`            | `danger`    |
-| Prioridade     | `low`                 | `muted`     |
-| Prioridade     | `normal`              | `neutral`   |
-| Prioridade     | `high`                | `warning`   |
-| Prioridade     | `urgent`              | `danger`    |
+| Domínio        | Status        | Tone        |
+|----------------|---------------|-------------|
+| PainelStatus   | `Aguardando`  | `info`      |
+| PainelStatus   | `Em dia`      | `success`   |
+| PainelStatus   | `Atrasado`    | `danger`    |
+| PainelStatus   | `Paralisada`  | `muted`     |
+| Severidade     | low / medium / high / critical | neutral / info / warning / danger |
+| Prioridade     | low / normal / high / urgent   | muted / neutral / warning / danger |
 
 ```ts
 import { getStatusTone } from '@/lib/statusTone';
@@ -130,87 +85,22 @@ import { StatusBadge } from '@/components/ui-premium';
 <StatusBadge tone={getStatusTone(obra.status)}>{obra.status}</StatusBadge>;
 ```
 
----
+## Ícones (lucide)
 
-## 5. Ícones (lucide-react)
+| Tamanho | Classe              | Uso                    |
+|---------|---------------------|------------------------|
+| 14 px   | `w-3.5 h-3.5`       | Inline em texto        |
+| 16 px   | `w-4 h-4`           | Botões, badges         |
+| 18 px   | `w-[18px] h-[18px]` | Sidebar, abas          |
+| 20 px   | `w-5 h-5`           | KPIs, cabeçalhos       |
+| 24 px   | `w-6 h-6`           | Empty state hero       |
 
-Padronizar tamanho conforme contexto.
+## Elevação · radius · z-index
 
-| Tamanho | Classe Tailwind  | Uso                                 |
-|---------|------------------|-------------------------------------|
-| 14px    | `w-3.5 h-3.5`    | Inline em texto, dots de tabela     |
-| 16px    | `w-4 h-4`        | Botões, badges, inputs              |
-| 18px    | `w-[18px] h-[18px]` | Sidebar, abas                    |
-| 20px    | `w-5 h-5`        | KPIs, cabeçalhos de seção           |
-| 24px    | `w-6 h-6`        | Empty state hero, avatares grandes  |
-
-Não use 12px (`w-3`) exceto em microbadges. Tamanhos pares ímpares (`w-7`,
-`w-9`) requerem justificativa visual.
-
----
-
-## 6. Elevação (sombras)
-
-Escala centralizada em `src/index.css` como `elevation-{xs,sm,md,lg,xl}`.
-**Evite** `shadow-sm/md/lg` solto — use `elevation-*` para herdar a curva
-unificada.
-
-| Token          | CSS                                      | Uso                                  |
-|----------------|------------------------------------------|--------------------------------------|
-| `elevation-xs` | `var(--shadow-xs)` — 1px subtle line     | Cards de seção (default)             |
-| `elevation-sm` | `var(--shadow-sm)`                       | Inputs, popovers leves               |
-| `elevation-md` | `var(--shadow-md)`                       | Dropdowns, hovers                    |
-| `elevation-lg` | `var(--shadow-lg)`                       | Modais, sheets                       |
-| `elevation-xl` | `var(--shadow-xl)`                       | Modais críticos, hero overlays       |
-
----
-
-## 7. Radius
-
-Tokens em `src/index.css`. Tailwind expõe via `rounded-{sm,md,lg}`.
-
-| Token          | CSS              | Uso                                       |
-|----------------|------------------|-------------------------------------------|
-| `radius-sm`    | `0.375rem` (6px) | Pills internos, microbadges               |
-| `radius-md`    | `0.5rem` (8px)   | Inputs, botões padrão                     |
-| `radius`       | `0.625rem` (10px)| **Default** — cards, sections, dialogs    |
-| `radius-lg`    | `0.875rem` (14px)| Hero cards, banners                       |
-| `radius-xl`    | `1.125rem` (18px)| Modais grandes, painéis hero              |
-
-> Regra: **`rounded-xl/2xl` ad-hoc requer justificativa.** O default de cards
-> deve ser `rounded-lg` (= `var(--radius)`), não `rounded-xl`.
-
----
-
-## 8. Z-index (overlays)
-
-Nunca sobrescrever `z-*` em `*Content` de Dialog/Sheet/Drawer/Popover/etc.
-Tokens em `tailwind.config.ts`: `z-modal`, `z-popover`, `z-alert`, etc.
-ESLint enforça via `no-restricted-syntax`.
-
----
-
-## 9. Backlog de migração (Bloco 3)
-
-Status no momento desta versão do doc:
-
-- ESLint: regras `warn` ativas — promover a `error` quando os contadores
-  abaixo zerarem.
-- `bg|text|border-{rose,amber,emerald,sky}-*`: ainda há uso em ~60 arquivos.
-- `@/components/ui/card`: ainda importado em ~120 arquivos.
-- `@/components/ui/badge`: ainda importado em ~140 arquivos.
-- `text-{2,3,4,5,6,7}xl`: ainda em ~80 ocorrências fora de
-  `@/components/typography` e `@/components/ui`.
-
-Cada PR de migração deve:
-
-1. Cobrir uma sub-pasta (`src/pages/`, `src/components/admin/`, etc.).
-2. Reduzir os contadores acima.
-3. Não introduzir novas violações (ESLint sinaliza).
-4. Atualizar este doc se a tabela mudar.
-
-Quando os contadores chegarem a zero, abrir um PR final que:
-
-- Promove `no-restricted-imports` e `no-restricted-syntax` de `warn` → `error`.
-- Remove os aliases legados (`text-h1/h2/h3`) de `src/index.css`.
-- Adiciona o teste de regressão visual com Playwright nas 10 rotas-chave.
+- **Elevação**: `elevation-{xs,sm,md,lg,xl}` (`src/index.css`). Default em
+  `SectionCard` é `elevation-xs`. Evite `shadow-sm/md/lg` solto.
+- **Radius**: `rounded-{sm,md,lg}` mapeiam a `--radius` (10px). Default de
+  cards é `rounded-lg`; `rounded-xl/2xl` requer justificativa (hero, modal).
+- **Z-index**: nunca sobrescrever `z-*` em `*Content` de Dialog / Sheet /
+  Drawer / Popover etc. Use tokens (`z-modal`, `z-popover`, `z-alert`) de
+  `tailwind.config.ts`.

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -1,0 +1,216 @@
+# Design Tokens — Portal BWild
+
+Referência única para tokens de design do Portal BWild. Todos os tokens vivem
+em `src/index.css` (variáveis HSL) e `tailwind.config.ts` (mapeamento Tailwind).
+Componentes do design system (`@/components/ui-premium` e
+`@/components/typography`) consomem estes tokens — **nunca** use cor literal,
+tamanho de texto solto ou primitivo legado fora dessas pastas.
+
+> **Bloco 3 (issue #20)** — este documento é o produto de centralização do
+> Design System. ESLint enforça as regras correspondentes (severidade
+> temporária `warn`, ver `eslint.config.js`).
+
+---
+
+## 1. Cores semânticas
+
+Use sempre o token semântico — nunca a cor literal Tailwind. Cores literais
+quebram dark mode e diluem a paleta primária BWild blue.
+
+| Token            | Light HSL          | Dark HSL           | Uso                                      |
+|------------------|--------------------|--------------------|------------------------------------------|
+| `primary`        | `204 100% 25%`     | `204 80% 35%`      | CTA principal, BWild blue dominante      |
+| `accent`         | `204 50% 95%`      | `204 40% 25%`      | Hover/selected sutil                     |
+| `background`     | `220 20% 98.5%`    | `220 14% 10%`      | Canvas da página                         |
+| `foreground`     | `222 25% 11%`      | `220 14% 96%`      | Texto principal                          |
+| `muted`          | `220 16% 95.5%`    | `220 14% 20%`      | Estados sem ação                         |
+| `muted-foreground` | `220 12% 38%`    | `220 9% 55%`       | Texto secundário                         |
+| `border`         | `220 14% 88%`      | —                  | Divisórias padrão                        |
+| `border-subtle`  | `220 16% 92%`      | —                  | Linhas internas (table rows)             |
+| `success`        | `152 65% 32%`      | `160 84% 45%`      | OK, concluído, em dia                    |
+| `info`           | `211 90% 38%`      | `204 80% 45%`      | Em andamento, aguardando                 |
+| `warning`        | `32 92% 42%`       | (escala dark)      | Atenção, urgente, aguardando cliente     |
+| `destructive`    | `0 72% 48%`        | (escala dark)      | Erro, atrasado, recusado, crítico        |
+
+### Mapeamento `cor literal → token semântico`
+
+ESLint sinaliza qualquer ocorrência fora de `src/components/ui/**`,
+`src/components/ui-premium/**` e `src/components/typography/**`.
+
+| Literal Tailwind   | Token semântico | Quando usar                       |
+|--------------------|-----------------|-----------------------------------|
+| `*-rose-*`         | `destructive`   | erro, bloqueio, atraso            |
+| `*-amber-*`        | `warning`       | atenção, urgente                  |
+| `*-emerald-*`      | `success`       | ok, concluído, em dia             |
+| `*-sky-*`          | `info`          | em andamento, informativo         |
+
+Exemplos:
+
+```diff
+- <div className="bg-rose-500/10 text-rose-600 border-rose-500/20">
++ <div className="bg-destructive/10 text-destructive border-destructive/20">
+
+- <div className="bg-emerald-500/10 text-emerald-700 border-emerald-300/50">
++ <div className="bg-success/10 text-success border-success/30">
+```
+
+---
+
+## 2. Tipografia
+
+Toda hierarquia de texto vive na escala `src/index.css` e é exposta pelos
+componentes em `@/components/typography`. **Não** use `text-2xl..text-7xl`
+solto — ESLint sinaliza.
+
+| Componente         | Token CSS                | Tamanho mobile | Tamanho desktop | Weight     | Uso                            |
+|--------------------|--------------------------|----------------|-----------------|------------|--------------------------------|
+| `<Heading level="page">`    | `text-page-title`  | 16px           | 18px            | bold       | Título de página               |
+| `<Heading level="section">` | `text-section-title` | 16px         | 18px            | semibold   | Seção / subseção               |
+| `<Heading level="card">`    | `text-card-label`  | 14px           | 15px            | semibold   | Label de card                  |
+| `<Heading level="value">`   | `text-card-value`  | 20px           | 24px            | bold (tab) | Valor numérico (KPI)           |
+| `<Text variant="body">`     | `text-body`        | 14px           | 15px            | regular    | Corpo padrão                   |
+| `<Text variant="caption">`  | `text-caption`     | 13px           | 14px            | regular    | Legenda / texto secundário     |
+| `<Text variant="meta">`     | `text-meta`        | 11px           | 12px            | regular    | Timestamp, badges, microcopy   |
+
+Aliases legados (`text-h1`, `text-h2`, `text-h3`) ainda existem em
+`src/index.css` por compatibilidade — não os use em código novo.
+
+```diff
+- <h1 className="text-h1 text-3xl md:text-5xl tracking-tight">Portal do Cliente</h1>
++ <Heading level="page" className="tracking-tight">Portal do Cliente</Heading>
+```
+
+---
+
+## 3. Componentes do design system
+
+Substitutos canônicos para primitivos shadcn — bloqueados via
+`no-restricted-imports` (severidade `warn`).
+
+| Substituir                          | Por                                       | Razão                              |
+|-------------------------------------|-------------------------------------------|------------------------------------|
+| `@/components/ui/card` (Card)       | `SectionCard` de `@/components/ui-premium` | Superfície consistente (border-subtle + elevation-xs + radius-lg + header padronizado) |
+| `@/components/ui/badge` (Badge)     | `StatusBadge` de `@/components/ui-premium` | Tom semântico (`tone`) + dot + tamanhos calibrados |
+| `<h1 className="text-3xl ...">`     | `<Heading level="page">`                   | Escala única                       |
+| `bg-rose-500/10`                    | `bg-destructive/10`                        | Token semântico                    |
+
+Exemplo `Badge → StatusBadge`:
+
+```diff
+- <Badge variant="outline" className="bg-emerald-500/10 text-emerald-600">Ativo</Badge>
++ <StatusBadge tone="success">Ativo</StatusBadge>
+```
+
+---
+
+## 4. Status tones (mapeamento de domínio)
+
+Centralizado em `src/lib/statusTone.ts` (PainelStatus) e
+`src/lib/statusTones.ts` (orçamento, severidade, fornecedor, etc.).
+
+| Domínio        | Status                | Tone        |
+|----------------|-----------------------|-------------|
+| PainelStatus   | `Aguardando`          | `info`      |
+| PainelStatus   | `Em dia`              | `success`   |
+| PainelStatus   | `Atrasado`            | `danger`    |
+| PainelStatus   | `Paralisada`          | `muted`     |
+| Severidade     | `low`                 | `neutral`   |
+| Severidade     | `medium`              | `info`      |
+| Severidade     | `high`                | `warning`   |
+| Severidade     | `critical`            | `danger`    |
+| Prioridade     | `low`                 | `muted`     |
+| Prioridade     | `normal`              | `neutral`   |
+| Prioridade     | `high`                | `warning`   |
+| Prioridade     | `urgent`              | `danger`    |
+
+```ts
+import { getStatusTone } from '@/lib/statusTone';
+import { StatusBadge } from '@/components/ui-premium';
+
+<StatusBadge tone={getStatusTone(obra.status)}>{obra.status}</StatusBadge>;
+```
+
+---
+
+## 5. Ícones (lucide-react)
+
+Padronizar tamanho conforme contexto.
+
+| Tamanho | Classe Tailwind  | Uso                                 |
+|---------|------------------|-------------------------------------|
+| 14px    | `w-3.5 h-3.5`    | Inline em texto, dots de tabela     |
+| 16px    | `w-4 h-4`        | Botões, badges, inputs              |
+| 18px    | `w-[18px] h-[18px]` | Sidebar, abas                    |
+| 20px    | `w-5 h-5`        | KPIs, cabeçalhos de seção           |
+| 24px    | `w-6 h-6`        | Empty state hero, avatares grandes  |
+
+Não use 12px (`w-3`) exceto em microbadges. Tamanhos pares ímpares (`w-7`,
+`w-9`) requerem justificativa visual.
+
+---
+
+## 6. Elevação (sombras)
+
+Escala centralizada em `src/index.css` como `elevation-{xs,sm,md,lg,xl}`.
+**Evite** `shadow-sm/md/lg` solto — use `elevation-*` para herdar a curva
+unificada.
+
+| Token          | CSS                                      | Uso                                  |
+|----------------|------------------------------------------|--------------------------------------|
+| `elevation-xs` | `var(--shadow-xs)` — 1px subtle line     | Cards de seção (default)             |
+| `elevation-sm` | `var(--shadow-sm)`                       | Inputs, popovers leves               |
+| `elevation-md` | `var(--shadow-md)`                       | Dropdowns, hovers                    |
+| `elevation-lg` | `var(--shadow-lg)`                       | Modais, sheets                       |
+| `elevation-xl` | `var(--shadow-xl)`                       | Modais críticos, hero overlays       |
+
+---
+
+## 7. Radius
+
+Tokens em `src/index.css`. Tailwind expõe via `rounded-{sm,md,lg}`.
+
+| Token          | CSS              | Uso                                       |
+|----------------|------------------|-------------------------------------------|
+| `radius-sm`    | `0.375rem` (6px) | Pills internos, microbadges               |
+| `radius-md`    | `0.5rem` (8px)   | Inputs, botões padrão                     |
+| `radius`       | `0.625rem` (10px)| **Default** — cards, sections, dialogs    |
+| `radius-lg`    | `0.875rem` (14px)| Hero cards, banners                       |
+| `radius-xl`    | `1.125rem` (18px)| Modais grandes, painéis hero              |
+
+> Regra: **`rounded-xl/2xl` ad-hoc requer justificativa.** O default de cards
+> deve ser `rounded-lg` (= `var(--radius)`), não `rounded-xl`.
+
+---
+
+## 8. Z-index (overlays)
+
+Nunca sobrescrever `z-*` em `*Content` de Dialog/Sheet/Drawer/Popover/etc.
+Tokens em `tailwind.config.ts`: `z-modal`, `z-popover`, `z-alert`, etc.
+ESLint enforça via `no-restricted-syntax`.
+
+---
+
+## 9. Backlog de migração (Bloco 3)
+
+Status no momento desta versão do doc:
+
+- ESLint: regras `warn` ativas — promover a `error` quando os contadores
+  abaixo zerarem.
+- `bg|text|border-{rose,amber,emerald,sky}-*`: ainda há uso em ~60 arquivos.
+- `@/components/ui/card`: ainda importado em ~120 arquivos.
+- `@/components/ui/badge`: ainda importado em ~140 arquivos.
+- `text-{2,3,4,5,6,7}xl`: ainda em ~80 ocorrências fora de
+  `@/components/typography` e `@/components/ui`.
+
+Cada PR de migração deve:
+
+1. Cobrir uma sub-pasta (`src/pages/`, `src/components/admin/`, etc.).
+2. Reduzir os contadores acima.
+3. Não introduzir novas violações (ESLint sinaliza).
+4. Atualizar este doc se a tabela mudar.
+
+Quando os contadores chegarem a zero, abrir um PR final que:
+
+- Promove `no-restricted-imports` e `no-restricted-syntax` de `warn` → `error`.
+- Remove os aliases legados (`text-h1/h2/h3`) de `src/index.css`.
+- Adiciona o teste de regressão visual com Playwright nas 10 rotas-chave.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,28 +45,97 @@ export default tseslint.config(
     },
   },
   {
-    /**
-     * Z-INDEX GUARD — proíbe sobrescrever `z-*` em componentes overlay
-     * (Dialog, Sheet, Drawer, Select, Popover, Dropdown, ContextMenu,
-     * HoverCard, Tooltip, Menubar, AlertDialog).
-     *
-     * A escala vive em `tailwind.config.ts` como tokens semânticos
-     * (`z-modal`, `z-popover`, `z-alert`, ...). Esses componentes já
-     * carregam o token correto internamente — sobrescrever quebra a
-     * hierarquia e causa bugs como "popup atrás do modal".
-     *
-     * Não se aplica a `src/components/ui/*` (definição base da escala).
-     */
+    // DESIGN SYSTEM + Z-INDEX GUARDS (Bloco 3 — issue #20).
+    //
+    // Aplicados a `src/...{ts,tsx}` exceto fonte do design system
+    // (`components/ui`, `components/ui-premium`, `components/typography`),
+    // que precisam usar os primitivos crus para definir a escala.
+    //
+    // 1. `no-restricted-imports` — bloqueia imports legados:
+    //    - `@/components/ui/card`  → use `SectionCard`  de `@/components/ui-premium`.
+    //    - `@/components/ui/badge` → use `StatusBadge` de `@/components/ui-premium`.
+    //
+    // 2. `no-restricted-syntax` — três conjuntos de selectors:
+    //    a) Z-index em overlays (Dialog/Sheet/Drawer/Select/Popover/Dropdown
+    //       /ContextMenu/HoverCard/Tooltip/Menubar/AlertDialog): nunca
+    //       sobrescrever `z-` direto — use tokens (`z-modal`, `z-popover`,
+    //       `z-alert`) de `tailwind.config.ts`. Quebra hierarquia e gera
+    //       "popup atrás do modal".
+    //    b) Cores literais Tailwind (rose/amber/emerald/sky em qualquer
+    //       prefixo bg/text/border/ring/...): usar tokens semânticos
+    //       (destructive / warning / success / info) — quebra dark mode e
+    //       branding BWild blue.
+    //    c) Tamanhos de texto soltos (`text-2xl..text-7xl`): usar
+    //       `<Heading level=...>` de `@/components/typography` para preservar
+    //       a escala oficial.
+    //
+    // Severidade = `warn` (temporário): o codebase tem ~400 violações de cor
+    // literal e ~250 imports legados acumulados. Subir para `error` deve ser
+    // feito em PR dedicado após os codemods completos. O selector de z-index
+    // historicamente era `error` (commit anterior); foi rebaixado a `warn`
+    // para coexistir num único rule entry — o flat config do ESLint sobrescreve
+    // `no-restricted-syntax` por last-wins quando declarado em blocos
+    // separados. Restaurar para `error` junto com os demais selectors quando
+    // a migração completar.
     files: ["src/**/*.{ts,tsx}"],
-    ignores: ["src/components/ui/**"],
+    ignores: [
+      "src/components/ui/**",
+      "src/components/ui-premium/**",
+      "src/components/typography/**",
+    ],
     rules: {
+      "no-restricted-imports": [
+        "warn",
+        {
+          patterns: [
+            {
+              group: ["@/components/ui/card"],
+              message:
+                "Use SectionCard de @/components/ui-premium em vez de Card legacy. Ver docs/DESIGN_TOKENS.md.",
+            },
+            {
+              group: ["@/components/ui/badge"],
+              message:
+                "Use StatusBadge de @/components/ui-premium em vez de Badge legacy (passe `tone` semântico). Ver docs/DESIGN_TOKENS.md.",
+            },
+          ],
+        },
+      ],
       "no-restricted-syntax": [
-        "error",
+        "warn",
         {
           selector:
             "JSXOpeningElement[name.name=/^(Dialog|Sheet|Drawer|Popover|Select|DropdownMenu|ContextMenu|HoverCard|Tooltip|Menubar|AlertDialog)Content$/] JSXAttribute[name.name='className'] Literal[value=/\\bz-/]",
           message:
             "Não sobrescreva z-index em componentes overlay. Use os tokens semânticos da escala (z-modal, z-popover, z-alert) definidos em tailwind.config.ts. Se precisar de um nível novo, adicione um token na escala.",
+        },
+        {
+          // Cores literais Tailwind (rose/amber/emerald/sky) em qualquer string.
+          // Cobre className, cn(), tw``, cva, etc. `\b` final aceita a fronteira
+          // independentemente do sufixo de opacidade (`/10`, `/20`, ...) — `/`
+          // é caractere não-palavra e gera word boundary.
+          selector:
+            "Literal[value=/\\b(bg|text|border|ring|from|to|via|fill|stroke|divide|outline|decoration|placeholder|caret|accent|shadow)-(rose|amber|emerald|sky)-(50|100|200|300|400|500|600|700|800|900|950)\\b/]",
+          message:
+            "Cor literal Tailwind proibida — use tokens semânticos: rose→destructive, amber→warning, emerald→success, sky→info. Ver docs/DESIGN_TOKENS.md.",
+        },
+        {
+          selector:
+            "TemplateElement[value.raw=/\\b(bg|text|border|ring|from|to|via|fill|stroke|divide|outline|decoration|placeholder|caret|accent|shadow)-(rose|amber|emerald|sky)-(50|100|200|300|400|500|600|700|800|900|950)\\b/]",
+          message:
+            "Cor literal Tailwind proibida — use tokens semânticos: rose→destructive, amber→warning, emerald→success, sky→info. Ver docs/DESIGN_TOKENS.md.",
+        },
+        {
+          selector:
+            "Literal[value=/\\btext-(2|3|4|5|6|7)xl\\b/]",
+          message:
+            "Tamanho de texto solto proibido — use <Heading level=...> de @/components/typography. Ver docs/DESIGN_TOKENS.md.",
+        },
+        {
+          selector:
+            "TemplateElement[value.raw=/\\btext-(2|3|4|5|6|7)xl\\b/]",
+          message:
+            "Tamanho de texto solto proibido — use <Heading level=...> de @/components/typography. Ver docs/DESIGN_TOKENS.md.",
         },
       ],
     },

--- a/src/components/gestao/ProjectsCardView.tsx
+++ b/src/components/gestao/ProjectsCardView.tsx
@@ -130,7 +130,7 @@ function ProjectCard({
         isOverdue
           ? 'border-destructive/30 bg-destructive/[0.02] hover:border-destructive/50'
           : isApproaching
-          ? 'border-amber-500/30 bg-amber-500/[0.02] hover:border-amber-500/50'
+          ? 'border-warning/30 bg-warning/[0.02] hover:border-warning/50'
           : 'border-border/50 hover:border-primary/30',
       )}
     >

--- a/src/components/gestao/ProjectsListView.tsx
+++ b/src/components/gestao/ProjectsListView.tsx
@@ -30,10 +30,10 @@ import type { ProjectSummary } from '@/infra/repositories/projects.repository';
 
 
 const statusColors: Record<string, string> = {
-  draft: 'bg-slate-500/10 text-slate-600 border-slate-300/50 dark:text-slate-400 dark:border-slate-500/20',
-  active: 'bg-emerald-500/10 text-emerald-700 border-emerald-300/50 dark:text-emerald-400 dark:border-emerald-500/20',
-  completed: 'bg-blue-500/10 text-blue-700 border-blue-300/50 dark:text-blue-400 dark:border-blue-500/20',
-  paused: 'bg-amber-500/10 text-amber-700 border-amber-300/50 dark:text-amber-400 dark:border-amber-500/20',
+  draft: 'bg-muted text-muted-foreground border-border',
+  active: 'bg-success/10 text-success border-success/30',
+  completed: 'bg-info/10 text-info border-info/30',
+  paused: 'bg-warning/10 text-warning border-warning/30',
   cancelled: 'bg-muted text-muted-foreground border-border',
 };
 
@@ -364,9 +364,9 @@ function ProjectRow({
         className={cn(
           'cursor-pointer transition-colors group/row border-b border-border/30 bg-white dark:bg-card',
           isOverdue
-            ? 'hover:bg-red-50/60 dark:hover:bg-destructive/[0.06]'
+            ? 'hover:bg-destructive/[0.06]'
             : isApproaching
-              ? 'hover:bg-amber-50/40 dark:hover:bg-amber-500/[0.05]'
+              ? 'hover:bg-warning/[0.06]'
               : 'hover:bg-muted/30',
         )}
       >
@@ -419,13 +419,13 @@ function ProjectRow({
           {currentStage ? (
             <div className="flex items-center gap-1.5 min-w-0">
               {currentStage.isAwaitingStart ? (
-                <Hourglass className="h-3 w-3 shrink-0 text-amber-500" />
+                <Hourglass className="h-3 w-3 shrink-0 text-warning" />
               ) : (
                 <HardHat className="h-3 w-3 shrink-0 text-primary" />
               )}
               <span className={cn(
                 'text-[11px] font-medium truncate max-w-[160px]',
-                currentStage.isAwaitingStart ? 'text-amber-600 dark:text-amber-400' : 'text-foreground/80',
+                currentStage.isAwaitingStart ? 'text-warning' : 'text-foreground/80',
               )}>
                 {currentStage.description}
               </span>
@@ -459,7 +459,7 @@ function ProjectRow({
             let cls: string;
             if (daysSinceUpdate === 0) {
               label = 'hoje';
-              cls = 'text-emerald-600 dark:text-emerald-400';
+              cls = 'text-success';
             } else if (daysSinceUpdate === 1) {
               label = 'ontem';
               cls = 'text-foreground/70';
@@ -468,7 +468,7 @@ function ProjectRow({
               cls = 'text-foreground/70';
             } else if (daysSinceUpdate <= 13) {
               label = `há ${daysSinceUpdate}d`;
-              cls = 'text-amber-600 dark:text-amber-400 font-semibold';
+              cls = 'text-warning font-semibold';
             } else {
               label = `há ${daysSinceUpdate}d`;
               cls = 'text-destructive font-bold';
@@ -493,15 +493,15 @@ function ProjectRow({
             <div className="flex flex-col items-center gap-0.5">
               <span className={cn(
                 'text-[13px] font-bold tabular-nums whitespace-nowrap leading-none',
-                isFinished ? 'text-emerald-600 dark:text-emerald-400' :
+                isFinished ? 'text-success' :
                 isOverdue ? 'text-destructive' :
-                isApproaching ? 'text-amber-600 dark:text-amber-400' :
+                isApproaching ? 'text-warning' :
                 'text-foreground',
               )}>
                 {format(plannedEnd, "dd/MM", { locale: ptBR })}
               </span>
               {isFinished ? (
-                <span className="text-[9px] text-emerald-600 dark:text-emerald-400 font-medium flex items-center gap-0.5 leading-none">
+                <span className="text-[9px] text-success font-medium flex items-center gap-0.5 leading-none">
                   <CheckCircle className="h-2.5 w-2.5" /> Entregue
                 </span>
               ) : isOverdue ? (
@@ -509,7 +509,7 @@ function ProjectRow({
                   <CalendarX className="h-2.5 w-2.5" /> {Math.abs(daysRemaining!)}d atraso
                 </span>
               ) : isApproaching ? (
-                <span className="text-[9px] text-amber-600 dark:text-amber-400 font-medium flex items-center gap-0.5 leading-none">
+                <span className="text-[9px] text-warning font-medium flex items-center gap-0.5 leading-none">
                   <Clock className="h-2.5 w-2.5" /> {daysRemaining}d
                 </span>
               ) : (
@@ -531,7 +531,7 @@ function ProjectRow({
                   <div
                     className={cn(
                       'absolute inset-y-0 left-0 rounded-full transition-all',
-                      progressDeviation >= 0 ? 'bg-emerald-500' : progressDeviation >= -10 ? 'bg-amber-500' : 'bg-destructive',
+                      progressDeviation >= 0 ? 'bg-success' : progressDeviation >= -10 ? 'bg-warning' : 'bg-destructive',
                     )}
                     style={{ width: `${Math.min(100, progress)}%` }}
                   />

--- a/src/components/pendencias/ApprovalDialog.tsx
+++ b/src/components/pendencias/ApprovalDialog.tsx
@@ -190,7 +190,7 @@ export function ApprovalDialog({
                 Solicitar Ajuste
               </Button>
               <Button
-                className="gap-2 bg-emerald-600 hover:bg-emerald-700 text-white"
+                className="gap-2 bg-success hover:bg-success/90 text-success-foreground"
                 onClick={() => setMode("approve")}
               >
                 <CheckCircle2 className="w-4 h-4" />
@@ -215,7 +215,7 @@ export function ApprovalDialog({
                 className={cn(
                   "gap-2",
                   mode === "approve"
-                    ? "bg-emerald-600 hover:bg-emerald-700 text-white"
+                    ? "bg-success hover:bg-success/90 text-success-foreground"
                     : "bg-[hsl(var(--warning))] hover:bg-[hsl(var(--warning))]/90 text-[hsl(var(--warning-foreground))]"
                 )}
               >

--- a/src/components/typography/Heading.tsx
+++ b/src/components/typography/Heading.tsx
@@ -1,0 +1,51 @@
+/**
+ * Heading — Componente de tipografia hierárquica do design system.
+ *
+ * Encapsula a escala definida em `src/index.css`:
+ *  - level="page"    → text-page-title (16/18px, semibold-bold)
+ *  - level="section" → text-section-title (16/18px, semibold)
+ *  - level="card"    → text-card-label   (14/15px, semibold)
+ *  - level="value"   → text-card-value   (20/24px, bold tabular)
+ *
+ * Substitui ad-hoc `text-h1/h2/h3` e `text-3xl/4xl/5xl` espalhados pelo
+ * código. Para tamanhos de hero/landing além da escala, use `level="page"`
+ * com `as="h1"` — a escala é intencionalmente conservadora.
+ *
+ * Bloco 3 (Design System): única fonte de verdade para títulos.
+ */
+import { forwardRef, type ElementType, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type HeadingLevel = 'page' | 'section' | 'card' | 'value';
+
+const levelClass: Record<HeadingLevel, string> = {
+  page: 'text-page-title',
+  section: 'text-section-title',
+  card: 'text-card-label',
+  value: 'text-card-value',
+};
+
+const defaultTagByLevel: Record<HeadingLevel, ElementType> = {
+  page: 'h1',
+  section: 'h2',
+  card: 'h3',
+  value: 'p',
+};
+
+interface HeadingProps extends HTMLAttributes<HTMLElement> {
+  level?: HeadingLevel;
+  as?: ElementType;
+  children: ReactNode;
+}
+
+export const Heading = forwardRef<HTMLElement, HeadingProps>(function Heading(
+  { level = 'section', as, className, children, ...rest },
+  ref,
+) {
+  const Tag = (as ?? defaultTagByLevel[level]) as ElementType;
+  return (
+    <Tag ref={ref} className={cn(levelClass[level], className)} {...rest}>
+      {children}
+    </Tag>
+  );
+});

--- a/src/components/typography/Text.tsx
+++ b/src/components/typography/Text.tsx
@@ -1,0 +1,39 @@
+/**
+ * Text — Componente de tipografia para corpo, legendas e meta.
+ *
+ * Encapsula a escala definida em `src/index.css`:
+ *  - variant="body"    → text-body    (14/15px)
+ *  - variant="caption" → text-caption (13/14px, muted)
+ *  - variant="meta"    → text-meta    (11/12px, muted)
+ *
+ * Bloco 3 (Design System): substitui usos soltos de `text-sm/text-xs/text-base`
+ * onde a intenção é semântica (corpo de parágrafo, legenda, timestamp).
+ */
+import { forwardRef, type ElementType, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type TextVariant = 'body' | 'caption' | 'meta';
+
+const variantClass: Record<TextVariant, string> = {
+  body: 'text-body',
+  caption: 'text-caption',
+  meta: 'text-meta',
+};
+
+interface TextProps extends HTMLAttributes<HTMLElement> {
+  variant?: TextVariant;
+  as?: ElementType;
+  children: ReactNode;
+}
+
+export const Text = forwardRef<HTMLElement, TextProps>(function Text(
+  { variant = 'body', as = 'p', className, children, ...rest },
+  ref,
+) {
+  const Tag = as as ElementType;
+  return (
+    <Tag ref={ref} className={cn(variantClass[variant], className)} {...rest}>
+      {children}
+    </Tag>
+  );
+});

--- a/src/components/typography/index.ts
+++ b/src/components/typography/index.ts
@@ -1,0 +1,8 @@
+/**
+ * typography — Escala única de títulos e corpo do design system.
+ *
+ * Importe daqui em vez de aplicar `text-h1/h2/h3` ou `text-3xl` direto.
+ * Veja `docs/DESIGN_TOKENS.md` para a tabela completa de tokens.
+ */
+export { Heading, type HeadingLevel } from './Heading';
+export { Text, type TextVariant } from './Text';

--- a/src/lib/statusTone.ts
+++ b/src/lib/statusTone.ts
@@ -1,0 +1,88 @@
+/**
+ * statusTone — Mapeamento centralizado PainelStatus → StatusTone semântico.
+ *
+ * Use junto com `<StatusBadge tone={getStatusTone(status)}>` ou para resolver
+ * a cor do dot indicador (`bg-${tone}` via util do design system).
+ *
+ * Bloco 3 (Design System): centralizar a decisão "qual cor para qual status"
+ * em um único lugar para que dark mode, branding e acessibilidade fiquem
+ * consistentes em todas as telas.
+ *
+ * Para outros domínios (orçamento, fornecedor, severidade, etc.) ver
+ * `src/lib/statusTones.ts` (mapas por domínio + getTone helper).
+ */
+import type { StatusTone } from '@/components/ui-premium';
+import type { PainelStatus } from '@/hooks/usePainelObras';
+
+/**
+ * Mapeamento canônico para `PainelStatus` (status de obra).
+ *
+ * - Aguardando → info     (em andamento, esperando algo)
+ * - Em dia     → success  (no prazo, ok)
+ * - Atrasado   → danger   (fora do prazo, requer ação)
+ * - Paralisada → muted    (pausada, sem movimento)
+ */
+export const PAINEL_STATUS_TONE: Record<PainelStatus, StatusTone> = {
+  Aguardando: 'info',
+  'Em dia': 'success',
+  Atrasado: 'danger',
+  Paralisada: 'muted',
+};
+
+/**
+ * Aliases para strings legadas / variantes de status que aparecem em outras
+ * telas (ex: PainelObras pode receber "Em andamento" vindo de um status mais
+ * antigo). Mantém a mesma intenção semântica.
+ */
+const STATUS_ALIAS_TONE: Record<string, StatusTone> = {
+  'Em andamento': 'info',
+  Pausado: 'muted',
+  'Aguardando cliente': 'warning',
+  Concluído: 'success',
+  Concluida: 'success',
+  Concluída: 'success',
+  'Não iniciado': 'neutral',
+  'Nao iniciado': 'neutral',
+  Finalizada: 'success',
+};
+
+/**
+ * Resolve o tom semântico para um status de obra.
+ *
+ * Aceita `PainelStatus` (tipado) ou strings ad-hoc — útil em telas que
+ * recebem o status como string genérica (kanban, filtros, badges em
+ * tabelas).
+ *
+ * @param status  status do painel ou string equivalente
+ * @param fallback tom usado quando o status é nulo/desconhecido (default: neutral)
+ */
+export function getStatusTone(
+  status: PainelStatus | string | null | undefined,
+  fallback: StatusTone = 'neutral',
+): StatusTone {
+  if (!status) return fallback;
+  if (status in PAINEL_STATUS_TONE) {
+    return PAINEL_STATUS_TONE[status as PainelStatus];
+  }
+  return STATUS_ALIAS_TONE[status] ?? fallback;
+}
+
+/**
+ * Classe Tailwind do dot indicador para um status — atalho equivalente a
+ * `bg-${tone}` resolvido via `getStatusTone`. Usado em pills inline e
+ * cabeçalhos de coluna de kanban onde StatusBadge seria pesado demais.
+ */
+const DOT_BY_TONE: Record<StatusTone, string> = {
+  neutral: 'bg-muted',
+  info: 'bg-info',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  danger: 'bg-destructive',
+  muted: 'bg-muted-foreground',
+};
+
+export function getStatusDotClass(
+  status: PainelStatus | string | null | undefined,
+): string {
+  return DOT_BY_TONE[getStatusTone(status)];
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { AppHeader } from "@/components/AppHeader";
 import CreateReportModal from "@/components/CreateReportModal";
 import { ReportData } from "@/types/report";
 import { useAuth } from "@/hooks/useAuth";
+import { Heading } from "@/components/typography";
 import { isDemoMode } from "@/config/flags";
 
 // Demo data - only used when isDemoMode is true
@@ -67,9 +68,9 @@ const Home = () => {
           {/* Hero Section */}
           <div className="space-y-4 md:space-y-6">
             <div className="flex flex-col items-center gap-2 md:gap-3 animate-fade-in">
-              <h1 className="text-h1 text-3xl md:text-5xl tracking-tight">
+              <Heading level="page" className="tracking-tight">
                 Portal do Cliente
-              </h1>
+              </Heading>
             </div>
             <p className="text-body text-muted-foreground max-w-md mx-auto leading-relaxed animate-fade-in [animation-delay:100ms] opacity-0 [animation-fill-mode:forwards] px-2">
               {isDemoMode 

--- a/src/pages/PainelObras.tsx
+++ b/src/pages/PainelObras.tsx
@@ -190,16 +190,13 @@ const computeOverdueDays = (obra: {
 };
 
 import { getEtapaWeek, formatEtapaLabel } from '@/lib/painelEtapaWeek';
+import { getStatusDotClass } from '@/lib/statusTone';
 
-const statusDotClass = (s: PainelStatus | null): string => {
-  switch (s) {
-    case 'Aguardando': return 'bg-info';
-    case 'Em dia':     return 'bg-success';
-    case 'Atrasado':   return 'bg-destructive';
-    case 'Paralisada': return 'bg-muted-foreground';
-    default:           return 'bg-muted';
-  }
-};
+// `statusDotClass` agora é uma fina camada sobre o helper central `getStatusDotClass`
+// (`src/lib/statusTone.ts`). Mantida como alias local para minimizar diff dos
+// muitos call-sites na tabela/kanban deste arquivo. Nova UI deve preferir
+// `<StatusBadge tone={getStatusTone(s)}>` direto.
+const statusDotClass = (s: PainelStatus | null): string => getStatusDotClass(s);
 
 const statusPillClass = (s: PainelStatus | null): string => {
   switch (s) {

--- a/src/pages/Pendencias.tsx
+++ b/src/pages/Pendencias.tsx
@@ -8,6 +8,7 @@ import { PageContainer } from "@/components/layout/PageContainer";
 import { ProjectSubNav } from "@/components/layout/ProjectSubNav";
 import { PageSkeleton } from "@/components/ui-premium";
 import { EmptyState } from "@/components/EmptyState";
+import { Heading } from "@/components/typography";
 import { PendenciaItemCard } from "@/components/tabs/PendenciaItemCard";
 
 const Pendencias = () => {
@@ -51,22 +52,22 @@ const Pendencias = () => {
 
   const summaryCards = (
     <>
-      <div className="bg-rose-500/10 border border-rose-500/20 rounded-lg p-3 md:p-4">
+      <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 md:p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 md:w-5 md:h-5 text-rose-500" />
-            <span className="text-caption md:text-sm text-rose-600 font-medium">Atrasados</span>
+            <AlertTriangle className="w-4 h-4 md:w-5 md:h-5 text-destructive" />
+            <span className="text-caption md:text-sm text-destructive font-medium">Atrasados</span>
           </div>
-          <p className="text-h2 md:text-2xl font-bold text-rose-600">{stats.overdueCount}</p>
+          <Heading level="value" as="p" className="text-destructive">{stats.overdueCount}</Heading>
         </div>
       </div>
-      <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 md:p-4">
+      <div className="bg-warning/10 border border-warning/20 rounded-lg p-3 md:p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Clock className="w-4 h-4 md:w-5 md:h-5 text-amber-500" />
-            <span className="text-caption md:text-sm text-amber-600 font-medium">Urgentes</span>
+            <Clock className="w-4 h-4 md:w-5 md:h-5 text-warning" />
+            <span className="text-caption md:text-sm text-warning font-medium">Urgentes</span>
           </div>
-          <p className="text-h2 md:text-2xl font-bold text-amber-600">{stats.urgentCount}</p>
+          <Heading level="value" as="p" className="text-warning">{stats.urgentCount}</Heading>
         </div>
       </div>
     </>


### PR DESCRIPTION
Refs #20.

Foundations (não-quebra, prepara migração incremental):

- src/lib/statusTone.ts: getStatusTone(PainelStatus | string) e
  getStatusDotClass para resolver tom semântico em qualquer lugar.
- src/components/typography/{Heading,Text}: encapsulam a escala de
  src/index.css. Substitutos canônicos para text-h1/h2/h3 e text-Nxl
  ad-hoc.
- docs/DESIGN_TOKENS.md: tabelas únicas de cores, tipografia, ícones,
  elevação, radius, status tones, e backlog de migração.

ESLint (severidade warn por enquanto):

- no-restricted-imports bloqueia @/components/ui/{card,badge}
  fora de ui/ ui-premium/ typography/.
- no-restricted-syntax bloqueia (bg|text|border|...)-{rose,amber,
  emerald,sky}-* e text-{2,3,4,5,6,7}xl. Combina com o selector de
  z-index original num único rule entry (flat config last-wins).
- Severidade volta para error em PR final, depois que os contadores
  de migração zerarem.

Refatores de exemplo:

- Pendencias.tsx: cards Atrasados/Urgentes usam destructive/warning
  + Heading level=value.
- PainelObras.tsx: statusDotClass agora delega para getStatusDotClass
  (mantém o muito-usado helper local mas centraliza a decisão).
- Home.tsx: hero usa Heading level=page.
- ProjectsListView.tsx, ProjectsCardView.tsx, ApprovalDialog.tsx:
  literal emerald/amber/rose → success/warning/destructive.

Lint, typecheck e build passam (npm run lint → 0 errors, 1577 warns;
npm run test → 56/57 files, 540/562 tests). Restam ~60 arquivos com
cor literal e ~250 imports legados — handle em PRs por sub-pasta
conforme issue.

https://claude.ai/code/session_01JAWj7iKU3QDKznMAXUWrUz