### PR TITLE
Refactor: Extract Assessor components and integrate into module pages

### DIFF
--- a/src/components/agent/AssessorEventsList.tsx
+++ b/src/components/agent/AssessorEventsList.tsx
@@ -1,0 +1,84 @@
+/**
+ * Lista de eventos passados do BWild Assessor para um projeto.
+ */
+
+import { formatDistanceToNow } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { BwildAgentEvent } from "@/infra/repositories/agentMemory.repository";
+import { EVENT_TYPE_LABEL, ROUTED_AGENT_LABEL, SOURCE_LABEL } from "./labels";
+
+interface AssessorEventsListProps {
+  isLoading: boolean;
+  events: BwildAgentEvent[];
+  highlightedEventId?: string | null;
+}
+
+export function AssessorEventsList({
+  isLoading,
+  events,
+  highlightedEventId = null,
+}: AssessorEventsListProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-16 w-full" />
+        ))}
+      </div>
+    );
+  }
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Nenhuma consulta registrada para esta obra ainda.
+      </p>
+    );
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {events.map((event) => (
+        <li
+          key={event.id}
+          className={
+            "py-3 " +
+            (event.id === highlightedEventId
+              ? "bg-primary/5 -mx-2 px-2 rounded"
+              : "")
+          }
+        >
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <Badge variant="outline">
+              {EVENT_TYPE_LABEL[event.event_type]}
+            </Badge>
+            {event.routed_agent && (
+              <Badge variant="secondary">
+                {ROUTED_AGENT_LABEL[event.routed_agent]}
+              </Badge>
+            )}
+            {event.source && (
+              <span className="text-xs text-muted-foreground">
+                {SOURCE_LABEL[event.source]}
+              </span>
+            )}
+            <span className="ml-auto text-xs text-muted-foreground">
+              {formatDistanceToNow(new Date(event.created_at), {
+                addSuffix: true,
+                locale: ptBR,
+              })}
+            </span>
+          </div>
+          <p className="text-sm text-foreground/90 line-clamp-2">
+            {event.content}
+          </p>
+          {event.status !== "success" && (
+            <p className="text-xs text-destructive mt-1">
+              {event.status}: {event.error_message ?? "Erro desconhecido"}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/agent/AssessorMemoryView.tsx
+++ b/src/components/agent/AssessorMemoryView.tsx
@@ -1,0 +1,92 @@
+/**
+ * Visualização da memória stateful do projeto (snapshot atual).
+ */
+
+import { Info } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import type { ProjectState } from "@/infra/repositories/agentMemory.repository";
+import { STATE_SECTION_LABEL } from "./labels";
+
+interface AssessorMemoryViewProps {
+  isLoading: boolean;
+  state: ProjectState | null;
+  version?: number;
+  updatedAt?: string;
+}
+
+export function AssessorMemoryView({
+  isLoading,
+  state,
+  version,
+  updatedAt,
+}: AssessorMemoryViewProps) {
+  if (isLoading) {
+    return (
+      <div className="mt-6 space-y-3">
+        <Skeleton className="h-6 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+  if (!state || Object.keys(state).length === 0) {
+    return (
+      <Alert className="mt-6">
+        <Info className="h-4 w-4" />
+        <AlertDescription>
+          Memória vazia — nenhuma consulta ainda preencheu o estado deste
+          projeto.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const sections = (
+    Object.keys(STATE_SECTION_LABEL) as Array<keyof ProjectState>
+  )
+    .map((key) => [key, state[key]] as const)
+    .filter(([, value]) => value && Object.keys(value).length > 0);
+
+  return (
+    <div className="mt-6 space-y-4">
+      <div className="text-xs text-muted-foreground flex items-center gap-3">
+        {typeof version === "number" && <span>versão {version}</span>}
+        {updatedAt && (
+          <span>
+            atualizado{" "}
+            {formatDistanceToNow(new Date(updatedAt), {
+              addSuffix: true,
+              locale: ptBR,
+            })}
+          </span>
+        )}
+      </div>
+      <Accordion
+        type="multiple"
+        defaultValue={sections.map(([k]) => String(k))}
+      >
+        {sections.map(([key, value]) => (
+          <AccordionItem key={String(key)} value={String(key)}>
+            <AccordionTrigger className="text-sm">
+              {STATE_SECTION_LABEL[key]}
+            </AccordionTrigger>
+            <AccordionContent>
+              <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
+                {JSON.stringify(value, null, 2)}
+              </pre>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+}

--- a/src/components/agent/AssessorResponse.tsx
+++ b/src/components/agent/AssessorResponse.tsx
@@ -1,0 +1,159 @@
+/**
+ * Renderiza a resposta estruturada do BWild Assessor.
+ * Compartilhado pela página `/obra/:projectId/assessor` e pelo
+ * AssessorSheet usado nas páginas de módulo.
+ */
+
+import { Clock } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import type { BwildAgentResponse } from "@/infra/edgeFunctions";
+import { ROUTED_AGENT_LABEL } from "./labels";
+
+interface AssessorResponseProps {
+  response: BwildAgentResponse;
+}
+
+export function AssessorResponse({ response }: AssessorResponseProps) {
+  const r = response.response;
+  if (!r) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        O assessor não retornou conteúdo estruturado.
+      </p>
+    );
+  }
+  const impactos = r.impactos ?? {};
+  const hasImpacts = Object.values(impactos).some((v) => !!v);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Badge variant="outline">
+          {ROUTED_AGENT_LABEL[response.routed_agent]}
+        </Badge>
+        <span>via {response.routing_reason}</span>
+        <span className="ml-auto inline-flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          {response.latency_ms} ms
+        </span>
+      </div>
+
+      {r.diagnostico && (
+        <Section title="Diagnóstico">
+          <p className="text-sm whitespace-pre-line">{r.diagnostico}</p>
+        </Section>
+      )}
+
+      {r.recomendacao && (
+        <Section title="Recomendação">
+          <p className="text-sm whitespace-pre-line">{r.recomendacao}</p>
+        </Section>
+      )}
+
+      {r.plano_de_acao && r.plano_de_acao.length > 0 && (
+        <Section title="Plano de ação">
+          <ul className="text-sm list-disc pl-5 space-y-1">
+            {r.plano_de_acao.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {r.decisoes_necessarias && r.decisoes_necessarias.length > 0 && (
+        <Section title="Decisões necessárias">
+          <ul className="text-sm list-disc pl-5 space-y-1">
+            {r.decisoes_necessarias.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      <Accordion type="multiple" className="border-t pt-2">
+        {hasImpacts && (
+          <AccordionItem value="impactos">
+            <AccordionTrigger className="text-sm">Impactos</AccordionTrigger>
+            <AccordionContent>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                {Object.entries(impactos).map(([key, value]) =>
+                  value ? (
+                    <div key={key}>
+                      <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+                        {key}
+                      </dt>
+                      <dd>{value}</dd>
+                    </div>
+                  ) : null,
+                )}
+              </dl>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+        {r.riscos && r.riscos.length > 0 && (
+          <AccordionItem value="riscos">
+            <AccordionTrigger className="text-sm">
+              Riscos ({r.riscos.length})
+            </AccordionTrigger>
+            <AccordionContent>
+              <ul className="text-sm list-disc pl-5 space-y-1">
+                {r.riscos.map((item, idx) => (
+                  <li key={idx}>{item}</li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+        {r.premissas && r.premissas.length > 0 && (
+          <AccordionItem value="premissas">
+            <AccordionTrigger className="text-sm">
+              Premissas ({r.premissas.length})
+            </AccordionTrigger>
+            <AccordionContent>
+              <ul className="text-sm list-disc pl-5 space-y-1">
+                {r.premissas.map((item, idx) => (
+                  <li key={idx}>{item}</li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+        {Object.keys(response.state_diff ?? {}).length > 0 && (
+          <AccordionItem value="diff">
+            <AccordionTrigger className="text-sm">
+              Atualização da memória
+            </AccordionTrigger>
+            <AccordionContent>
+              <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
+                {JSON.stringify(response.state_diff, null, 2)}
+              </pre>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+      </Accordion>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}

--- a/src/components/agent/AssessorSheet.tsx
+++ b/src/components/agent/AssessorSheet.tsx
@@ -1,0 +1,269 @@
+/**
+ * AssessorSheet — entrada contextual do BWild Assessor para uso dentro de
+ * páginas de módulo (Cronograma, Orçamento, Compras, Vistorias, NCs).
+ *
+ * Renderiza um botão (ou recebe um trigger via children) que abre um Sheet
+ * lateral com formulário pré-configurado para o módulo (event_type fixo
+ * mas editável, source padrão, placeholder específico) e exibe a resposta
+ * estruturada em sequência. Para o histórico completo, link para a página
+ * `/obra/:projectId/assessor`.
+ *
+ * Permissão `assessor:use` é checada — se o usuário não tem acesso, o
+ * componente não renderiza nada (silencioso, sem placeholder vazio).
+ */
+
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { AlertCircle, Bot, Send, Sparkles, ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+import { useBwildAgentMutation } from "@/hooks/useBwildAgent";
+import { useCanFeature } from "@/hooks/useCan";
+import type {
+  AgentEventSource,
+  AgentEventType,
+} from "@/infra/repositories/agentMemory.repository";
+
+import { AssessorResponse } from "./AssessorResponse";
+import { EVENT_TYPE_LABEL, SOURCE_LABEL } from "./labels";
+
+type ButtonVariant = React.ComponentProps<typeof Button>["variant"];
+type ButtonSize = React.ComponentProps<typeof Button>["size"];
+
+export interface AssessorSheetProps {
+  /**
+   * Override do projectId. Por padrão o componente lê `:projectId` da rota.
+   */
+  projectId?: string;
+  /**
+   * Tipo de evento pré-selecionado quando o sheet abre. O usuário ainda
+   * pode trocar pelo select dentro do sheet.
+   */
+  defaultEventType: AgentEventType;
+  /**
+   * Fonte padrão. Default: "gestor".
+   */
+  defaultSource?: AgentEventSource;
+  /**
+   * Placeholder do textarea — deve ser específico do módulo onde o Sheet
+   * está sendo usado.
+   */
+  placeholder?: string;
+  /**
+   * Texto e visual do botão padrão. Ignorado se `children` for passado.
+   */
+  triggerLabel?: string;
+  triggerVariant?: ButtonVariant;
+  triggerSize?: ButtonSize;
+  /**
+   * Children opcional usado como trigger (recebe `asChild`). Se não
+   * passado, renderiza um Button padrão com ícone Bot.
+   */
+  children?: React.ReactNode;
+}
+
+const DEFAULT_PLACEHOLDER =
+  "Descreva a situação. O assessor usa a memória stateful do projeto para responder com diagnóstico, plano de ação e decisões necessárias.";
+
+export function AssessorSheet({
+  projectId: projectIdProp,
+  defaultEventType,
+  defaultSource = "gestor",
+  placeholder = DEFAULT_PLACEHOLDER,
+  triggerLabel = "Consultar Assessor",
+  triggerVariant = "outline",
+  triggerSize = "sm",
+  children,
+}: AssessorSheetProps) {
+  const params = useParams<{ projectId: string }>();
+  const projectId = projectIdProp ?? params.projectId;
+  const canUse = useCanFeature("assessor:use");
+
+  const [open, setOpen] = useState(false);
+
+  if (!canUse || !projectId) return null;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      {children ? (
+        <SheetTrigger asChild>{children}</SheetTrigger>
+      ) : (
+        <SheetTrigger asChild>
+          <Button variant={triggerVariant} size={triggerSize}>
+            <Bot className="h-4 w-4 mr-2" />
+            {triggerLabel}
+          </Button>
+        </SheetTrigger>
+      )}
+      <SheetContent className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-primary" />
+            Assessor BWild
+          </SheetTitle>
+          <SheetDescription>
+            Pré-classificado como{" "}
+            <strong>{EVENT_TYPE_LABEL[defaultEventType]}</strong>. O assessor
+            usa a memória do projeto e devolve análise técnica.
+          </SheetDescription>
+        </SheetHeader>
+
+        <AssessorSheetBody
+          projectId={projectId}
+          defaultEventType={defaultEventType}
+          defaultSource={defaultSource}
+          placeholder={placeholder}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+interface BodyProps {
+  projectId: string;
+  defaultEventType: AgentEventType;
+  defaultSource: AgentEventSource;
+  placeholder: string;
+}
+
+function AssessorSheetBody({
+  projectId,
+  defaultEventType,
+  defaultSource,
+  placeholder,
+}: BodyProps) {
+  const [eventType, setEventType] = useState<AgentEventType>(defaultEventType);
+  const [source, setSource] = useState<AgentEventSource | "none">(
+    defaultSource,
+  );
+  const [content, setContent] = useState("");
+
+  const mutation = useBwildAgentMutation(projectId);
+  const lastResponse = mutation.data;
+
+  const trimmed = content.trim();
+  const canSubmit = trimmed.length > 0 && !mutation.isPending;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    mutation.mutate({
+      event_type: eventType,
+      content: trimmed,
+      source: source === "none" ? undefined : source,
+    });
+  };
+
+  return (
+    <div className="mt-6 space-y-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="assessor-sheet-event">Tipo de evento</Label>
+          <Select
+            value={eventType}
+            onValueChange={(v) => setEventType(v as AgentEventType)}
+          >
+            <SelectTrigger id="assessor-sheet-event">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(EVENT_TYPE_LABEL).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="assessor-sheet-source">Fonte</Label>
+          <Select
+            value={source}
+            onValueChange={(v) => setSource(v as AgentEventSource | "none")}
+          >
+            <SelectTrigger id="assessor-sheet-source">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">Não informar</SelectItem>
+              {Object.entries(SOURCE_LABEL).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="assessor-sheet-content">Descreva a situação</Label>
+        <Textarea
+          id="assessor-sheet-content"
+          placeholder={placeholder}
+          rows={6}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          disabled={mutation.isPending}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/obra/${projectId}/assessor`}>
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Histórico e memória
+          </Link>
+        </Button>
+        <Button onClick={submit} disabled={!canSubmit}>
+          <Send className="h-4 w-4 mr-2" />
+          {mutation.isPending ? "Consultando…" : "Consultar"}
+        </Button>
+      </div>
+
+      {mutation.isError && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Falha na consulta</AlertTitle>
+          <AlertDescription>
+            {mutation.error?.message ?? "Erro desconhecido."}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {mutation.isPending && (
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      )}
+
+      {!mutation.isPending && lastResponse && (
+        <div className="border-t pt-4">
+          <AssessorResponse response={lastResponse} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/agent/index.ts
+++ b/src/components/agent/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Componentes do BWild Assessor (agente stateful).
+ * Spec: docs/BWILD_AI_AGENTS_SPEC.yaml
+ */
+export { AssessorSheet, type AssessorSheetProps } from "./AssessorSheet";
+export { AssessorResponse } from "./AssessorResponse";
+export { AssessorEventsList } from "./AssessorEventsList";
+export { AssessorMemoryView } from "./AssessorMemoryView";
+export {
+  EVENT_TYPE_LABEL,
+  SOURCE_LABEL,
+  ROUTED_AGENT_LABEL,
+  STATE_SECTION_LABEL,
+} from "./labels";

--- a/src/components/agent/labels.ts
+++ b/src/components/agent/labels.ts
@@ -1,0 +1,67 @@
+/**
+ * Tabelas de rótulos PT-BR para os enums do BWild Assessor.
+ * Compartilhado entre AssessorSheet, AssessorResponse, AssessorEventsList,
+ * AssessorMemoryView e a página dedicada `/obra/:projectId/assessor`.
+ *
+ * Spec autoritativa: docs/BWILD_AI_AGENTS_SPEC.yaml
+ */
+
+import type {
+  AgentEventSource,
+  AgentEventType,
+  ProjectState,
+  RoutedAgent,
+} from "@/infra/repositories/agentMemory.repository";
+
+export const EVENT_TYPE_LABEL: Record<AgentEventType, string> = {
+  new_project: "Novo projeto",
+  project_update: "Atualização do projeto",
+  schedule_request: "Cronograma",
+  budget_request: "Orçamento",
+  field_problem: "Problema em campo",
+  client_message: "Mensagem ao cliente",
+  supplier_quote: "Cotação de fornecedor",
+  purchase_decision: "Decisão de compra",
+  quality_inspection: "Inspeção de qualidade",
+  scope_change: "Mudança de escopo",
+  handover: "Entrega / pós-obra",
+};
+
+export const SOURCE_LABEL: Record<AgentEventSource, string> = {
+  cliente: "Cliente",
+  equipe: "Equipe",
+  fornecedor: "Fornecedor",
+  gestor: "Gestor",
+  vistoria: "Vistoria",
+  documento: "Documento",
+};
+
+export const ROUTED_AGENT_LABEL: Record<RoutedAgent, string> = {
+  master_bwild: "Master BWild",
+  schedule_planner: "Planejador",
+  cost_engineer: "Eng. de Custos",
+  procurement_manager: "Suprimentos",
+  field_engineer: "Eng. de Campo",
+  root_cause_engineer: "Diagnóstico",
+  coordination_engineer: "Compatibilização",
+  risk_manager: "Riscos",
+  quality_controller: "Qualidade",
+  client_communication: "Comunicação",
+  supplier_evaluator: "Aval. Fornecedor",
+  millwork_agent: "Marcenaria",
+  stonework_agent: "Marmoraria",
+  delay_recovery: "Recup. de Atraso",
+  handover_postwork: "Entrega / Pós-obra",
+};
+
+export const STATE_SECTION_LABEL: Record<keyof ProjectState, string> = {
+  project_context: "Contexto do projeto",
+  technical_scope: "Escopo técnico",
+  design_status: "Status do projeto/design",
+  schedule_state: "Cronograma",
+  financial_state: "Financeiro",
+  procurement_state: "Suprimentos",
+  execution_state: "Execução",
+  quality_state: "Qualidade",
+  communication_state: "Comunicação",
+};

--- a/src/pages/Assessor.tsx
+++ b/src/pages/Assessor.tsx
@@ -6,12 +6,8 @@ import {
   Sparkles,
   Brain,
   AlertCircle,
-  Clock,
   History,
-  Info,
 } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
-import { ptBR } from "date-fns/locale";
 
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageContainer } from "@/components/layout/PageContainer";
@@ -40,12 +36,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 
 import {
   useAgentEventsQuery,
@@ -56,63 +46,15 @@ import type {
   AgentEventSource,
   AgentEventType,
   BwildAgentEvent,
-  ProjectState,
-  RoutedAgent,
 } from "@/infra/repositories/agentMemory.repository";
-import type { BwildAgentResponse } from "@/infra/edgeFunctions";
 
-const EVENT_TYPE_LABEL: Record<AgentEventType, string> = {
-  new_project: "Novo projeto",
-  project_update: "Atualização do projeto",
-  schedule_request: "Cronograma",
-  budget_request: "Orçamento",
-  field_problem: "Problema em campo",
-  client_message: "Mensagem ao cliente",
-  supplier_quote: "Cotação de fornecedor",
-  purchase_decision: "Decisão de compra",
-  quality_inspection: "Inspeção de qualidade",
-  scope_change: "Mudança de escopo",
-  handover: "Entrega / pós-obra",
-};
-
-const SOURCE_LABEL: Record<AgentEventSource, string> = {
-  cliente: "Cliente",
-  equipe: "Equipe",
-  fornecedor: "Fornecedor",
-  gestor: "Gestor",
-  vistoria: "Vistoria",
-  documento: "Documento",
-};
-
-const ROUTED_AGENT_LABEL: Record<RoutedAgent, string> = {
-  master_bwild: "Master BWild",
-  schedule_planner: "Planejador",
-  cost_engineer: "Eng. de Custos",
-  procurement_manager: "Suprimentos",
-  field_engineer: "Eng. de Campo",
-  root_cause_engineer: "Diagnóstico",
-  coordination_engineer: "Compatibilização",
-  risk_manager: "Riscos",
-  quality_controller: "Qualidade",
-  client_communication: "Comunicação",
-  supplier_evaluator: "Aval. Fornecedor",
-  millwork_agent: "Marcenaria",
-  stonework_agent: "Marmoraria",
-  delay_recovery: "Recup. de Atraso",
-  handover_postwork: "Entrega / Pós-obra",
-};
-
-const STATE_SECTION_LABEL: Record<keyof ProjectState, string> = {
-  project_context: "Contexto do projeto",
-  technical_scope: "Escopo técnico",
-  design_status: "Status do projeto/design",
-  schedule_state: "Cronograma",
-  financial_state: "Financeiro",
-  procurement_state: "Suprimentos",
-  execution_state: "Execução",
-  quality_state: "Qualidade",
-  communication_state: "Comunicação",
-};
+import {
+  AssessorEventsList,
+  AssessorMemoryView,
+  AssessorResponse,
+  EVENT_TYPE_LABEL,
+  SOURCE_LABEL,
+} from "@/components/agent";
 
 const Assessor = () => {
   const { paths } = useProjectNavigation();
@@ -222,7 +164,7 @@ const AssessorContent = () => {
                   automaticamente quando o agente identifica novas informações.
                 </SheetDescription>
               </SheetHeader>
-              <MemoryDrawerContent
+              <AssessorMemoryView
                 isLoading={memoryQuery.isLoading}
                 state={memoryQuery.data?.state ?? null}
                 version={memoryQuery.data?.version}
@@ -339,7 +281,7 @@ const AssessorContent = () => {
                     <Skeleton className="h-4 w-2/3" />
                   </div>
                 ) : lastResponse ? (
-                  <ResponsePanel response={lastResponse} />
+                  <AssessorResponse response={lastResponse} />
                 ) : (
                   <p className="text-sm text-muted-foreground">
                     Nenhuma consulta ainda. Envie um evento para receber a
@@ -358,7 +300,7 @@ const AssessorContent = () => {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <EventsList
+              <AssessorEventsList
                 isLoading={eventsQuery.isLoading}
                 events={eventsQuery.data ?? []}
                 highlightedEventId={lastEvent?.id ?? null}
@@ -370,296 +312,5 @@ const AssessorContent = () => {
     </div>
   );
 };
-
-interface ResponsePanelProps {
-  response: BwildAgentResponse;
-}
-
-function ResponsePanel({ response }: ResponsePanelProps) {
-  const r = response.response;
-  if (!r) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        O assessor não retornou conteúdo estruturado.
-      </p>
-    );
-  }
-  const impactos = r.impactos ?? {};
-  const hasImpacts = Object.values(impactos).some((v) => !!v);
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Badge variant="outline">
-          {ROUTED_AGENT_LABEL[response.routed_agent]}
-        </Badge>
-        <span>via {response.routing_reason}</span>
-        <span className="ml-auto inline-flex items-center gap-1">
-          <Clock className="h-3 w-3" />
-          {response.latency_ms} ms
-        </span>
-      </div>
-
-      {r.diagnostico && (
-        <Section title="Diagnóstico">
-          <p className="text-sm whitespace-pre-line">{r.diagnostico}</p>
-        </Section>
-      )}
-
-      {r.recomendacao && (
-        <Section title="Recomendação">
-          <p className="text-sm whitespace-pre-line">{r.recomendacao}</p>
-        </Section>
-      )}
-
-      {r.plano_de_acao && r.plano_de_acao.length > 0 && (
-        <Section title="Plano de ação">
-          <ul className="text-sm list-disc pl-5 space-y-1">
-            {r.plano_de_acao.map((item, idx) => (
-              <li key={idx}>{item}</li>
-            ))}
-          </ul>
-        </Section>
-      )}
-
-      {r.decisoes_necessarias && r.decisoes_necessarias.length > 0 && (
-        <Section title="Decisões necessárias">
-          <ul className="text-sm list-disc pl-5 space-y-1">
-            {r.decisoes_necessarias.map((item, idx) => (
-              <li key={idx}>{item}</li>
-            ))}
-          </ul>
-        </Section>
-      )}
-
-      <Accordion type="multiple" className="border-t pt-2">
-        {hasImpacts && (
-          <AccordionItem value="impactos">
-            <AccordionTrigger className="text-sm">Impactos</AccordionTrigger>
-            <AccordionContent>
-              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
-                {Object.entries(impactos).map(([key, value]) =>
-                  value ? (
-                    <div key={key}>
-                      <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                        {key}
-                      </dt>
-                      <dd>{value}</dd>
-                    </div>
-                  ) : null,
-                )}
-              </dl>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-        {r.riscos && r.riscos.length > 0 && (
-          <AccordionItem value="riscos">
-            <AccordionTrigger className="text-sm">
-              Riscos ({r.riscos.length})
-            </AccordionTrigger>
-            <AccordionContent>
-              <ul className="text-sm list-disc pl-5 space-y-1">
-                {r.riscos.map((item, idx) => (
-                  <li key={idx}>{item}</li>
-                ))}
-              </ul>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-        {r.premissas && r.premissas.length > 0 && (
-          <AccordionItem value="premissas">
-            <AccordionTrigger className="text-sm">
-              Premissas ({r.premissas.length})
-            </AccordionTrigger>
-            <AccordionContent>
-              <ul className="text-sm list-disc pl-5 space-y-1">
-                {r.premissas.map((item, idx) => (
-                  <li key={idx}>{item}</li>
-                ))}
-              </ul>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-        {Object.keys(response.state_diff ?? {}).length > 0 && (
-          <AccordionItem value="diff">
-            <AccordionTrigger className="text-sm">
-              Atualização da memória
-            </AccordionTrigger>
-            <AccordionContent>
-              <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
-                {JSON.stringify(response.state_diff, null, 2)}
-              </pre>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-      </Accordion>
-    </div>
-  );
-}
-
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
-        {title}
-      </h3>
-      {children}
-    </div>
-  );
-}
-
-interface EventsListProps {
-  isLoading: boolean;
-  events: BwildAgentEvent[];
-  highlightedEventId: string | null;
-}
-
-function EventsList({
-  isLoading,
-  events,
-  highlightedEventId,
-}: EventsListProps) {
-  if (isLoading) {
-    return (
-      <div className="space-y-3">
-        {[0, 1, 2].map((i) => (
-          <Skeleton key={i} className="h-16 w-full" />
-        ))}
-      </div>
-    );
-  }
-  if (events.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Nenhuma consulta registrada para esta obra ainda.
-      </p>
-    );
-  }
-  return (
-    <ul className="divide-y divide-border">
-      {events.map((event) => (
-        <li
-          key={event.id}
-          className={
-            "py-3 " +
-            (event.id === highlightedEventId
-              ? "bg-primary/5 -mx-2 px-2 rounded"
-              : "")
-          }
-        >
-          <div className="flex flex-wrap items-center gap-2 mb-1">
-            <Badge variant="outline">
-              {EVENT_TYPE_LABEL[event.event_type]}
-            </Badge>
-            {event.routed_agent && (
-              <Badge variant="secondary">
-                {ROUTED_AGENT_LABEL[event.routed_agent]}
-              </Badge>
-            )}
-            {event.source && (
-              <span className="text-xs text-muted-foreground">
-                {SOURCE_LABEL[event.source]}
-              </span>
-            )}
-            <span className="ml-auto text-xs text-muted-foreground">
-              {formatDistanceToNow(new Date(event.created_at), {
-                addSuffix: true,
-                locale: ptBR,
-              })}
-            </span>
-          </div>
-          <p className="text-sm text-foreground/90 line-clamp-2">
-            {event.content}
-          </p>
-          {event.status !== "success" && (
-            <p className="text-xs text-destructive mt-1">
-              {event.status}: {event.error_message ?? "Erro desconhecido"}
-            </p>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-interface MemoryDrawerProps {
-  isLoading: boolean;
-  state: ProjectState | null;
-  version?: number;
-  updatedAt?: string;
-}
-
-function MemoryDrawerContent({
-  isLoading,
-  state,
-  version,
-  updatedAt,
-}: MemoryDrawerProps) {
-  if (isLoading) {
-    return (
-      <div className="mt-6 space-y-3">
-        <Skeleton className="h-6 w-1/2" />
-        <Skeleton className="h-32 w-full" />
-        <Skeleton className="h-24 w-full" />
-      </div>
-    );
-  }
-  if (!state || Object.keys(state).length === 0) {
-    return (
-      <Alert className="mt-6">
-        <Info className="h-4 w-4" />
-        <AlertDescription>
-          Memória vazia — nenhuma consulta ainda preencheu o estado deste
-          projeto.
-        </AlertDescription>
-      </Alert>
-    );
-  }
-
-  const sections = (
-    Object.keys(STATE_SECTION_LABEL) as Array<keyof ProjectState>
-  )
-    .map((key) => [key, state[key]] as const)
-    .filter(([, value]) => value && Object.keys(value).length > 0);
-
-  return (
-    <div className="mt-6 space-y-4">
-      <div className="text-xs text-muted-foreground flex items-center gap-3">
-        {typeof version === "number" && <span>versão {version}</span>}
-        {updatedAt && (
-          <span>
-            atualizado{" "}
-            {formatDistanceToNow(new Date(updatedAt), {
-              addSuffix: true,
-              locale: ptBR,
-            })}
-          </span>
-        )}
-      </div>
-      <Accordion
-        type="multiple"
-        defaultValue={sections.map(([k]) => String(k))}
-      >
-        {sections.map(([key, value]) => (
-          <AccordionItem key={String(key)} value={String(key)}>
-            <AccordionTrigger className="text-sm">
-              {STATE_SECTION_LABEL[key]}
-            </AccordionTrigger>
-            <AccordionContent>
-              <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
-                {JSON.stringify(value, null, 2)}
-              </pre>
-            </AccordionContent>
-          </AccordionItem>
-        ))}
-      </Accordion>
-    </div>
-  );
-}
 
 export default Assessor;

--- a/src/pages/Compras.tsx
+++ b/src/pages/Compras.tsx
@@ -21,6 +21,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { PurchaseAlertsPanel } from "@/components/PurchaseAlertsPanel";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { AssessorSheet } from "@/components/agent";
 import { useComprasState } from "./compras/useComprasState";
 import { ComprasKPICards } from "./compras/ComprasKPICards";
 import { PurchasesTable } from "./compras/PurchasesTable";
@@ -332,7 +333,14 @@ export default function Compras() {
           { label: "Gestão", href: "/gestao" },
           { label: "Compras" },
         ]}
-      />
+      >
+        <div className="flex items-center gap-2">
+          <AssessorSheet
+            defaultEventType="purchase_decision"
+            placeholder="Ex: A marmoraria deu prazo de 30 dias para a bancada — vou conseguir instalar antes da marcenaria?"
+          />
+        </div>
+      </PageHeader>
       <div className="py-6">
         <PageContainer maxWidth="full">
           <Tabs value={activeTab} onValueChange={setActiveTab}>

--- a/src/pages/Cronograma.tsx
+++ b/src/pages/Cronograma.tsx
@@ -23,6 +23,7 @@ import { Progress } from "@/components/ui/progress";
 import { ImportScheduleModal } from "@/components/ImportScheduleModal";
 import { CronogramaMobileView } from "@/components/cronograma/CronogramaMobileView";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { AssessorSheet } from "@/components/agent";
 import { cn } from "@/lib/utils";
 
 interface ActivityFormData {
@@ -741,6 +742,10 @@ const Cronograma = () => {
             <Upload className="w-4 h-4 mr-1.5" />
             <span className="hidden sm:inline">Importar</span>
           </Button>
+          <AssessorSheet
+            defaultEventType="schedule_request"
+            placeholder="Ex: A demolição encontrou parede de tijolo maciço — qual o impacto no caminho crítico?"
+          />
           <Button size="sm" onClick={handleSave} disabled={saving}>
             {saving ? (
               <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />

--- a/src/pages/NaoConformidades.tsx
+++ b/src/pages/NaoConformidades.tsx
@@ -15,6 +15,7 @@ import { NcDetailDialog } from "@/components/vistorias/NcDetailDialog";
 import { CreateNcDialog } from "@/components/vistorias/CreateNcDialog";
 import { PageSkeleton } from "@/components/ui-premium";
 import { useCan } from "@/hooks/useCan";
+import { AssessorSheet } from "@/components/agent";
 import { cn } from "@/lib/utils";
 
 export default function NaoConformidades() {
@@ -82,6 +83,10 @@ export default function NaoConformidades() {
           >
             <Search className="h-4 w-4" />
           </Button>
+          <AssessorSheet
+            defaultEventType="field_problem"
+            placeholder="Ex: Surgiu uma fissura na alvenaria nova após a primeira chuva — como diagnostico a causa-raiz antes de pintar?"
+          />
           {can("ncs:create") && (
             <Button
               onClick={() => setShowCreateDialog(true)}

--- a/src/pages/Vistorias.tsx
+++ b/src/pages/Vistorias.tsx
@@ -18,6 +18,7 @@ import { CreateNcDialog } from "@/components/vistorias/CreateNcDialog";
 import { CorrectiveActionTemplatesAdmin } from "@/components/vistorias/CorrectiveActionTemplatesAdmin";
 import { useNonConformities } from "@/hooks/useNonConformities";
 import { useCan } from "@/hooks/useCan";
+import { AssessorSheet } from "@/components/agent";
 
 export default function Vistorias() {
   const { projectId } = useProjectNavigation();
@@ -63,6 +64,10 @@ export default function Vistorias() {
           >
             <Search className="h-4 w-4" />
           </Button>
+          <AssessorSheet
+            defaultEventType="quality_inspection"
+            placeholder="Ex: Encontrei 3 NCs críticas no banheiro do casal — revestimento, ralo e elétrica. O que preciso travar antes de avançar?"
+          />
           {can("inspections:create") && (
             <Button
               onClick={() => setShowCreateDialog(true)}

--- a/src/pages/gestao/OrcamentoDetalhe.tsx
+++ b/src/pages/gestao/OrcamentoDetalhe.tsx
@@ -44,6 +44,7 @@ import { format } from "date-fns";
 import { toast } from "sonner";
 import { formatBRL } from "@/lib/formatBRL";
 import { PageSkeleton, EmptyState, StatusBadge } from "@/components/ui-premium";
+import { AssessorSheet } from "@/components/agent";
 import {
   BUDGET_STATUS_TONE,
   BUDGET_STATUS_LABEL,
@@ -481,6 +482,13 @@ export default function OrcamentoDetalhe({
               ))}
             </SelectContent>
           </Select>
+
+          <div className="ml-auto">
+            <AssessorSheet
+              defaultEventType="budget_request"
+              placeholder="Ex: A margem está em 8% — onde posso reduzir custo sem comprometer a qualidade percebida?"
+            />
+          </div>
         </div>
       </div>
 

--- a/supabase/functions/bwild-agent/index.ts
+++ b/supabase/functions/bwild-agent/index.ts
@@ -27,7 +27,7 @@ const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
-const MODEL = Deno.env.get('BWILD_AGENT_MODEL') ?? 'claude-sonnet-4-5';
+const MODEL = Deno.env.get('BWILD_AGENT_MODEL') ?? 'claude-sonnet-4-6';
 const MAX_TOKENS = 4096;
 const TOOL_NAME = 'bwild_agent_response';
 

--- a/supabase/functions/bwild-agent/index.ts
+++ b/supabase/functions/bwild-agent/index.ts
@@ -23,11 +23,13 @@ import {
   type ProjectState,
 } from './_lib/state.ts';
 
-const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
+const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
-const MODEL = Deno.env.get('BWILD_AGENT_MODEL') ?? 'google/gemini-3-flash-preview';
+const MODEL = Deno.env.get('BWILD_AGENT_MODEL') ?? 'claude-sonnet-4-5';
+const MAX_TOKENS = 4096;
+const TOOL_NAME = 'bwild_agent_response';
 
 const VALID_EVENT_TYPES: AgentEventType[] = [
   'new_project',
@@ -60,8 +62,8 @@ Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return corsResponse();
   if (req.method !== 'POST') return jsonResponse({ error: 'Method not allowed' }, 405);
 
-  if (!LOVABLE_API_KEY) {
-    return jsonResponse({ error: 'LOVABLE_API_KEY não configurada' }, 500);
+  if (!ANTHROPIC_API_KEY) {
+    return jsonResponse({ error: 'ANTHROPIC_API_KEY não configurada' }, 500);
   }
 
   // ---- Parse body --------------------------------------------------------
@@ -149,8 +151,6 @@ Deno.serve(async (req) => {
     '',
     'Input do usuário:',
     content,
-    '',
-    'Responda em JSON puro, sem markdown ou cercas de código, seguindo o schema do system prompt.',
   ].join('\n');
 
   let llmRespJson: unknown = null;
@@ -159,19 +159,66 @@ Deno.serve(async (req) => {
   let llmErrorMessage: string | null = null;
 
   try {
-    const llmResp = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
+    const llmResp = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
       },
       body: JSON.stringify({
         model: MODEL,
-        response_format: { type: 'json_object' },
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userMessage },
+        max_tokens: MAX_TOKENS,
+        // System prompt is large (~2-4 KB) and stable per agent — cache it
+        // so subsequent calls within the 5-minute TTL only pay for the user
+        // message tokens.
+        system: [
+          {
+            type: 'text',
+            text: systemPrompt,
+            cache_control: { type: 'ephemeral' },
+          },
         ],
+        messages: [{ role: 'user', content: userMessage }],
+        tools: [
+          {
+            name: TOOL_NAME,
+            description:
+              'Resposta estruturada do agente BWild. memoria_atualizada deve conter APENAS as seções de estado que mudaram.',
+            input_schema: {
+              type: 'object',
+              properties: {
+                diagnostico: { type: 'string' },
+                premissas: { type: 'array', items: { type: 'string' } },
+                impactos: {
+                  type: 'object',
+                  properties: {
+                    prazo: { type: 'string' },
+                    custo: { type: 'string' },
+                    qualidade: { type: 'string' },
+                    retrabalho: { type: 'string' },
+                    cliente: { type: 'string' },
+                  },
+                },
+                recomendacao: { type: 'string' },
+                plano_de_acao: { type: 'array', items: { type: 'string' } },
+                riscos: { type: 'array', items: { type: 'string' } },
+                decisoes_necessarias: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                memoria_atualizada: {
+                  type: 'object',
+                  description:
+                    'Patch parcial do estado. Chaves válidas: project_context, technical_scope, design_status, schedule_state, financial_state, procurement_state, execution_state, quality_state, communication_state.',
+                  additionalProperties: true,
+                },
+              },
+              required: ['diagnostico', 'recomendacao'],
+            },
+          },
+        ],
+        tool_choice: { type: 'tool', name: TOOL_NAME },
       }),
     });
 
@@ -180,13 +227,22 @@ Deno.serve(async (req) => {
       llmErrorMessage = `LLM ${llmResp.status}: ${t.slice(0, 200)}`;
     } else {
       const llmData = await llmResp.json();
-      tokensIn = llmData?.usage?.prompt_tokens ?? 0;
-      tokensOut = llmData?.usage?.completion_tokens ?? 0;
-      const raw = llmData?.choices?.[0]?.message?.content ?? '';
-      try {
-        llmRespJson = JSON.parse(raw);
-      } catch {
-        llmErrorMessage = 'Resposta do modelo não é JSON válido';
+      const usage = llmData?.usage ?? {};
+      // Cached tokens count as input but at a discount; surface the total.
+      tokensIn =
+        (usage.input_tokens ?? 0) +
+        (usage.cache_creation_input_tokens ?? 0) +
+        (usage.cache_read_input_tokens ?? 0);
+      tokensOut = usage.output_tokens ?? 0;
+      const blocks: Array<{ type: string; name?: string; input?: unknown }> =
+        Array.isArray(llmData?.content) ? llmData.content : [];
+      const toolUse = blocks.find(
+        (b) => b.type === 'tool_use' && b.name === TOOL_NAME,
+      );
+      if (toolUse?.input && isPlainObject(toolUse.input)) {
+        llmRespJson = toolUse.input;
+      } else {
+        llmErrorMessage = 'Modelo não retornou tool_use estruturado';
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
This PR refactors the BWild Assessor functionality by extracting reusable components from the dedicated Assessor page and creating a new `AssessorSheet` component for contextual access within module pages (Cronograma, Orçamento, Compras, Vistorias, NCs). It also updates the backend edge function to use Anthropic's Claude API with tool-based structured output instead of the previous Lovable gateway.

## Key Changes

### Frontend Refactoring
- **New component library** (`src/components/agent/`):
  - `AssessorSheet.tsx` — Contextual sheet component for module pages with pre-configured event types, source selection, and inline response display
  - `AssessorResponse.tsx` — Extracted response rendering logic (diagnostics, recommendations, impacts, risks, etc.)
  - `AssessorEventsList.tsx` — Extracted event history list component
  - `AssessorMemoryView.tsx` — Extracted project memory state visualization
  - `labels.ts` — Centralized PT-BR label mappings for event types, sources, routed agents, and state sections
  - `index.ts` — Public barrel export for the agent component library

- **Assessor page refactoring** (`src/pages/Assessor.tsx`):
  - Removed inline component definitions (ResponsePanel, EventsList, MemoryDrawerContent)
  - Removed duplicate label definitions and date-fns imports
  - Updated to import and use new extracted components
  - Simplified page logic by delegating to reusable components

- **Module page integration**:
  - Added `AssessorSheet` to Cronograma, Orçamento (OrcamentoDetalhe), Compras, Vistorias, and NaoConformidades pages
  - Each sheet is pre-configured with the appropriate `defaultEventType` for its module context
  - Permission check (`assessor:use`) is handled silently within the sheet component

### Backend Updates
- **Edge function migration** (`supabase/functions/bwild-agent/index.ts`):
  - Replaced Lovable API gateway with direct Anthropic Claude API integration
  - Updated authentication from `LOVABLE_API_KEY` to `ANTHROPIC_API_KEY`
  - Changed default model from `google/gemini-3-flash-preview` to `claude-sonnet-4-6`
  - Implemented Anthropic's tool-based structured output using `tools` parameter instead of `response_format`
  - Added prompt caching for system prompt (ephemeral cache control) to reduce token costs
  - Increased max tokens to 4096 for more comprehensive responses
  - Removed markdown formatting instruction from user message (handled by tool schema)

## Notable Implementation Details
- **Shared labels**: All PT-BR translations for event types, sources, agents, and state sections are now centralized in `labels.ts` to ensure consistency across the application
- **Permission handling**: `AssessorSheet` silently returns `null` if the user lacks `assessor:use` permission, preventing empty UI elements
- **Prompt caching**: System prompt is cached at the Anthropic API level to optimize costs for repeated queries within the 5-minute TTL
- **Tool-based output**: Structured responses are now enforced via Anthropic's tool schema rather than JSON mode, providing better type safety and validation

https://claude.ai/code/session_01494HBZKrp2NaKUnEe7S3cW