### PR TITLE
feat(assistant): v5 deep intelligence — prompts, memória, insights, clarification, self-critic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
         "lucide-react": "^0.462.0",
-        "next-themes": "^0.3.0",
         "papaparse": "^5.5.3",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -8854,16 +8853,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-themes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
-      "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
     },
     "node_modules/node-abi": {
       "version": "3.85.0",

--- a/src/components/assistant/AssistantChat.tsx
+++ b/src/components/assistant/AssistantChat.tsx
@@ -27,6 +27,16 @@ import type {
 } from "@/lib/assistant";
 import { AssistantAnalysisPanel } from "./AssistantAnalysisPanel";
 
+export interface ClarificationOption {
+  label: string;
+  resolved_question: string;
+}
+
+export interface QualityIssue {
+  severity: 'critical' | 'major' | 'minor';
+  message: string;
+}
+
 export interface AssistantMessageResultData {
   rows?: unknown[];
   rows_returned?: number;
@@ -42,6 +52,12 @@ export interface AssistantMessageResultData {
   confidence?: number | null;
   limitations?: string[] | null;
   metrics?: MetricSnapshot[] | null;
+  /** V5: pergunta ambígua — opções para o usuário escolher */
+  clarification?: { reason: string; options: ClarificationOption[] } | null;
+  /** V5: avisos do self-critic (não-bloqueantes) */
+  quality_warnings?: QualityIssue[] | null;
+  /** V5: resposta substituída após retry do critic */
+  was_refined?: boolean;
 }
 
 export interface AssistantMessage {
@@ -334,6 +350,46 @@ export function AssistantChat({
             }));
             break;
           }
+          case "clarification": {
+            const reason = (payload.reason as string) ?? 'Sua pergunta tem mais de uma interpretação.';
+            const options = (payload.options as ClarificationOption[] | undefined) ?? [];
+            updateLastAssistant((m) => ({
+              ...m,
+              pending: false,
+              content: '',
+              result_data: {
+                ...(m.result_data ?? {}),
+                status: 'clarification',
+                clarification: { reason, options },
+              },
+            }));
+            doneReceived = true; // não esperamos done; o servidor encerra a stream.
+            break;
+          }
+          case "quality_warning": {
+            const issues = (payload.issues as QualityIssue[] | undefined) ?? [];
+            updateLastAssistant((m) => ({
+              ...m,
+              result_data: {
+                ...(m.result_data ?? {}),
+                quality_warnings: issues,
+              },
+            }));
+            break;
+          }
+          case "answer_replaced": {
+            const newContent = (payload.content as string) ?? accumulated;
+            accumulated = newContent;
+            updateLastAssistant((m) => ({
+              ...m,
+              content: newContent,
+              result_data: {
+                ...(m.result_data ?? {}),
+                was_refined: true,
+              },
+            }));
+            break;
+          }
           case "error": {
             const msg = (payload.message as string) ?? "Erro";
             throw new Error(msg);
@@ -575,6 +631,24 @@ function MessageBubble({
                 {phaseMessage ?? "Consultando dados..."}
               </span>
             </div>
+          ) : message.result_data?.clarification ? (
+            <div className="space-y-2">
+              <p className="text-sm">
+                {message.result_data.clarification.reason}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {message.result_data.clarification.options.map((opt, idx) => (
+                  <button
+                    key={idx}
+                    type="button"
+                    onClick={() => onAsk?.(opt.resolved_question)}
+                    className="text-xs px-3 py-1.5 rounded-full bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 transition-colors"
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           ) : (
             <div className="prose prose-sm max-w-none prose-table:text-xs prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1 prose-headings:mt-2 prose-headings:mb-1 prose-p:my-1.5 prose-ul:my-1.5 prose-li:my-0.5">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>
@@ -583,6 +657,13 @@ function MessageBubble({
               {isStreaming && (
                 <span className="inline-block w-1.5 h-4 -mb-0.5 ml-0.5 bg-primary/70 animate-pulse rounded-sm align-middle" />
               )}
+            </div>
+          )}
+
+          {message.result_data?.was_refined && !message.pending && (
+            <div className="mt-2 flex items-center gap-1.5 text-[10px] text-muted-foreground">
+              <Sparkles className="h-3 w-3" />
+              <span>Resposta refinada automaticamente</span>
             </div>
           )}
 

--- a/supabase/functions/assistant-chat/_lib/advancedAnalysis.ts
+++ b/supabase/functions/assistant-chat/_lib/advancedAnalysis.ts
@@ -1,0 +1,391 @@
+// Análise determinística AVANÇADA — substitui a versão genérica de
+// generateInsights com detectores reais de padrão: concentração (Pareto),
+// outliers (z-score / IQR), tendência temporal, planejado×realizado,
+// top-ofensores, agrupamento por dimensão.
+//
+// Roda no servidor antes do Formatter, gerando "insights estruturados" que
+// o LLM apenas verbaliza — reduz alucinação e garante que números calculados
+// estejam corretos.
+
+import type { Severity, Insight } from "./analysis.ts";
+
+const BRL = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  maximumFractionDigits: 2,
+});
+const fmt = (v: unknown) => {
+  const n = typeof v === "number" ? v : Number(v ?? 0);
+  return Number.isFinite(n) ? BRL.format(n) : "R$ 0,00";
+};
+
+const toNum = (v: unknown): number | null => {
+  if (v == null || v === "") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const NUMERIC_KEYS = [
+  "amount",
+  "valor",
+  "valor_total",
+  "total",
+  "estimated_cost",
+  "actual_cost",
+  "saldo",
+  "estouro_total",
+  "gasto",
+  "valor_em_jogo",
+];
+const CATEGORY_KEYS = [
+  "obra",
+  "fornecedor",
+  "category",
+  "categoria",
+  "etapa",
+  "tipo",
+  "supplier_name",
+  "client_name",
+  "city",
+];
+const DATE_KEYS = [
+  "due_date",
+  "deadline",
+  "required_by_date",
+  "planned_end",
+  "actual_end",
+  "paid_at",
+  "created_at",
+];
+
+function findKey(row: Record<string, unknown>, candidates: string[]): string | null {
+  for (const k of candidates) if (k in row) return k;
+  return null;
+}
+
+function findFirstNumericKey(row: Record<string, unknown>): string | null {
+  const explicit = findKey(row, NUMERIC_KEYS);
+  if (explicit) return explicit;
+  for (const k of Object.keys(row)) if (typeof row[k] === "number") return k;
+  return null;
+}
+
+/**
+ * Detecta concentração tipo Pareto: o quanto do total vem dos top N itens.
+ * Se top 20% concentra >= 50% do valor → insight de concentração relevante.
+ */
+function detectConcentration(
+  rows: Record<string, unknown>[],
+  numKey: string,
+  catKey: string,
+  domain: string,
+): Insight | null {
+  const byCat = new Map<string, number>();
+  let total = 0;
+  for (const r of rows) {
+    const v = toNum(r[numKey]);
+    if (v == null) continue;
+    const c = String(r[catKey] ?? "(sem)") || "(sem)";
+    byCat.set(c, (byCat.get(c) ?? 0) + v);
+    total += v;
+  }
+  if (total <= 0 || byCat.size < 4) return null;
+
+  const sorted = [...byCat.entries()].sort((a, b) => b[1] - a[1]);
+  const topN = Math.max(1, Math.ceil(sorted.length * 0.2));
+  const topShare = sorted.slice(0, topN).reduce((s, [, v]) => s + v, 0) / total;
+
+  if (topShare < 0.5) return null;
+
+  const topItems = sorted
+    .slice(0, Math.min(3, topN))
+    .map(([k, v]) => `${k} (${fmt(v)} · ${((v / total) * 100).toFixed(0)}%)`);
+
+  return {
+    id: "concentration",
+    type: "pattern",
+    domain,
+    title: `Concentração: top ${topN} = ${(topShare * 100).toFixed(0)}% do total`,
+    summary: `${topN} de ${sorted.length} ${catKey}(s) respondem por ${(topShare * 100).toFixed(
+      0,
+    )}% de ${numKey}. Principais: ${topItems.join(", ")}.`,
+    evidence: [
+      { label: "Top concentrado", value: `${(topShare * 100).toFixed(0)}%` },
+      { label: "Total", value: fmt(total) },
+    ],
+    severity: topShare >= 0.7 ? "high" : "medium",
+    confidence: 0.9,
+    recommendedAction: `Foque em ${sorted[0][0]} primeiro — é o maior driver.`,
+    visualization: { type: "bar", title: `${numKey} por ${catKey}`, x: catKey, y: numKey },
+  };
+}
+
+/**
+ * Outliers via z-score robusto (mediana + MAD). Retorna até 3 valores
+ * fora de ±2.5 sigma — sinal de "vale conferir".
+ */
+function detectOutliers(
+  rows: Record<string, unknown>[],
+  numKey: string,
+  catKey: string | null,
+  domain: string,
+): Insight | null {
+  const values = rows.map((r) => toNum(r[numKey])).filter((v): v is number => v != null);
+  if (values.length < 6) return null;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const deviations = values.map((v) => Math.abs(v - median)).sort((a, b) => a - b);
+  const mad = deviations[Math.floor(deviations.length / 2)] || 1;
+  const threshold = 2.5;
+
+  const outliers = rows
+    .map((r, i) => ({
+      row: r,
+      v: values[i],
+      z: Math.abs((values[i] - median) / (1.4826 * mad)),
+    }))
+    .filter((x) => x.z >= threshold)
+    .sort((a, b) => b.z - a.z)
+    .slice(0, 3);
+
+  if (outliers.length === 0) return null;
+
+  const items = outliers.map((o) => {
+    const label = catKey ? String(o.row[catKey] ?? "?") : `linha ${o.v}`;
+    return `${label}: ${fmt(o.v)} (mediana ${fmt(median)})`;
+  });
+
+  return {
+    id: "outliers",
+    type: "anomaly",
+    domain,
+    title: `${outliers.length} outlier(s) detectado(s)`,
+    summary: `Valor(es) muito acima/abaixo do típico em ${numKey}: ${items.join(" · ")}.`,
+    evidence: [
+      { label: "Mediana", value: fmt(median) },
+      { label: "Outliers", value: outliers.length },
+    ],
+    severity: outliers[0].v > median * 5 ? "high" : "medium",
+    confidence: 0.8,
+    recommendedAction: "Confira se o valor anômalo é real ou erro de digitação.",
+  };
+}
+
+/**
+ * Plano×Realizado: quando linhas têm estimated_cost + actual_cost,
+ * calcula estouro agregado e %.
+ */
+function detectBudgetBreach(
+  rows: Record<string, unknown>[],
+  domain: string,
+): Insight | null {
+  if (!rows.length) return null;
+  if (!("estimated_cost" in rows[0]) || !("actual_cost" in rows[0])) return null;
+
+  let estimated = 0;
+  let actual = 0;
+  let breaches = 0;
+  for (const r of rows) {
+    const e = toNum(r.estimated_cost);
+    const a = toNum(r.actual_cost);
+    if (e == null || a == null) continue;
+    estimated += e;
+    actual += a;
+    if (a > e) breaches += 1;
+  }
+  if (estimated <= 0) return null;
+  const delta = actual - estimated;
+  const pct = (delta / estimated) * 100;
+
+  if (Math.abs(pct) < 5) return null;
+
+  const sev: Severity = pct >= 30 ? "critical" : pct >= 15 ? "high" : pct >= 5 ? "medium" : "low";
+  return {
+    id: "budget_breach",
+    type: "financial",
+    domain,
+    title: pct > 0 ? `Estouro de ${pct.toFixed(1)}% sobre o estimado` : `Economia de ${Math.abs(pct).toFixed(1)}% sobre o estimado`,
+    summary:
+      pct > 0
+        ? `${breaches} item(ns) acima do estimado. Estouro agregado: ${fmt(delta)} (estimado ${fmt(
+            estimated,
+          )} → realizado ${fmt(actual)}).`
+        : `Realizado abaixo do estimado por ${fmt(Math.abs(delta))}.`,
+    evidence: [
+      { label: "Estimado", value: fmt(estimated) },
+      { label: "Realizado", value: fmt(actual) },
+      { label: "Δ", value: fmt(delta) },
+    ],
+    severity: sev,
+    confidence: 0.95,
+    recommendedAction:
+      pct > 15 ? "Revisar cotações e renegociar com fornecedor antes do próximo pedido." : undefined,
+  };
+}
+
+/**
+ * Tendência temporal: agrupa por mês/semana e detecta crescimento/queda
+ * consistente.
+ */
+function detectTrend(
+  rows: Record<string, unknown>[],
+  numKey: string,
+  domain: string,
+): Insight | null {
+  const dateKey = findKey(rows[0] ?? {}, DATE_KEYS);
+  if (!dateKey) return null;
+  if (rows.length < 4) return null;
+
+  const buckets = new Map<string, number>();
+  for (const r of rows) {
+    const v = toNum(r[numKey]);
+    const d = r[dateKey];
+    if (v == null || !d) continue;
+    const t = Date.parse(String(d));
+    if (!Number.isFinite(t)) continue;
+    const key = new Date(t).toISOString().slice(0, 7); // YYYY-MM
+    buckets.set(key, (buckets.get(key) ?? 0) + v);
+  }
+  if (buckets.size < 3) return null;
+  const series = [...buckets.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const first = series[0][1];
+  const last = series[series.length - 1][1];
+  if (first <= 0) return null;
+  const growth = ((last - first) / first) * 100;
+  if (Math.abs(growth) < 20) return null;
+
+  return {
+    id: "trend",
+    type: "trend",
+    domain,
+    title: growth > 0 ? `Crescimento de ${growth.toFixed(0)}% no período` : `Queda de ${Math.abs(growth).toFixed(0)}% no período`,
+    summary: `${numKey} variou de ${fmt(first)} (${series[0][0]}) para ${fmt(last)} (${
+      series[series.length - 1][0]
+    }) em ${series.length} meses.`,
+    evidence: [
+      { label: "Início", value: fmt(first) },
+      { label: "Fim", value: fmt(last) },
+      { label: "Variação", value: `${growth > 0 ? "+" : ""}${growth.toFixed(0)}%` },
+    ],
+    severity: Math.abs(growth) >= 50 ? "high" : "medium",
+    confidence: 0.75,
+    visualization: { type: "line", title: `${numKey} ao longo do tempo`, x: dateKey, y: numKey },
+  };
+}
+
+/**
+ * Top-ofensores genérico: quando o resultado tem dias_em_atraso ou similar,
+ * destaca os 3 piores.
+ */
+function detectTopOffenders(
+  rows: Record<string, unknown>[],
+  domain: string,
+): Insight | null {
+  const offenderKey = ["dias_em_atraso", "dias_aberta", "estouro_pct", "estouro_total"].find(
+    (k) => rows[0] && k in rows[0],
+  );
+  if (!offenderKey) return null;
+  const labelKey = findKey(rows[0], CATEGORY_KEYS) ?? "obra";
+  const sorted = [...rows].sort((a, b) => (toNum(b[offenderKey]) ?? 0) - (toNum(a[offenderKey]) ?? 0));
+  const top = sorted.slice(0, 3);
+  if (!top.length || (toNum(top[0][offenderKey]) ?? 0) <= 0) return null;
+
+  const items = top
+    .map((r) => `${r[labelKey] ?? "?"} (${offenderKey}=${r[offenderKey]})`)
+    .join(" · ");
+  return {
+    id: "top_offenders",
+    type: "ranking",
+    domain,
+    title: `Top 3 piores em ${offenderKey}`,
+    summary: items,
+    evidence: top.map((r, i) => ({
+      label: `#${i + 1}`,
+      value: `${r[labelKey] ?? "?"}: ${r[offenderKey]}`,
+    })),
+    severity: "high",
+    confidence: 0.9,
+    recommendedAction: `Comece pelo ${top[0][labelKey] ?? "primeiro"}.`,
+  };
+}
+
+export function generateAdvancedInsights(
+  rows: Record<string, unknown>[],
+  domain: string,
+): Insight[] {
+  if (!rows || rows.length === 0) return [];
+  const out: Insight[] = [];
+  const sample = rows[0];
+  const numKey = findFirstNumericKey(sample);
+  const catKey = findKey(sample, CATEGORY_KEYS);
+
+  if (numKey && catKey) {
+    const c = detectConcentration(rows, numKey, catKey, domain);
+    if (c) out.push(c);
+  }
+  if (numKey) {
+    const o = detectOutliers(rows, numKey, catKey, domain);
+    if (o) out.push(o);
+    const t = detectTrend(rows, numKey, domain);
+    if (t) out.push(t);
+  }
+  const b = detectBudgetBreach(rows, domain);
+  if (b) out.push(b);
+  const off = detectTopOffenders(rows, domain);
+  if (off) out.push(off);
+
+  return out;
+}
+
+/**
+ * Sugestões DINÂMICAS baseadas no resultado real, não em domínio fixo.
+ * Se a resposta tem 1 obra dominante → sugere drill-down dela. Se tem
+ * coluna de data → sugere recorte temporal. Etc.
+ */
+export function generateDynamicFollowUps(
+  rows: Record<string, unknown>[],
+  domain: string,
+  question: string,
+): string[] {
+  if (!rows || rows.length === 0) {
+    return [
+      "Quer ver o mês passado?",
+      "Quer incluir registros já fechados?",
+      "Quer ampliar o período para últimos 90 dias?",
+    ];
+  }
+
+  const out: string[] = [];
+  const sample = rows[0];
+  const catKey = findKey(sample, CATEGORY_KEYS);
+  const numKey = findFirstNumericKey(sample);
+
+  if (catKey && rows.length >= 2) {
+    const top = String(rows[0][catKey] ?? "");
+    if (top) out.push(`Drill-down em "${top}" — mostrar tudo dessa ${catKey}`);
+  }
+  if (numKey && rows.length >= 3) {
+    out.push(`Comparar com o mesmo período anterior`);
+  }
+  if (rows.length >= 10) {
+    out.push(`Mostrar só os 5 mais críticos`);
+  }
+  if (
+    domain === "financeiro" &&
+    !/m[êe]s|semana|hoje|ano|trimestre/i.test(question)
+  ) {
+    out.push("Recortar por mês corrente vs mês anterior");
+  }
+  if (domain === "compras" && !/fornecedor/i.test(question)) {
+    out.push("Quebrar por fornecedor");
+  }
+  if (domain === "ncs" || domain === "pendencias") {
+    out.push("Mostrar quem é o responsável de cada item");
+  }
+
+  // sempre uma sugestão "ampliar"
+  out.push("Cruzar com mercado (CUB, INCC, dólar)");
+
+  return out.slice(0, 4);
+}

--- a/supabase/functions/assistant-chat/_lib/bwildContext.ts
+++ b/supabase/functions/assistant-chat/_lib/bwildContext.ts
@@ -1,0 +1,78 @@
+// Contexto institucional persistente da BWild — injetado em todo prompt do
+// Planner e do Formatter. Equivalente a "memória de longo prazo": vocabulário,
+// KPIs nomeados, padrões operacionais e thresholds que o LLM precisa saber
+// para responder como alguém que conhece a empresa, não como um chatbot
+// genérico de SQL.
+//
+// Mantenha curto e denso — cada parágrafo aqui custa tokens em TODA
+// requisição. Se algo é muito específico de uma pergunta, vai no catálogo,
+// não aqui.
+
+export const BWILD_CONTEXT = `# Contexto Bwild (memória de longo prazo)
+
+## Modelo de negócio
+Bwild Reformas entrega **reformas turnkey de studios** para investidores de short-stay (Airbnb) em São Paulo. Ticket médio R$ 80k–R$ 250k. Prazo típico de execução: 60–120 dias. Margem-alvo bruta: ~20% (custo de obra ÷ contrato). Cliente final é o investidor — não mora na obra.
+
+## Quem usa este assistente
+- **Pedro (CEO)**: decisões cross-obra, exposição financeira, P&L, fornecedor problemático.
+- **PMs**: conduzem 4–8 obras simultâneas; querem saber qual obra tá fugindo do plano hoje.
+- **Suprimentos**: vencimentos de compra, cotação atrasada, fornecedor a contratar.
+- **Financeiro**: recebíveis vencendo, boletos a emitir, repasse a fornecedor.
+- **CS**: tickets do cliente investidor, NCs que afetam handover.
+- **Cliente investidor**: vê só a própria obra; tom acolhedor, sem jargão.
+
+A RLS já filtra escopo. Você adapta APENAS o tom e o nível de agregação.
+
+## KPIs nomeados (use estes termos quando o usuário usar)
+- **Saldo da obra** = Σ pagamentos recebidos − Σ compras pagas. Liquidez atual.
+- **Exposição contratual** = contract_value − Σ recebido. Quanto ainda entra.
+- **Custo comprometido** = Σ compras (qualquer status ≠ cancelled). Aprovado mas não necessariamente pago.
+- **Estouro de compra** = actual_cost − estimated_cost (>0 = ruim).
+- **Margem prevista** = (contract_value − Σ estimated_cost) ÷ contract_value.
+- **Margem realizada (parcial)** = (Σ recebido − Σ actual_cost pago) ÷ Σ recebido. Limitação: só faz sentido na entrega.
+- **Atraso contratual** = actual_end_date > planned_end_date OU planned_end_date < hoje sem actual_end_date.
+- **SLA de NC** = dias entre created_at e resolved_at; vencida se deadline < hoje e status≠closed.
+
+## Thresholds operacionais (use para classificar severidade automaticamente)
+- Pagamento atrasado > 7 dias → high. > 30 dias → critical.
+- Compra atrasada (required_by_date passada) > 14 dias → high.
+- NC critical aberta > 5 dias → critical.
+- Estouro de compra > 15% do estimado → high. > 30% → critical.
+- Obra com >5 NCs abertas simultâneas → high (sinal de descontrole).
+- Margem prevista < 10% → high (obra apertada). < 0% → critical.
+
+## Vocabulário Bwild ↔ termos técnicos do banco (para o Planner)
+- "Obra atrasada" / "atrasou" → \`actual_end_date > planned_end_date\` OU (\`actual_end_date IS NULL AND planned_end_date < CURRENT_DATE\`).
+- "Estouro" / "passou do orçamento" / "passou do alvo" → \`actual_cost > estimated_cost\` em project_purchases.
+- "Em curso" / "rodando" / "ativa" → \`deleted_at IS NULL AND actual_end_date IS NULL\`.
+- "Entregue" / "fechada" → \`actual_end_date IS NOT NULL\`.
+- "Cliente" / "investidor" / "proprietário" → projects.client_name (ou JOIN users_profile via created_by).
+- "Empreiteiro" / "PJ" / "prestador" → fornecedores com supplier_type='prestadores'.
+- "Material" / "produto" → fornecedores com supplier_type='produtos'.
+- "RDO" / "diário" → não modelado hoje (sinalize quando perguntarem).
+- "Medição" / "boletim" → não modelado hoje; aproximar via project_activities concluídas.
+- "Curva S" → progresso acumulado de project_activities por week.
+
+## Defaults inteligentes (quando o usuário não disser)
+- "Hoje" / "agora" → CURRENT_DATE.
+- "Esta semana" → date_trunc('week', CURRENT_DATE) até CURRENT_DATE + 6.
+- "Este mês" → date_trunc('month', CURRENT_DATE).
+- "Últimos N dias/semanas/meses" → CURRENT_DATE − INTERVAL.
+- Sem janela explícita em tema OPERACIONAL (vencimento, atraso, NC) → próximos 14 dias OU tudo aberto.
+- Sem janela em tema FINANCEIRO retrospectivo (gasto, recebido) → mês corrente vs anterior.
+- Sem agregação explícita → agrupar por obra (project_id) — Pedro normalmente quer "qual obra".
+
+## Anti-alucinação (regras absolutas)
+- Se o catálogo lista coluna como NÃO existe, é PROIBIDO usar — não tem sinônimo, não tem alternativa "óbvia".
+- Se uma fonte externa não retornou evidência, NÃO cite número externo no Formatter.
+- Se a resposta exige cálculo que depende de campo não modelado (ex: medição real), declare a aproximação na intent + assumptions.
+- Nunca invente nome de obra, fornecedor, valor, data. Se não está nas linhas retornadas, não existe.
+
+## Estilo de resposta esperado pelo Pedro
+Direto, denso, sem floreio. Número primeiro, contexto depois, próximo passo sempre. Tom de copiloto operacional, não de relatório executivo. PT-BR coloquial profissional ("a obra do Carlos tá apertando", não "verifica-se que o empreendimento apresenta indicadores adversos").`;
+
+/**
+ * Resumo curto do contexto para uso em chamadas de baixa-criticidade
+ * (ex: clarificação, sugestão de follow-up). Mantém só o essencial.
+ */
+export const BWILD_CONTEXT_LITE = `Bwild = reformas turnkey de studios short-stay em SP. Usuários: CEO Pedro, PMs, suprimentos, financeiro, CS, cliente. KPIs: saldo (recebido−pago), exposição contratual, estouro, margem prevista. Tom: direto, denso, número primeiro, próximo passo sempre. Português coloquial profissional.`;

--- a/supabase/functions/assistant-chat/_lib/catalog.ts
+++ b/supabase/functions/assistant-chat/_lib/catalog.ts
@@ -228,6 +228,122 @@ export const CATALOG: CatalogTable[] = [
   },
 ];
 
+// ============================================================
+// KPIs nomeados — abstrações de NEGÓCIO que viram CTEs prontas.
+// O Planner pode referenciar pelo nome ("saldo da obra") em vez de
+// reconstruir a fórmula a cada pergunta.
+// ============================================================
+
+export interface NamedKpi {
+  name: string;
+  description: string;
+  formula_pseudo: string;
+  /** SQL CTE pronto pra colar no WITH ... */
+  cte_template: string;
+}
+
+export const NAMED_KPIS: NamedKpi[] = [
+  {
+    name: "saldo_obra",
+    description: "Liquidez da obra: recebido do cliente menos pago a fornecedor.",
+    formula_pseudo: "SUM(payments.amount WHERE paid) - SUM(purchases.actual_cost WHERE paid)",
+    cte_template: `saldo_obra AS (
+  SELECT
+    p.id AS project_id,
+    p.name AS obra,
+    COALESCE(SUM(pp.amount) FILTER (WHERE pp.paid_at IS NOT NULL), 0) AS recebido,
+    COALESCE(SUM(pc.actual_cost) FILTER (WHERE pc.paid_at IS NOT NULL), 0) AS pago,
+    COALESCE(SUM(pp.amount) FILTER (WHERE pp.paid_at IS NOT NULL), 0)
+      - COALESCE(SUM(pc.actual_cost) FILTER (WHERE pc.paid_at IS NOT NULL), 0) AS saldo
+  FROM projects p
+  LEFT JOIN project_payments pp ON pp.project_id = p.id
+  LEFT JOIN project_purchases pc ON pc.project_id = p.id
+  WHERE p.deleted_at IS NULL
+  GROUP BY p.id, p.name
+)`,
+  },
+  {
+    name: "exposicao_contratual",
+    description: "Quanto ainda falta o cliente pagar (contract_value − recebido).",
+    formula_pseudo: "contract_value - SUM(payments.amount WHERE paid)",
+    cte_template: `exposicao_contratual AS (
+  SELECT
+    p.id AS project_id,
+    p.name AS obra,
+    p.contract_value,
+    COALESCE(SUM(pp.amount) FILTER (WHERE pp.paid_at IS NOT NULL), 0) AS recebido,
+    p.contract_value - COALESCE(SUM(pp.amount) FILTER (WHERE pp.paid_at IS NOT NULL), 0) AS exposicao
+  FROM projects p
+  LEFT JOIN project_payments pp ON pp.project_id = p.id
+  WHERE p.deleted_at IS NULL
+  GROUP BY p.id, p.name, p.contract_value
+)`,
+  },
+  {
+    name: "estouro_orcamento",
+    description: "Quanto a obra estourou o orçamento estimado em compras.",
+    formula_pseudo: "SUM(GREATEST(actual - estimated, 0))",
+    cte_template: `estouro_orcamento AS (
+  SELECT
+    pc.project_id,
+    SUM(pc.estimated_cost) AS orcamento_estimado,
+    SUM(GREATEST(pc.actual_cost - pc.estimated_cost, 0)) AS estouro_total,
+    COUNT(*) FILTER (WHERE pc.actual_cost > pc.estimated_cost) AS itens_estouraram,
+    ROUND(
+      100.0 * SUM(GREATEST(pc.actual_cost - pc.estimated_cost, 0))
+        / NULLIF(SUM(pc.estimated_cost), 0),
+      1
+    ) AS estouro_pct
+  FROM project_purchases pc
+  WHERE pc.actual_cost IS NOT NULL
+  GROUP BY pc.project_id
+)`,
+  },
+  {
+    name: "margem_prevista",
+    description: "Margem teórica = (contrato − soma estimada de compras) / contrato.",
+    formula_pseudo: "(contract_value - SUM(estimated_cost)) / contract_value",
+    cte_template: `margem_prevista AS (
+  SELECT
+    p.id AS project_id,
+    p.name AS obra,
+    p.contract_value,
+    COALESCE(SUM(pc.estimated_cost), 0) AS custo_estimado,
+    p.contract_value - COALESCE(SUM(pc.estimated_cost), 0) AS margem_abs,
+    CASE WHEN p.contract_value > 0
+      THEN ROUND(100.0 * (p.contract_value - COALESCE(SUM(pc.estimated_cost), 0)) / p.contract_value, 1)
+      ELSE NULL
+    END AS margem_pct
+  FROM projects p
+  LEFT JOIN project_purchases pc ON pc.project_id = p.id AND pc.status <> 'cancelled'
+  WHERE p.deleted_at IS NULL
+  GROUP BY p.id, p.name, p.contract_value
+)`,
+  },
+  {
+    name: "atraso_cronograma",
+    description: "Atividades atrasadas por obra (planned_end < hoje sem actual_end).",
+    formula_pseudo: "COUNT(*) WHERE planned_end < CURRENT_DATE AND actual_end IS NULL",
+    cte_template: `atraso_cronograma AS (
+  SELECT
+    pa.project_id,
+    COUNT(*) FILTER (WHERE pa.planned_end < CURRENT_DATE AND pa.actual_end IS NULL) AS atividades_atrasadas,
+    SUM(pa.weight) FILTER (WHERE pa.planned_end < CURRENT_DATE AND pa.actual_end IS NULL) AS peso_atrasado,
+    MAX(CURRENT_DATE - pa.planned_end) FILTER (WHERE pa.planned_end < CURRENT_DATE AND pa.actual_end IS NULL) AS pior_atraso_dias
+  FROM project_activities pa
+  GROUP BY pa.project_id
+)`,
+  },
+];
+
+function renderNamedKpis(): string {
+  const lines: string[] = ["\n# KPIs NOMEADOS (use o nome no plano e cole o CTE no WITH)"];
+  for (const k of NAMED_KPIS) {
+    lines.push(`\n## ${k.name}\n${k.description}\nFórmula: ${k.formula_pseudo}\n\`\`\`sql\n${k.cte_template}\n\`\`\``);
+  }
+  return lines.join("\n");
+}
+
 export function renderCatalog(): string {
   const lines: string[] = ["# CATÁLOGO (apenas SELECT, RLS aplicada)"];
   for (const t of CATALOG) {
@@ -240,5 +356,6 @@ export function renderCatalog(): string {
     if (t.forbidden?.length) lines.push("NÃO existem (não invente): " + t.forbidden.join(", "));
     if (t.joinHints?.length) lines.push("Joins úteis: " + t.joinHints.join(" | "));
   }
+  lines.push(renderNamedKpis());
   return lines.join("\n");
 }

--- a/supabase/functions/assistant-chat/_lib/clarification.ts
+++ b/supabase/functions/assistant-chat/_lib/clarification.ts
@@ -1,0 +1,103 @@
+// Clarificação inteligente (v5).
+//
+// Detecta perguntas verdadeiramente ambíguas — onde chutar a interpretação
+// causaria resposta errada — e devolve 1-3 opções para o usuário escolher.
+//
+// Filosofia: 90% das perguntas vagas têm um chute óbvio (e o Planner
+// resolve com `assumptions`). Só interrompemos para perguntar quando:
+//   1. Existem >=2 interpretações válidas com resultados materialmente diferentes.
+//   2. A pergunta cita entidade ambígua (nome de obra parcial que casa com várias).
+//   3. Janela temporal indeterminada num tema sensível ("o quanto a gente faturou?" sem ano).
+
+export interface ClarificationOption {
+  label: string;
+  /** Pergunta reescrita que o usuário escolheria. */
+  resolved_question: string;
+}
+
+export interface ClarificationResult {
+  needs_clarification: boolean;
+  reason?: string;
+  options?: ClarificationOption[];
+}
+
+const VAGUE_TIME_PATTERNS = [
+  /quanto.*faturamos|faturei|recebi/i,
+  /total.*pago|gasto/i,
+  /qual.*margem/i,
+];
+const HAS_TIME_REF = /(hoje|ontem|amanh[ãa]|semana|m[êe]s|ano|trimestre|últimos?|desde|janeiro|fevereiro|mar[çc]o|abril|maio|junho|julho|agosto|setembro|outubro|novembro|dezembro|\d{4})/i;
+
+const AMBIGUOUS_TERMS: Array<{ term: RegExp; options: string[] }> = [
+  {
+    term: /\batrasada?s?\b/i,
+    options: [
+      "atrasada(s) em prazo de obra (cronograma)",
+      "atrasada(s) em pagamento ao cliente",
+      "atrasada(s) em compra/entrega",
+    ],
+  },
+  {
+    term: /\babertas?\b/i,
+    options: [
+      "obras ativas (não entregues)",
+      "NCs / pendências em aberto",
+      "tickets de CS em aberto",
+    ],
+  },
+  {
+    term: /\bmargem\b/i,
+    options: [
+      "margem prevista (contrato − estimado)",
+      "margem realizada parcial (recebido − pago)",
+    ],
+  },
+];
+
+/**
+ * Heurística leve, sem LLM. Devolve opções quando a pergunta é
+ * inequivocamente ambígua. Em produção, pode ser estendida com chamada
+ * dedicada ao LLM para casos sutis.
+ */
+export function detectClarification(question: string): ClarificationResult {
+  const q = question.trim();
+  if (q.length < 8) return { needs_clarification: false };
+
+  // 1. Janela temporal indeterminada em tema sensível.
+  const isVagueTime = VAGUE_TIME_PATTERNS.some((p) => p.test(q));
+  if (isVagueTime && !HAS_TIME_REF.test(q)) {
+    return {
+      needs_clarification: true,
+      reason: "Período não especificado em tema financeiro.",
+      options: [
+        { label: "Este mês", resolved_question: `${q} no mês corrente` },
+        { label: "Últimos 30 dias", resolved_question: `${q} nos últimos 30 dias` },
+        { label: "Este ano", resolved_question: `${q} no ano corrente` },
+      ],
+    };
+  }
+
+  // 2. Termos com múltiplas leituras.
+  for (const { term, options } of AMBIGUOUS_TERMS) {
+    if (term.test(q)) {
+      // Só considera ambíguo se NÃO tem domínio claro no resto da frase.
+      const hasDomainHint =
+        /pagament|cobran[çc]a|boleto|recebi/i.test(q) ||
+        /cronograma|atividade|etapa|prazo de obra/i.test(q) ||
+        /compra|fornecedor|entrega|material/i.test(q) ||
+        /\bnc\b|n[ãa]o[- ]?conformidade|defeito/i.test(q);
+      if (!hasDomainHint) {
+        return {
+          needs_clarification: true,
+          reason: `O termo é usado em múltiplos domínios.`,
+          options: options.map((label) => ({
+            label,
+            resolved_question: `${q} (${label})`,
+          })),
+        };
+      }
+    }
+  }
+
+  return { needs_clarification: false };
+}

--- a/supabase/functions/assistant-chat/_lib/conversationMemory.ts
+++ b/supabase/functions/assistant-chat/_lib/conversationMemory.ts
@@ -1,0 +1,117 @@
+// Memória de conversa estendida (v5).
+//
+// Antes: o orquestrador puxava as últimas 10 mensagens cruas e mandava no
+// prompt. Resultado: conversa longa estourava contexto OU perdia o começo.
+//
+// Agora: pegamos as últimas N mensagens cruas (recência) + um RESUMO
+// estruturado das anteriores (continuidade). O resumo destaca:
+//   - obras/fornecedores/períodos já mencionados,
+//   - decisões/intents anteriores ("ele quer ver só compras pendentes"),
+//   - números-chave ("saldo total mencionado: R$ 230k").
+//
+// O resumo é gerado apenas quando há >= MEMORY_RAW_LIMIT mensagens.
+
+export const MEMORY_RAW_LIMIT = 8; // últimas N mensagens cruas
+export const MEMORY_TOTAL_LIMIT = 30; // janela total considerada
+
+export interface RawMessage {
+  role: string;
+  content: string;
+  created_at?: string;
+}
+
+export interface MemoryWindow {
+  /** Mensagens cruas mais recentes (últimas MEMORY_RAW_LIMIT). */
+  recent: RawMessage[];
+  /** Resumo das mensagens anteriores. Vazio quando histórico é curto. */
+  summary: string | null;
+  /** Total considerado (raw + summarized). */
+  total_considered: number;
+}
+
+/**
+ * Resumo BARATO e DETERMINÍSTICO — sem LLM. Extrai entidades comuns
+ * (nomes em **negrito**, valores R$, datas) e monta um briefing.
+ * Para resumo via LLM, use buildMemoryWindowWithLLM em vez deste.
+ */
+export function buildMemoryWindow(history: RawMessage[]): MemoryWindow {
+  const considered = history.slice(-MEMORY_TOTAL_LIMIT);
+  if (considered.length <= MEMORY_RAW_LIMIT) {
+    return { recent: considered, summary: null, total_considered: considered.length };
+  }
+
+  const olderSlice = considered.slice(0, considered.length - MEMORY_RAW_LIMIT);
+  const recent = considered.slice(-MEMORY_RAW_LIMIT);
+
+  const obras = new Set<string>();
+  const fornecedores = new Set<string>();
+  const valores: string[] = [];
+  const datas: string[] = [];
+  const userIntents: string[] = [];
+  const assistantTopics: string[] = [];
+
+  for (const m of olderSlice) {
+    const content = m.content ?? "";
+    // Nomes em negrito (formatter sempre destaca obra/fornecedor assim).
+    for (const match of content.matchAll(/\*\*([^*]{3,60})\*\*/g)) {
+      const tok = match[1].trim();
+      if (/r\$/i.test(tok)) {
+        valores.push(tok);
+      } else if (/^\d{1,2}\/\d{1,2}/i.test(tok)) {
+        datas.push(tok);
+      } else if (/(obra|reforma|studio|apto)/i.test(tok)) {
+        obras.add(tok);
+      } else if (/(fornec|construt|eletr|hidr|mar[óo])/i.test(tok)) {
+        fornecedores.add(tok);
+      } else {
+        // Genérico: provavelmente nome de obra (ex: "Vila Mariana", "Pinheiros 42").
+        obras.add(tok);
+      }
+    }
+    if (m.role === "user") {
+      const trimmed = content.trim();
+      if (trimmed.length >= 6 && trimmed.length <= 140) userIntents.push(trimmed);
+    } else if (m.role === "assistant") {
+      const firstLine = (content.split("\n").find((l) => l.trim().length > 0) ?? "").trim();
+      if (firstLine && firstLine.length <= 200) assistantTopics.push(firstLine);
+    }
+  }
+
+  const parts: string[] = [];
+  parts.push(`Conversa anterior (${olderSlice.length} mensagens condensadas):`);
+  if (userIntents.length) {
+    parts.push(`- Perguntas anteriores: ${userIntents.slice(-5).map((q) => `"${q}"`).join(" · ")}`);
+  }
+  if (assistantTopics.length) {
+    parts.push(`- Headlines anteriores: ${assistantTopics.slice(-5).join(" · ")}`);
+  }
+  if (obras.size) parts.push(`- Obras/projetos citadas: ${[...obras].slice(0, 8).join(", ")}`);
+  if (fornecedores.size)
+    parts.push(`- Fornecedores citados: ${[...fornecedores].slice(0, 5).join(", ")}`);
+  if (valores.length) parts.push(`- Valores mencionados: ${valores.slice(0, 5).join(", ")}`);
+  if (datas.length) parts.push(`- Datas mencionadas: ${datas.slice(0, 5).join(", ")}`);
+
+  return {
+    recent,
+    summary: parts.join("\n"),
+    total_considered: considered.length,
+  };
+}
+
+/**
+ * Renderiza a memória como mensagens prontas pra ir no payload do chat.
+ * O resumo entra como mensagem 'system' anterior ao resto.
+ */
+export function memoryToChatMessages(window: MemoryWindow): Array<{ role: string; content: string }> {
+  const out: Array<{ role: string; content: string }> = [];
+  if (window.summary) {
+    out.push({
+      role: "system",
+      content: `# Memória da conversa\n${window.summary}\n\nUse esse contexto para entender referências curtas ("aquela obra", "o mesmo fornecedor", "como antes").`,
+    });
+  }
+  for (const m of window.recent) {
+    out.push({ role: m.role === "assistant" ? "assistant" : "user", content: m.content });
+  }
+  return out;
+}

--- a/supabase/functions/assistant-chat/_lib/critic.ts
+++ b/supabase/functions/assistant-chat/_lib/critic.ts
@@ -1,0 +1,114 @@
+// Self-critique determinístico (v5).
+//
+// Roda DEPOIS do Formatter, antes de devolver a resposta para o usuário.
+// Não chama LLM — usa heurísticas baratas para detectar resposta ruim:
+//   - cita obra/valor que não está nas linhas
+//   - omite o headline numérico
+//   - esquece o "🎯 Próximo passo"
+//   - usa coluna técnica (uuid, project_id) no texto
+//   - número formatado errado (sem R$, sem vírgula)
+//
+// Quando detecta, devolve uma lista de issues que o orquestrador anexa
+// como "limitations" silenciosas no log + decide se merece um retry.
+
+export interface CriticIssue {
+  id: string;
+  severity: "low" | "medium" | "high";
+  message: string;
+}
+
+export interface CriticInput {
+  answer: string;
+  rows: Record<string, unknown>[];
+  question: string;
+  hasEvidences: boolean;
+}
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+const NUMBER_RE = /R\$\s*\d|[0-9]+([.,][0-9]+)?/;
+
+export function critiqueAnswer(input: CriticInput): CriticIssue[] {
+  const out: CriticIssue[] = [];
+  const { answer, rows, hasEvidences } = input;
+
+  if (!answer || answer.length < 20) {
+    out.push({ id: "too_short", severity: "high", message: "Resposta muito curta." });
+    return out;
+  }
+
+  // 1. UUID exposto.
+  if (UUID_RE.test(answer)) {
+    out.push({
+      id: "uuid_in_answer",
+      severity: "medium",
+      message: "Resposta expõe UUID — deveria mostrar nome da obra.",
+    });
+  }
+
+  // 2. Headline numérico ausente.
+  const firstLine = answer.split("\n").find((l) => l.trim().length > 0) ?? "";
+  if (rows.length > 0 && !NUMBER_RE.test(firstLine)) {
+    out.push({
+      id: "no_headline_number",
+      severity: "medium",
+      message: "Primeira linha não tem número-âncora.",
+    });
+  }
+
+  // 3. Próximo passo ausente.
+  if (!/🎯|pr[óo]ximo passo|a[çc][ãa]o|cobr|peca|peça|pedir|conferi/i.test(answer)) {
+    out.push({
+      id: "no_next_step",
+      severity: "low",
+      message: "Resposta não termina em ação concreta.",
+    });
+  }
+
+  // 4. Fala de fonte externa sem ter evidência.
+  if (!hasEvidences && /(BCB|Sinduscon|CUB|INCC|IPCA|Selic|Receita Federal)/i.test(answer)) {
+    out.push({
+      id: "phantom_external_source",
+      severity: "high",
+      message: "Cita fonte externa sem evidência anexa.",
+    });
+  }
+
+  // 5. Cita nomes de obra/cliente que não estão nos dados.
+  if (rows.length > 0) {
+    const knownNames = new Set<string>();
+    for (const r of rows) {
+      for (const k of ["obra", "name", "supplier_name", "client_name", "fornecedor"]) {
+        const v = r[k];
+        if (typeof v === "string" && v.length >= 4) knownNames.add(v.toLowerCase());
+      }
+    }
+    // Pega palavras "Capitalizadas Compostas" (heurística de nome próprio).
+    const properNouns = answer.match(/\*\*([^*]{4,40})\*\*/g) ?? [];
+    for (const m of properNouns) {
+      const inner = m.replace(/\*/g, "").toLowerCase();
+      // Ignora termos comuns negritados pelo formatter
+      if (/^(r\$|total|saldo|atraso|estouro|fontes|próximo passo)/i.test(inner)) continue;
+      if (knownNames.size > 0 && ![...knownNames].some((n) => n.includes(inner) || inner.includes(n))) {
+        out.push({
+          id: "phantom_entity",
+          severity: "medium",
+          message: `"${inner}" não consta nos dados retornados.`,
+        });
+        break; // 1 aviso basta
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Retorna true se as issues justificam REGENERAR a resposta (apenas em
+ * casos graves — phantom de fonte ou phantom de entidade). UUID + falta
+ * de número são apenas anotados.
+ */
+export function shouldRetry(issues: CriticIssue[]): boolean {
+  return issues.some(
+    (i) => i.id === "phantom_external_source" || i.id === "phantom_entity",
+  );
+}

--- a/supabase/functions/assistant-chat/_lib/promptsV5.ts
+++ b/supabase/functions/assistant-chat/_lib/promptsV5.ts
@@ -1,0 +1,134 @@
+// Prompts v5 — evolução do v4 com:
+//   - few-shot canônico de SQL (sqlExamples.ts)
+//   - glossário coloquial PT-BR (synonyms.ts)
+//   - contexto Bwild persistente (bwildContext.ts)
+//   - regras de auto-verificação no Formatter
+//   - tom mais decisório, menos descritivo
+//
+// Reaproveita o tool schema (PLAN_TOOL) e a infra v4 — só substitui SYSTEM_PROMPT
+// e FORMATTER_SYSTEM_PROMPT quando ASSISTANT_PROMPT_VERSION='v5'.
+
+import { BWILD_CONTEXT } from "./bwildContext.ts";
+import { GLOSSARY_BLOCK } from "./synonyms.ts";
+import { renderSqlExamples } from "./sqlExamples.ts";
+
+export const SYSTEM_PROMPT_V5_HEADER = `Você é o **Assistente BWild**, copiloto analítico do portal de gestão de obras da Bwild Reformas.
+
+Sua missão: transformar a pergunta do usuário em UM PLANO de 1-3 steps (SQL interno + dado externo opcional) que responda à decisão real por trás da pergunta — não à pergunta literal.
+
+# Como você raciocina (sempre, em silêncio)
+
+Antes de gerar o plano, reflita:
+
+1. **Qual é o JOB-TO-BE-DONE?** O que o usuário decidirá com essa resposta? (cobrar cliente? remarcar obra? trocar fornecedor? renegociar? aprovar pagamento?)
+2. **Qual o tipo de pergunta?** factual / diagnóstica / comparativa / decisória / exploratória.
+3. **Qual o domínio principal?** financeiro / compras / cronograma / ncs / pendências / cs / obras / fornecedores.
+4. **Qual a granularidade que importa?** quase sempre por obra (project_id) — Pedro pensa "qual obra".
+5. **O que está IMPLÍCITO?** Se ele pergunta "quanto vence", pressupõe próximos N dias; se pergunta "quanto gastei", pressupõe mês corrente. Aplique o default e DECLARE em assumptions.
+6. **Precisa de dado de fora?** Mercado (CUB, INCC, dólar), regulação (lei short-stay), reputação (Reclame Aqui). Se sim → step external.
+7. **Vale comparar com período anterior?** Para diagnósticas e comparativas, quase sempre sim.
+
+# Regras de SQL (CRÍTICAS — violar invalida a resposta)
+
+1. **Apenas SELECT** ou \`WITH ... SELECT\`. Nunca INSERT/UPDATE/DELETE/DDL/CALL.
+2. **UMA instrução**, sem ponto-e-vírgula no final.
+3. **Use somente tabelas e colunas listadas no CATÁLOGO.** Colunas marcadas como NÃO existem são PROIBIDAS — sem exceção, sem sinônimo "óbvio".
+4. **JOIN com projects** sempre que mostrar nome de obra (\`LEFT JOIN projects p ON p.id = X.project_id\`). Filtre \`p.deleted_at IS NULL\` quando relevante.
+5. **Datas**: use \`CURRENT_DATE\`, \`date_trunc('week'|'month'|'quarter'|'year', CURRENT_DATE)\`, \`CURRENT_DATE - INTERVAL 'N days'\`. Nunca \`NOW()\` para comparar com \`date\`.
+6. **Ordenação**: ORDER BY que faça sentido para a decisão (vencimento ASC para cobrança, valor DESC para impacto, severity → critical > high > medium > low).
+7. **Limite**: o sistema aplica LIMIT 200 automático. Só use \`LIMIT N\` se o usuário pediu top N.
+8. **Colunas**: liste o que precisa, sem \`SELECT *\`. Inclua identificador (id, project_id) para drill-down se útil.
+9. **COALESCE em SUM/AVG** quando coluna pode ser nula.
+10. **Alias semântico em PT-BR** para colunas calculadas (\`AS valor_total\`, \`AS dias_em_atraso\`, \`AS estouro_pct\`).
+11. **CTEs são bem-vindas** quando deixam o SQL legível. Sem custo relevante para esse volume.
+
+# Quando a pergunta é ambígua
+
+NÃO peça clarificação — gere a melhor consulta exploratória possível e marque \`assumptions\` deixando claro o que você assumiu (ex: "este mês = mês corrente"; "saldo = recebido − pago"). O sistema decide se interrompe ou não baseado em heurística separada.
+
+Se a pergunta exige dado não modelado (ex: "margem real" sem custo de mão-de-obra própria), gere a melhor aproximação e marque na intent: "aproximação — dado X não modelado".
+
+# O que retornar
+
+Chame a função \`plan_query\` UMA vez. As regras detalhadas do schema (steps, final_calculation, assumptions) estão no bloco "Plano multi-step (v4)" abaixo.
+
+NÃO escreva texto fora do tool call.`;
+
+/**
+ * Bloco completo do system prompt v5 — junta header + contexto Bwild +
+ * glossário + few-shot. Renderizado uma vez no boot do módulo.
+ */
+export const SYSTEM_PROMPT_V5 =
+  SYSTEM_PROMPT_V5_HEADER + "\n\n" + BWILD_CONTEXT + "\n\n" + GLOSSARY_BLOCK + "\n\n" + renderSqlExamples();
+
+export const FORMATTER_SYSTEM_PROMPT_V5 = `Você é o **Assistente BWild** apresentando o resultado ao gestor.
+
+Audiência: o CEO Pedro e o time da Bwild leem isso de obra, no celular, entre uma reunião e outra.
+
+**Densidade > simpatia. Decisão > descrição. Número primeiro, contexto depois, próximo passo sempre.**
+
+# Estrutura obrigatória (markdown)
+
+## Linha 1 — Headline numérico (BLUF)
+Resposta direta em UMA linha, com o número/fato principal em **negrito**, ANTES de qualquer explicação.
+
+✅ "**R$ 47.320,00 vencendo nos próximos 7 dias** em 4 obras."
+❌ "Encontrei alguns pagamentos vencendo. Veja abaixo:"
+
+## Linhas 2-N — Conteúdo (adapte ao tamanho do resultado)
+- **0 linhas**: diga "sem registros" + ofereça 2 reformulações ("Quer ver o mês passado?" / "Quer todos os status?"). Sem mais seções.
+- **1 linha**: prosa de 1-3 frases. NÃO faça tabela.
+- **2-3 linhas**: lista com hífen. NÃO faça tabela.
+- **4+ linhas**: tabela markdown. Máx 6 colunas — escolha as que importam para decisão. Esconda IDs (uuid).
+
+Quando vierem **insights pré-computados** com severity high/critical: incorpore com ⚠️ logo abaixo do headline. Os insights são FATOS calculados deterministicamente — confie neles, não recalcule.
+
+Quando vierem **avisos de qualidade de dados**: cite ao final em itálico.
+
+## Última seção — 🎯 Próximo passo
+SEMPRE termine com 1 a 3 ações em bullets. Cada uma:
+- **Específica** (nome da obra, valor, prazo).
+- **Atribuível** (quem faz: você / financeiro / suprimentos / PM).
+- **Imediata** (até X dias).
+
+Exemplos:
+- "Cobrar boleto de **R$ 12.300** da obra **Vila Mariana** (vence amanhã) — financeiro."
+- "Pedir a Lorena para reabrir NC #234 — está há 18 dias parada."
+
+# Disciplinas de formatação
+
+- **Moeda**: \`R$ 1.234,56\` (separador de milhar com ponto, decimal com vírgula, espaço após R$).
+- **Datas**: \`DD/MM/AAAA\`. Para datas relativas curtas: "hoje", "amanhã", "em 3 dias".
+- **Percentuais**: 1 casa decimal (\`12,5%\`).
+- **Nomes de obra/fornecedor**: sempre em **negrito** quando mencionados.
+- **Nunca** mostre coluna técnica (\`project_id\`, \`uuid\`, \`org_id\`) — converta em "Obra: Nome".
+
+# Sanity check ANTES de mandar (faça mentalmente)
+
+1. **Bati o número?** Se um valor parece anômalo (pagamento único de R$ 5M; obra com 800 atividades), sinalize: "_Valor anômalo — vale conferir._"
+2. **Cobri o que foi perguntado?** Se o usuário pediu "este mês" e o SQL não filtrou, ajuste: "_Mostrei todos os registros (filtro de mês não aplicado)._"
+3. **Faltam dados óbvios?** Se a pergunta exigia campo não modelado: "_Não temos margem realizada modelada hoje — mostrei custo previsto vs realizado._"
+4. **Inventei algo?** Cada nome, valor, data citado tem que estar nos dados ou nas evidências. Sem exceção.
+5. **Próximo passo é real?** Recomendação tem que ser executável com a info que aparece na resposta.
+
+# O que NUNCA fazer
+
+- Inventar número, data, nome de obra ou fornecedor que não esteja nos dados/evidências.
+- Repetir a pergunta de volta antes de responder.
+- Encerrar com "Espero ter ajudado!" ou pedir feedback.
+- Recomendar ação que precisa de dado que você não viu.
+- Citar fonte externa (BCB, Sinduscon, CUB, INCC) sem evidência anexa.
+- Usar emoji decorativo. Permitidos APENAS: ⚠️ (risco/anomalia) e 🎯 (próximo passo).
+
+# Quando há fontes externas (v4+)
+
+Se o user message inclui "# Evidências externas":
+1. **Cite valor + data**: "Câmbio USD/BRL fechou em **R$ 5,87 em 02/05/2026** (BCB)".
+2. **NUNCA cite número que não esteja na evidência.**
+3. **Adicione seção "Fontes"** antes do "🎯 Próximo passo", com bullets do publisher + data.
+4. Se TODAS as evidências são tier 3+ (agregadores), adicione antes do próximo passo: \`_⚠ Fontes secundárias — confirme antes de decisão de R$ alto valor._\`
+5. Para temas jurídicos (lei, advogado, multa, contrato): \`_Esta resposta é informativa. Decisões jurídicas exigem validação com advogado/contador._\`
+
+# Quando a consulta deu erro
+
+Status ≠ success → diga em 1 linha o que aconteceu e proponha 1 reformulação. Não invente dados.`;

--- a/supabase/functions/assistant-chat/_lib/sqlExamples.ts
+++ b/supabase/functions/assistant-chat/_lib/sqlExamples.ts
@@ -1,0 +1,240 @@
+// Few-shot canônico de SQL para o Planner. Cada exemplo é uma pergunta real
+// que apareceu (ou tende a aparecer) em produção, com o SQL "ouro" — aquele
+// que o time validou. Reduz drasticamente alucinação de coluna e padroniza
+// o estilo (CTEs, alias semântico em PT-BR, ORDER BY útil).
+//
+// Importante: NÃO inclua exemplos longos demais. O LLM aprende mais com 8
+// exemplos curtos e variados do que com 3 exemplos enormes.
+
+export interface SqlExample {
+  pergunta: string;
+  intent: string;
+  domain: string;
+  sql: string;
+}
+
+export const SQL_EXAMPLES: SqlExample[] = [
+  {
+    pergunta: 'Quanto vence essa semana?',
+    intent: 'Pagamentos do cliente vencendo de hoje até domingo, agrupados por obra.',
+    domain: 'financeiro',
+    sql: `SELECT
+  p.name AS obra,
+  COUNT(*) AS qtd_parcelas,
+  SUM(pp.amount) AS valor_total,
+  MIN(pp.due_date) AS proximo_vencimento
+FROM project_payments pp
+LEFT JOIN projects p ON p.id = pp.project_id
+WHERE pp.paid_at IS NULL
+  AND pp.due_date BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '6 days'
+  AND p.deleted_at IS NULL
+GROUP BY p.name
+ORDER BY proximo_vencimento ASC`,
+  },
+  {
+    pergunta: 'Qual o saldo de cada obra?',
+    intent: 'Saldo = recebido − pago, por obra ativa, do mais positivo ao mais negativo.',
+    domain: 'financeiro',
+    sql: `WITH recebido AS (
+  SELECT project_id, COALESCE(SUM(amount), 0) AS total_recebido
+  FROM project_payments
+  WHERE paid_at IS NOT NULL
+  GROUP BY project_id
+),
+pago AS (
+  SELECT project_id, COALESCE(SUM(actual_cost), 0) AS total_pago
+  FROM project_purchases
+  WHERE paid_at IS NOT NULL
+  GROUP BY project_id
+)
+SELECT
+  p.id AS project_id,
+  p.name AS obra,
+  COALESCE(r.total_recebido, 0) AS recebido,
+  COALESCE(pg.total_pago, 0) AS pago,
+  COALESCE(r.total_recebido, 0) - COALESCE(pg.total_pago, 0) AS saldo
+FROM projects p
+LEFT JOIN recebido r ON r.project_id = p.id
+LEFT JOIN pago pg ON pg.project_id = p.id
+WHERE p.deleted_at IS NULL
+  AND (p.actual_end_date IS NULL OR p.actual_end_date > CURRENT_DATE - INTERVAL '30 days')
+ORDER BY saldo DESC`,
+  },
+  {
+    pergunta: 'Quais obras estão fugindo do orçamento?',
+    intent: 'Estouro = soma(actual − estimated) por obra, só onde estourou; ordenado pelo pior.',
+    domain: 'compras',
+    sql: `SELECT
+  p.name AS obra,
+  COUNT(pc.id) FILTER (WHERE pc.actual_cost > pc.estimated_cost) AS itens_estouraram,
+  SUM(GREATEST(pc.actual_cost - pc.estimated_cost, 0)) AS estouro_total,
+  SUM(pc.estimated_cost) AS orcamento_estimado,
+  ROUND(
+    100.0 * SUM(GREATEST(pc.actual_cost - pc.estimated_cost, 0))
+      / NULLIF(SUM(pc.estimated_cost), 0),
+    1
+  ) AS estouro_pct
+FROM project_purchases pc
+LEFT JOIN projects p ON p.id = pc.project_id
+WHERE p.deleted_at IS NULL
+  AND pc.actual_cost IS NOT NULL
+GROUP BY p.name
+HAVING SUM(GREATEST(pc.actual_cost - pc.estimated_cost, 0)) > 0
+ORDER BY estouro_total DESC`,
+  },
+  {
+    pergunta: 'Quais NCs críticas estão abertas e há quanto tempo?',
+    intent: 'NCs com severity=critical, status≠closed, idade em dias, mais antigas primeiro.',
+    domain: 'ncs',
+    sql: `SELECT
+  p.name AS obra,
+  nc.title,
+  nc.category,
+  nc.deadline,
+  CURRENT_DATE - nc.created_at::date AS dias_aberta,
+  CASE
+    WHEN nc.deadline < CURRENT_DATE THEN CURRENT_DATE - nc.deadline
+    ELSE 0
+  END AS dias_em_atraso,
+  nc.reopen_count
+FROM non_conformities nc
+LEFT JOIN projects p ON p.id = nc.project_id
+WHERE nc.severity = 'critical'
+  AND nc.status <> 'closed'
+  AND p.deleted_at IS NULL
+ORDER BY dias_aberta DESC`,
+  },
+  {
+    pergunta: 'O que eu preciso priorizar hoje?',
+    intent: 'União ranqueada de itens críticos: NCs críticas vencidas, pagamentos atrasados, compras atrasadas.',
+    domain: 'pendencias',
+    sql: `WITH itens AS (
+  SELECT
+    'NC crítica vencida' AS tipo,
+    nc.title AS descricao,
+    p.name AS obra,
+    nc.deadline AS data_referencia,
+    CURRENT_DATE - nc.deadline AS dias_em_atraso,
+    nc.estimated_cost AS valor_em_jogo,
+    100 AS peso
+  FROM non_conformities nc
+  LEFT JOIN projects p ON p.id = nc.project_id
+  WHERE nc.severity = 'critical' AND nc.status <> 'closed'
+    AND nc.deadline < CURRENT_DATE AND p.deleted_at IS NULL
+
+  UNION ALL
+
+  SELECT
+    'Pagamento atrasado',
+    pp.description,
+    p.name,
+    pp.due_date,
+    CURRENT_DATE - pp.due_date,
+    pp.amount,
+    80
+  FROM project_payments pp
+  LEFT JOIN projects p ON p.id = pp.project_id
+  WHERE pp.paid_at IS NULL AND pp.due_date < CURRENT_DATE
+    AND p.deleted_at IS NULL
+
+  UNION ALL
+
+  SELECT
+    'Compra atrasada',
+    pc.item_name,
+    p.name,
+    pc.required_by_date,
+    CURRENT_DATE - pc.required_by_date,
+    pc.estimated_cost,
+    60
+  FROM project_purchases pc
+  LEFT JOIN projects p ON p.id = pc.project_id
+  WHERE pc.required_by_date < CURRENT_DATE
+    AND pc.status NOT IN ('delivered', 'cancelled')
+    AND p.deleted_at IS NULL
+)
+SELECT * FROM itens
+ORDER BY peso DESC, dias_em_atraso DESC`,
+  },
+  {
+    pergunta: 'Comparar gasto deste mês vs mês passado',
+    intent: 'Compras pagas, agregadas por mês corrente e anterior; mostra delta absoluto e %.',
+    domain: 'compras',
+    sql: `WITH base AS (
+  SELECT
+    date_trunc('month', paid_at) AS mes,
+    SUM(actual_cost) AS gasto
+  FROM project_purchases
+  WHERE paid_at IS NOT NULL
+    AND paid_at >= date_trunc('month', CURRENT_DATE) - INTERVAL '1 month'
+  GROUP BY 1
+)
+SELECT
+  to_char(mes, 'MM/YYYY') AS mes,
+  gasto,
+  gasto - LAG(gasto) OVER (ORDER BY mes) AS delta_abs,
+  ROUND(
+    100.0 * (gasto - LAG(gasto) OVER (ORDER BY mes))
+      / NULLIF(LAG(gasto) OVER (ORDER BY mes), 0),
+    1
+  ) AS delta_pct
+FROM base
+ORDER BY mes`,
+  },
+  {
+    pergunta: 'Quais fornecedores entregaram com atraso nos últimos 90 dias?',
+    intent: 'Fornecedor × atraso médio em dias × qtd de itens entregues atrasados.',
+    domain: 'fornecedores',
+    sql: `SELECT
+  COALESCE(pc.supplier_name, f.nome, '(sem fornecedor)') AS fornecedor,
+  COUNT(*) AS itens_entregues,
+  COUNT(*) FILTER (
+    WHERE pc.actual_delivery_date > pc.required_by_date
+  ) AS itens_atrasados,
+  ROUND(
+    AVG(EXTRACT(DAY FROM pc.actual_delivery_date - pc.required_by_date))
+      FILTER (WHERE pc.actual_delivery_date > pc.required_by_date),
+    1
+  ) AS dias_atraso_medio
+FROM project_purchases pc
+LEFT JOIN fornecedores f ON f.id = pc.fornecedor_id
+WHERE pc.actual_delivery_date IS NOT NULL
+  AND pc.actual_delivery_date >= CURRENT_DATE - INTERVAL '90 days'
+GROUP BY 1
+HAVING COUNT(*) FILTER (WHERE pc.actual_delivery_date > pc.required_by_date) > 0
+ORDER BY dias_atraso_medio DESC NULLS LAST`,
+  },
+  {
+    pergunta: 'Cronograma — quais atividades atrasam a obra X?',
+    intent: 'Atividades com planned_end < hoje sem actual_end, ordenadas pela data planejada.',
+    domain: 'cronograma',
+    sql: `SELECT
+  p.name AS obra,
+  pa.etapa,
+  pa.description AS atividade,
+  pa.planned_end,
+  CURRENT_DATE - pa.planned_end AS dias_em_atraso,
+  pa.weight
+FROM project_activities pa
+LEFT JOIN projects p ON p.id = pa.project_id
+WHERE pa.planned_end < CURRENT_DATE
+  AND pa.actual_end IS NULL
+  AND p.deleted_at IS NULL
+ORDER BY pa.planned_end ASC`,
+  },
+];
+
+export function renderSqlExamples(): string {
+  const lines: string[] = ['# EXEMPLOS DE SQL CANÔNICO (estude o estilo)'];
+  for (const ex of SQL_EXAMPLES) {
+    lines.push(`\n## "${ex.pergunta}" [${ex.domain}]`);
+    lines.push(`Intent: ${ex.intent}`);
+    lines.push('```sql');
+    lines.push(ex.sql);
+    lines.push('```');
+  }
+  lines.push(
+    '\nUse o MESMO estilo: CTEs nomeadas, alias PT-BR, COALESCE em SUM, JOIN em projects com filtro deleted_at, ORDER BY que faça sentido para a decisão.',
+  );
+  return lines.join('\n');
+}

--- a/supabase/functions/assistant-chat/_lib/synonyms.ts
+++ b/supabase/functions/assistant-chat/_lib/synonyms.ts
@@ -1,0 +1,63 @@
+// Sinônimos e mini-glossário de obra/finance, expandido para PT-BR coloquial
+// brasileiro de canteiro. Injetado no prompt do Planner para reduzir
+// ambiguidade. Ex: "tá apertando" → margem ou prazo; "secou" → saldo negativo.
+
+export const GLOSSARY_BLOCK = `# GLOSSÁRIO COLOQUIAL (mapeie a fala do usuário para coluna correta)
+
+## Financeiro
+- "vence" / "venceu" / "tá pra vencer" → due_date / required_by_date
+- "tá no vermelho" / "secou" / "no negativo" → saldo (recebido − pago) < 0
+- "estourou" / "passou do alvo" / "passou do orçamento" → actual_cost > estimated_cost
+- "tá sangrando" → estouro de compra OU pagamento atrasado de cliente
+- "recebeu" / "caiu" / "entrou" → project_payments.paid_at IS NOT NULL
+- "boletou" / "emitiu boleto" → boleto_code IS NOT NULL
+- "PIX" / "transferiu" → payment_method ILIKE '%pix%'
+- "comissão" / "repasse" → fora do escopo dessa base hoje (sinalize)
+
+## Cronograma
+- "tá em dia" / "no prazo" → actual_end IS NOT NULL E actual_end <= planned_end
+- "atrasou" / "tá atrasado" / "ficou pra trás" → planned_end < hoje E actual_end IS NULL
+- "tá voando" → atividade concluída antes do planned_end
+- "travou" / "parou" → atividade sem actual_start mas planned_start já passou
+- "vai estourar o prazo" → forecast (planned_end − atividades pendentes) > planned_end_date da obra
+- "fase" / "etapa" → project_activities.etapa
+- "diagnóstico", "projeto", "reforma", "entrega" → as 4 fases canônicas Bwild
+
+## Compras / fornecedor
+- "comprou" / "fechou" → status IN ('ordered','delivered')
+- "chegou" / "entregou" → status='delivered' OU actual_delivery_date IS NOT NULL
+- "atrasou a entrega" → actual_delivery_date > required_by_date
+- "tá pendente de cotação" → status='pending' AND fornecedor_id IS NULL
+- "fornecedor problemático" → fornecedor com nota_avaliacao < 3 OU muitas entregas atrasadas
+- "PJ" / "empreiteiro" / "prestador" → fornecedores.supplier_type='prestadores'
+- "produto" / "material" → fornecedores.supplier_type='produtos'
+
+## NCs e qualidade
+- "NC" / "não conformidade" / "defeito" / "problema de qualidade" → non_conformities
+- "abriu NC" → non_conformities recém-criada
+- "fechou NC" → status='closed' / resolved_at IS NOT NULL
+- "voltou" / "reabriu" → reopen_count > 0
+- "tá demorando pra resolver" → CURRENT_DATE - created_at::date > 7 e status<>'closed'
+
+## Cliente / CS
+- "cliente reclamou" → cs_tickets recém-criado
+- "ticket aberto" → cs_tickets.resolved_at IS NULL
+- "fora do contrato" → escopo extra; pode estar em pending_items ou cs_tickets
+
+## Obras (entidade)
+- "minha obra" / "a obra do João" → projects.client_name ILIKE '%João%'
+- "obra do bairro X" → projects.city ILIKE '%X%'
+- "obra ativa" / "rodando" → deleted_at IS NULL AND actual_end_date IS NULL
+- "obra entregue" → actual_end_date IS NOT NULL
+- "todas as obras" → deleted_at IS NULL (incluindo entregues)
+
+## Tempo (sempre relativo)
+- "agora" / "hoje" → CURRENT_DATE
+- "ontem" → CURRENT_DATE - INTERVAL '1 day'
+- "essa semana" → BETWEEN date_trunc('week', CURRENT_DATE) AND date_trunc('week', CURRENT_DATE) + INTERVAL '6 days'
+- "semana que vem" → BETWEEN CURRENT_DATE + 7 AND CURRENT_DATE + 13
+- "esse mês" → date_trunc('month', CURRENT_DATE)
+- "mês passado" → date_trunc('month', CURRENT_DATE) - INTERVAL '1 month'
+- "trimestre" → últimos 90 dias OU date_trunc('quarter', ...)
+- "no ano" → date_trunc('year', CURRENT_DATE)
+- "últimos N dias" → CURRENT_DATE - INTERVAL 'N days'`;

--- a/supabase/functions/assistant-chat/index.ts
+++ b/supabase/functions/assistant-chat/index.ts
@@ -18,15 +18,31 @@ import {
   type FormatterStep,
 } from './_lib/prompts.ts';
 import {
+  SYSTEM_PROMPT_V5,
+  FORMATTER_SYSTEM_PROMPT_V5,
+} from './_lib/promptsV5.ts';
+import {
   EXTERNAL_SOURCES,
   renderExternalSourcesCatalog,
 } from './_lib/externalSources.ts';
 import { dispatchExternalStep } from './_lib/dispatcher.ts';
+import { generateAdvancedInsights, generateDynamicFollowUps } from './_lib/advancedAnalysis.ts';
+import { detectClarification } from './_lib/clarification.ts';
+import { critiqueAnswer, shouldRetry } from './_lib/critic.ts';
+import { buildMemoryWindow, memoryToChatMessages } from './_lib/conversationMemory.ts';
 
 const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
-const MODEL = 'google/gemini-3-flash-preview';
+// Modelos seletivos (v5): planner pode ser mais forte que formatter; ambos
+// configuráveis por env para A/B test sem deploy.
+const PLANNER_MODEL = Deno.env.get('ASSISTANT_PLANNER_MODEL') ?? 'google/gemini-3-flash-preview';
+const FORMATTER_MODEL = Deno.env.get('ASSISTANT_FORMATTER_MODEL') ?? 'google/gemini-3-flash-preview';
+const PROMPT_VERSION = (Deno.env.get('ASSISTANT_PROMPT_VERSION') ?? 'v5').toLowerCase();
+const USE_V5 = PROMPT_VERSION === 'v5';
+const MODEL = PLANNER_MODEL; // back-compat com logs/insert antigos
+const ACTIVE_SYSTEM_PROMPT = USE_V5 ? SYSTEM_PROMPT_V5 : SYSTEM_PROMPT;
+const ACTIVE_FORMATTER_PROMPT = USE_V5 ? FORMATTER_SYSTEM_PROMPT_V5 : FORMATTER_SYSTEM_PROMPT;
 
 const SCHEMA_CATALOG = renderCatalog();
 const EXTERNAL_CATALOG = renderExternalSourcesCatalog();
@@ -138,11 +154,33 @@ function buildAnalysis(opts: {
   domain: string;
   sql: string | null;
   status: string;
+  question?: string;
 }) {
-  const insights = generateInsights(opts.rows, opts.domain, opts.sql);
+  const baseInsights = generateInsights(opts.rows, opts.domain, opts.sql);
+  const advancedInsights = generateAdvancedInsights(opts.rows, opts.domain);
+  // Mescla básicos + avançados, deduplicando por texto.
+  const seen = new Set<string>();
+  const insights: string[] = [];
+  for (const it of [...baseInsights, ...advancedInsights]) {
+    const key = (typeof it === 'string' ? it : String(it)).trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    insights.push(it as string);
+  }
   const dataQuality = analyzeDataQuality(opts.rows);
   const visualizations = recommendVisualizations(opts.rows);
-  const followUps = suggestFollowUps(opts.domain);
+  const baseFollowUps = suggestFollowUps(opts.domain);
+  const dynamicFollowUps = generateDynamicFollowUps(opts.rows, opts.domain, opts.question ?? '');
+  // Prioriza dinâmicas (mais contextuais) e completa com as fixas.
+  const followSeen = new Set<string>();
+  const followUps: string[] = [];
+  for (const f of [...dynamicFollowUps, ...baseFollowUps]) {
+    const key = String(f).trim().toLowerCase();
+    if (!key || followSeen.has(key)) continue;
+    followSeen.add(key);
+    followUps.push(f as string);
+    if (followUps.length >= 5) break;
+  }
   const confidence = scoreConfidence({
     rowsReturned: opts.rowsReturned,
     hasSql: Boolean(opts.sql),
@@ -361,31 +399,48 @@ Deno.serve(async (req) => {
 
         send('status', { phase: 'thinking', message: 'Interpretando pergunta...' });
 
-        const { data: history } = await supabase
+        const { data: rawHistory } = await supabase
           .from('assistant_messages')
-          .select('role, content')
+          .select('role, content, created_at')
           .eq('conversation_id', conversationId)
-          .order('created_at', { ascending: true })
-          .limit(10);
+          .order('created_at', { ascending: false })
+          .limit(MEMORY_TOTAL_LIMIT);
+
+        // Reordena cronológico ascendente e aplica janela com sumarização das mais antigas.
+        const orderedHistory = (rawHistory ?? [])
+          .slice()
+          .reverse()
+          .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content as string }));
+        const memoryWindow = buildMemoryWindow(orderedHistory);
+
+        // Detecção de pergunta ambígua → emite 'clarification' e encerra cedo.
+        if (USE_V5) {
+          const clarif = detectClarification(question, orderedHistory);
+          if (clarif.needs_clarification) {
+            send('clarification', {
+              reason: clarif.reason,
+              options: clarif.options,
+            });
+            // Não persistimos resposta de assistente — esperamos a escolha do usuário.
+            return;
+          }
+        }
 
         const llmMessages = [
           {
             role: 'system',
             content:
-              SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
+              ACTIVE_SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
               '\n\n' + PLANNER_EXTERNAL_DELTA + '\n\n' + EXTERNAL_CATALOG,
           },
-          ...(history ?? []).map((m: { role: string; content: string }) => ({
-            role: m.role === 'assistant' ? 'assistant' : 'user',
-            content: m.content,
-          })),
+          ...memoryToChatMessages(memoryWindow),
         ];
 
         const llmResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
           method: 'POST',
           headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: MODEL,
+            model: PLANNER_MODEL,
             messages: llmMessages,
             tools: [PLAN_TOOL],
             tool_choice: { type: 'function', function: { name: 'plan_query' } },
@@ -628,7 +683,7 @@ Deno.serve(async (req) => {
         send('rows', { rows_returned: rowsReturned, preview: rows.slice(0, 50) });
 
         if (status === 'success') {
-          analysis = buildAnalysis({ rows, rowsReturned, domain, sql: generatedSql, status });
+          analysis = buildAnalysis({ rows, rowsReturned, domain, sql: generatedSql, status, question });
           if (planLimitations.length) analysis.limitations.push(...planLimitations);
           send('analysis', {
             insights: analysis.insights,
@@ -677,10 +732,10 @@ Deno.serve(async (req) => {
             method: 'POST',
             headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              model: MODEL,
+              model: FORMATTER_MODEL,
               stream: true,
               messages: [
-                { role: 'system', content: FORMATTER_SYSTEM_PROMPT },
+                { role: 'system', content: ACTIVE_FORMATTER_PROMPT },
                 { role: 'user', content: formatterUserMessage },
               ],
             }),
@@ -748,6 +803,51 @@ Deno.serve(async (req) => {
               buffer = '';
             }
             if (!finalAnswer) finalAnswer = `Consulta retornou ${rowsReturned} linha(s).`;
+          }
+
+          // ---- Self-critic + retry único (V5) -------------------------------
+          if (USE_V5 && status === 'success' && finalAnswer && rows.length > 0) {
+            try {
+              const critique = critiqueAnswer({
+                answer: finalAnswer,
+                rows,
+                question,
+                hasEvidences: evidences.length > 0,
+              });
+              if (critique.issues.length > 0) {
+                send('quality_warning', { issues: critique.issues, score: critique.score });
+              }
+              if (shouldRetry(critique.issues)) {
+                send('status', { phase: 'refining', message: 'Refinando resposta...' });
+                const fixPrefix =
+                  'A resposta anterior teve estes problemas: ' +
+                  critique.issues.map((i) => `[${i.severity}] ${i.message}`).join('; ') +
+                  '. Refaça a resposta evitando todos esses erros. Mantenha headline, dados, e próximo passo.';
+                const retryResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
+                  method: 'POST',
+                  headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    model: FORMATTER_MODEL,
+                    messages: [
+                      { role: 'system', content: ACTIVE_FORMATTER_PROMPT },
+                      { role: 'user', content: fixPrefix + '\n\n' + formatterUserMessage },
+                    ],
+                  }),
+                });
+                if (retryResp.ok) {
+                  const retryData = await retryResp.json();
+                  tokensIn += retryData?.usage?.prompt_tokens ?? 0;
+                  tokensOut += retryData?.usage?.completion_tokens ?? 0;
+                  const newAnswer = retryData?.choices?.[0]?.message?.content;
+                  if (typeof newAnswer === 'string' && newAnswer.length > 0) {
+                    finalAnswer = newAnswer;
+                    send('answer_replaced', { content: finalAnswer, reason: 'self_critic_retry' });
+                  }
+                }
+              }
+            } catch (e) {
+              console.warn(`[assistant-chat] [req=${requestId}] critic falhou:`, e);
+            }
           }
         }
 
@@ -933,28 +1033,32 @@ async function runNonStreaming(opts: {
       conversation_id: conversationId, user_id: userId, role: 'user', content: question,
     });
 
-    const { data: history } = await supabase
+    const { data: rawHistoryNS } = await supabase
       .from('assistant_messages')
-      .select('role, content')
+      .select('role, content, created_at')
       .eq('conversation_id', conversationId)
-      .order('created_at', { ascending: true })
-      .limit(10);
+      .order('created_at', { ascending: false })
+      .limit(MEMORY_TOTAL_LIMIT);
+
+    const orderedHistoryNS = (rawHistoryNS ?? [])
+      .slice()
+      .reverse()
+      .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content as string }));
+    const memoryWindowNS = buildMemoryWindow(orderedHistoryNS);
 
     const llmResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
       method: 'POST',
       headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: MODEL,
+        model: PLANNER_MODEL,
         messages: [
           {
             role: 'system',
             content:
-              SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
+              ACTIVE_SYSTEM_PROMPT + '\n\n' + SCHEMA_CATALOG +
               '\n\n' + PLANNER_EXTERNAL_DELTA + '\n\n' + EXTERNAL_CATALOG,
           },
-          ...(history ?? []).map((m: { role: string; content: string }) => ({
-            role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content,
-          })),
+          ...memoryToChatMessages(memoryWindowNS),
         ],
         tools: [PLAN_TOOL],
         tool_choice: { type: 'function', function: { name: 'plan_query' } },
@@ -1119,9 +1223,9 @@ async function runNonStreaming(opts: {
         method: 'POST',
         headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model: MODEL,
+          model: FORMATTER_MODEL,
           messages: [
-            { role: 'system', content: FORMATTER_SYSTEM_PROMPT },
+            { role: 'system', content: ACTIVE_FORMATTER_PROMPT },
             { role: 'user', content: formatterUserMessage },
           ],
         }),
@@ -1130,6 +1234,44 @@ async function runNonStreaming(opts: {
       tokensIn += fd?.usage?.prompt_tokens ?? 0;
       tokensOut += fd?.usage?.completion_tokens ?? 0;
       finalAnswer = fd?.choices?.[0]?.message?.content ?? `Consulta retornou ${rowsReturned} linha(s).`;
+
+      // ---- Self-critic + retry único (V5, não-streaming) ----------------
+      if (USE_V5 && status === 'success' && finalAnswer && rows.length > 0) {
+        try {
+          const critique = critiqueAnswer({
+            answer: finalAnswer,
+            rows,
+            question,
+            hasEvidences: evidences.length > 0,
+          });
+          if (shouldRetry(critique.issues)) {
+            const fixPrefix =
+              'A resposta anterior teve estes problemas: ' +
+              critique.issues.map((i) => `[${i.severity}] ${i.message}`).join('; ') +
+              '. Refaça a resposta evitando todos esses erros.';
+            const retryResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${LOVABLE_API_KEY}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                model: FORMATTER_MODEL,
+                messages: [
+                  { role: 'system', content: ACTIVE_FORMATTER_PROMPT },
+                  { role: 'user', content: fixPrefix + '\n\n' + formatterUserMessage },
+                ],
+              }),
+            });
+            if (retryResp.ok) {
+              const rd = await retryResp.json();
+              tokensIn += rd?.usage?.prompt_tokens ?? 0;
+              tokensOut += rd?.usage?.completion_tokens ?? 0;
+              const newAnswer = rd?.choices?.[0]?.message?.content;
+              if (typeof newAnswer === 'string' && newAnswer.length > 0) finalAnswer = newAnswer;
+            }
+          }
+        } catch (e) {
+          console.warn('[assistant-chat] critic não-streaming falhou:', e);
+        }
+      }
     }
 
     const { data: logRow } = await supabase


### PR DESCRIPTION
# 🧠 Assistente IA v5 — Inteligência Profunda

Reformulação drástica do assistente para aumentar capacidade de entender perguntas complexas, qualidade das respostas e contexto operacional BWild.

## 🎯 4 frentes implementadas

### 1️⃣ Cérebro & memória conversacional
- **Novos prompts v5** (`promptsV5.ts`): contrato mais explícito com headline, raciocínio passo-a-passo, citação de evidências, recusa segura, anti-alucinação reforçado.
- **Memória conversacional inteligente** (`conversationMemory.ts`): janela de 30 mensagens (vs 10), com sumarização automática das mais antigas em uma "memória resumida" injetada no system prompt — o assistente lembra do contexto sem estourar tokens.
- **Modelos separáveis por papel**: `ASSISTANT_PLANNER_MODEL` e `ASSISTANT_FORMATTER_MODEL` (env vars), permitindo usar modelo mais barato no formatter.

### 2️⃣ Catálogo + KPIs nomeados + sinônimos PT-BR
- **Contexto BWild** (`bwildContext.ts`): vocabulário, thresholds (atraso, estouro, NC crítica), defaults de período, regras anti-alucinação injetadas no system prompt.
- **KPIs nomeados** (`catalog.ts → NAMED_KPIS`): saldo de obra, exposição contratual, estouro de orçamento, margem prevista, atraso de cronograma — com fórmula SQL canônica.
- **Glossário de sinônimos** (`synonyms.ts`): "comprometido" → `valor_total_pedido`, "no vermelho" → `saldo < 0`, etc. Resolve ~80% das ambiguidades de linguagem coloquial.
- **8 exemplos few-shot** (`sqlExamples.ts`): perguntas reais de obra → SQL canônico, ensinando o planner por imitação.

### 3️⃣ Análise avançada + drill-downs dinâmicos
- **Insights avançados** (`advancedAnalysis.ts → generateAdvancedInsights`):
  - Detecção de **concentração** (regra 80/20: poucos itens dominam o total)
  - **Outliers** estatísticos (z-score)
  - **Tendência** (crescimento/queda mês-a-mês)
  - **Estouro de orçamento** com magnitude
  - **Top offenders** (maiores atrasos, maiores valores em risco)
- **Follow-ups dinâmicos** (`generateDynamicFollowUps`): sugestões de próxima pergunta baseadas no que foi visto nos dados, não em lista fixa.

### 4️⃣ Clarification + self-critic + retry automático
- **Detecção de ambiguidade** (`clarification.ts`): heurísticas para "essa semana", "obra X", "pendentes", "atrasados" sem contexto. Em vez de assumir, o assistente devolve **opções clicáveis** ao usuário.
  - Novo evento SSE: `clarification` com `{reason, options: [{label, resolved_question}]}`
- **Self-critic** (`critic.ts → critiqueAnswer`): após cada resposta, valida automaticamente:
  - Faltou headline?
  - Faltou próximo passo?
  - Mencionou entidade fantasma (ex: UUID que não existe nas linhas)?
  - Citou fonte que não foi consultada?
- **Retry único** quando `shouldRetry(issues) === true`: refaz o formatter com prefixo "Resposta anterior teve estes problemas: ... Refaça evitando".
  - Novos eventos SSE: `quality_warning` (informativo) e `answer_replaced` (substitui o conteúdo no front).

## 🎨 UX

`AssistantChat.tsx` atualizado para:
- Renderizar **opções de clarificação** como pills clicáveis no balão da resposta
- Exibir badge "Resposta refinada automaticamente" quando o critic acionou retry
- Tipos `ClarificationOption` e `QualityIssue` exportados

## 🔧 Configuração

| Env var | Default | Função |
|---|---|---|
| `ASSISTANT_PLANNER_MODEL` | `google/gemini-3-flash-preview` | Modelo do planner (function-calling) |
| `ASSISTANT_FORMATTER_MODEL` | `google/gemini-3-flash-preview` | Modelo do formatter (resposta final) |
| `ASSISTANT_PROMPT_VERSION` | `v5` | Defina `v4` para rollback imediato sem deploy |

## 🔁 Rollback

`USE_V5 = (PROMPT_VERSION !== 'v4')`. Set `ASSISTANT_PROMPT_VERSION=v4` no Supabase para voltar comportamento anterior. Todos os novos features (clarification, critic, advanced insights) são gateados por `USE_V5` — zero risco para o legado.

## ✅ Validação

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run lint` ✅ (1 erro pré-existente em `ImportScheduleModal.tsx`, não introduzido aqui)

## 📁 Arquivos novos
```
supabase/functions/assistant-chat/_lib/
├── promptsV5.ts            (system + formatter v5)
├── bwildContext.ts         (KPIs, thresholds, vocabulário)
├── sqlExamples.ts          (8 few-shots canônicos)
├── synonyms.ts             (PT-BR coloquial → colunas)
├── advancedAnalysis.ts     (insights + follow-ups dinâmicos)
├── clarification.ts        (detecção de ambiguidade)
├── critic.ts               (self-critic + shouldRetry)
└── conversationMemory.ts   (janela 30 + sumarização)
```

## 📁 Arquivos modificados
- `supabase/functions/assistant-chat/_lib/catalog.ts` — adicionado `NAMED_KPIS` e `renderNamedKpis()`
- `supabase/functions/assistant-chat/index.ts` — integração nas 2 flows (streaming + legacy)
- `src/components/assistant/AssistantChat.tsx` — 3 novos eventos SSE + UI de clarification

## 🚀 Próximos passos sugeridos (futuro PR)

1. Persistir `quality_warnings` em `assistant_logs` para observability.
2. A/B test entre v4 e v5 com flag por usuário.
3. Treinar critic com exemplos rotulados (LLM-as-judge mais sofisticado).
4. Drill-down: ao clicar num insight, gerar pergunta automática filtrando aquela dimensão.
