### PR TITLE
Fix gallery photo expiration & media load errors

### DIFF
--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -6,8 +6,10 @@ import {
   Minimize,
   Volume2,
   VolumeX,
+  AlertTriangle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { logWarn } from "@/lib/errorLogger";
 
 // Vendor-prefixed fullscreen APIs (Safari, older IE/Edge)
 interface VendorDocument {
@@ -45,6 +47,7 @@ const VideoPlayer = ({ src, title, poster }: VideoPlayerProps) => {
   const [currentTime, setCurrentTime] = useState("0:00");
   const [duration, setDuration] = useState("0:00");
   const [showControls, setShowControls] = useState(true);
+  const [hasError, setHasError] = useState(false);
   const hideControlsTimeout = useRef<NodeJS.Timeout>();
 
   const formatTime = (seconds: number) => {
@@ -241,10 +244,29 @@ const VideoPlayer = ({ src, title, poster }: VideoPlayerProps) => {
         poster={poster}
         playsInline
         onClick={togglePlay}
+        onError={() => {
+          logWarn("VideoPlayer failed to load source", {
+            component: "VideoPlayer",
+            src,
+            title,
+          });
+          setHasError(true);
+        }}
       />
 
+      {/* Error overlay */}
+      {hasError && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/80 text-white/80 p-4 text-center">
+          <AlertTriangle className="w-8 h-8" />
+          <p className="text-sm">
+            Não foi possível carregar o vídeo. Recarregue a página e tente
+            novamente.
+          </p>
+        </div>
+      )}
+
       {/* Play button overlay when paused */}
-      {!isPlaying && (
+      {!hasError && !isPlaying && (
         <button
           onClick={togglePlay}
           aria-label="Reproduzir vídeo"

--- a/src/components/WeeklyReportsHistory.tsx
+++ b/src/components/WeeklyReportsHistory.tsx
@@ -23,6 +23,7 @@ interface WeeklyReportsHistoryProps {
   onReportClick?: (report: WeeklyReport, index: number) => void;
   isStaff?: boolean; // Staff can see all reports immediately
   projectEndDate?: string; // Caps weekly report generation at the project end
+  availableAtByWeek?: Map<number, string | null>; // Server-controlled release
 }
 
 const BRASILIA_TZ = "America/Sao_Paulo";
@@ -129,6 +130,10 @@ export const generateWeeklyReports = (
   reportDate: string,
   activities: Activity[],
   projectEndDate?: string,
+  // week_number -> server `available_at` (ISO) or null. When a row has a
+  // non-null value it is authoritative: the report is visible to customers
+  // once that instant has passed, regardless of the date heuristic.
+  availableAtByWeek?: Map<number, string | null>,
 ): ExtendedWeeklyReport[] => {
   const startDate = parseLocalDate(projectStartDate);
   // Cap report generation at the project end date so the timeline does not
@@ -213,6 +218,20 @@ export const generateWeeklyReports = (
     // Check availability for customers
     const { isAvailable, availableAt } = isReportAvailableForCustomer(weekEnd);
 
+    // Server-controlled availability wins when present. A non-null
+    // `available_at` means staff/the backend explicitly scheduled (or already
+    // released) this report; respect it instead of recomputing from dates.
+    const serverAvailableAtRaw = availableAtByWeek?.get(weekNumber);
+    let serverAvailable: boolean | null = null;
+    let effectiveAvailableAt = availableAt;
+    if (serverAvailableAtRaw != null) {
+      const parsed = new Date(serverAvailableAtRaw);
+      if (!isNaN(parsed.getTime())) {
+        effectiveAvailableAt = parsed;
+        serverAvailable = new Date() >= parsed;
+      }
+    }
+
     // Also unlock if all overlapping activities for this week are completed
     // (actualEnd filled with a date <= weekEndDate means the stage finished early)
     const allOverlappingCompleted =
@@ -235,8 +254,11 @@ export const generateWeeklyReports = (
       status,
       variance,
       currentActivityName: currentActivity?.description || null,
-      isAvailableForCustomer: isAvailable || allOverlappingCompleted,
-      availableAt,
+      isAvailableForCustomer:
+        serverAvailable !== null
+          ? serverAvailable
+          : isAvailable || allOverlappingCompleted,
+      availableAt: effectiveAvailableAt,
     });
 
     // Move to next week (next Monday after the current Friday)
@@ -289,12 +311,14 @@ const WeeklyReportsHistory = ({
   onReportClick,
   isStaff = false,
   projectEndDate,
+  availableAtByWeek,
 }: WeeklyReportsHistoryProps) => {
   const weeklyReportsAsc = generateWeeklyReports(
     projectStartDate,
     reportDate,
     activities,
     projectEndDate,
+    availableAtByWeek,
   );
   // Display in descending order (most recent first)
   const weeklyReports = [...weeklyReportsAsc].reverse();

--- a/src/components/report/PhotoGallery.tsx
+++ b/src/components/report/PhotoGallery.tsx
@@ -20,6 +20,16 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
   const touchStartX = useRef<number | null>(null);
   const touchEndX = useRef<number | null>(null);
 
+  // photo.id is only unique within a single report (ids like "g1"/"photo-…"
+  // are reused across weeks). The component instance is reused when
+  // navigating between reports, so reset broken state whenever the gallery
+  // identity changes — and when URLs are re-signed, so refreshed media gets
+  // a fresh attempt instead of staying marked broken.
+  const photosKey = photos.map((p) => `${p.id}::${p.url}`).join("|");
+  useEffect(() => {
+    setBrokenIds(new Set());
+  }, [photosKey]);
+
   const markBroken = useCallback((photo: GalleryPhoto, kind: string) => {
     logWarn("Gallery media failed to load", {
       component: "PhotoGallery",

--- a/src/components/report/PhotoGallery.tsx
+++ b/src/components/report/PhotoGallery.tsx
@@ -2,19 +2,9 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { GalleryPhoto } from "@/types/weeklyReport";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
-import { X, ChevronLeft, ChevronRight, Play } from "lucide-react";
-
-const isVideoUrl = (url: string) => {
-  if (!url) return false;
-  const lower = url.toLowerCase().split("?")[0];
-  return (
-    lower.endsWith(".mp4") ||
-    lower.endsWith(".mov") ||
-    lower.endsWith(".webm") ||
-    lower.endsWith(".quicktime") ||
-    lower.includes("video/")
-  );
-};
+import { X, ChevronLeft, ChevronRight, Play, ImageOff } from "lucide-react";
+import { isVideoUrl } from "@/lib/mediaTypes";
+import { logWarn } from "@/lib/errorLogger";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
@@ -26,8 +16,33 @@ interface PhotoGalleryProps {
 
 const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
   const touchStartX = useRef<number | null>(null);
   const touchEndX = useRef<number | null>(null);
+
+  const markBroken = useCallback((photo: GalleryPhoto, kind: string) => {
+    logWarn("Gallery media failed to load", {
+      component: "PhotoGallery",
+      photoId: photo.id,
+      kind,
+      url: photo.url,
+    });
+    setBrokenIds((prev) => {
+      if (prev.has(photo.id)) return prev;
+      const next = new Set(prev);
+      next.add(photo.id);
+      return next;
+    });
+  }, []);
+
+  const MediaUnavailable = ({ compact = false }: { compact?: boolean }) => (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-muted text-muted-foreground p-2 text-center">
+      <ImageOff className={compact ? "w-4 h-4" : "w-6 h-6"} />
+      {!compact && (
+        <span className="text-tiny">Mídia indisponível — recarregue</span>
+      )}
+    </div>
+  );
 
   const handlePrevious = useCallback(() => {
     if (selectedIndex !== null && selectedIndex > 0) {
@@ -95,7 +110,9 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
         opacity: animationDelay > 0 ? 0 : 1,
       }}
     >
-      {isVideoUrl(photo.url) ? (
+      {brokenIds.has(photo.id) ? (
+        <MediaUnavailable />
+      ) : isVideoUrl(photo.url) ? (
         <>
           <video
             src={`${photo.url}#t=0.5`}
@@ -103,6 +120,7 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
             muted
             playsInline
             disablePictureInPicture
+            onError={() => markBroken(photo, "video-thumb")}
             className="w-full h-full object-cover transition-transform group-hover:scale-105"
           />
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
@@ -116,6 +134,7 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
           src={photo.url}
           alt={photo.caption}
           loading="lazy"
+          onError={() => markBroken(photo, "image-thumb")}
           className="w-full h-full object-cover transition-transform group-hover:scale-105"
         />
       )}
@@ -138,13 +157,16 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
             onClick={() => setSelectedIndex(index)}
             className="relative w-28 h-20 rounded-lg overflow-hidden bg-muted shrink-0"
           >
-            {isVideoUrl(photo.url) ? (
+            {brokenIds.has(photo.id) ? (
+              <MediaUnavailable compact />
+            ) : isVideoUrl(photo.url) ? (
               <>
                 <video
                   src={`${photo.url}#t=0.5`}
                   preload="metadata"
                   muted
                   playsInline
+                  onError={() => markBroken(photo, "video-thumb")}
                   className="w-full h-full object-cover"
                 />
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
@@ -158,6 +180,7 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
                 src={photo.url}
                 alt={photo.caption}
                 loading="lazy"
+                onError={() => markBroken(photo, "image-thumb")}
                 className="w-full h-full object-cover"
               />
             )}
@@ -255,18 +278,38 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
 
               {/* Image / Video */}
               <div className="flex-1 flex items-center justify-center p-4 sm:p-8">
-                {isVideoUrl(photos[selectedIndex].url) ? (
+                {brokenIds.has(photos[selectedIndex].id) ? (
+                  <div className="flex flex-col items-center gap-3 text-white/80 text-center">
+                    <ImageOff className="w-10 h-10" />
+                    <p className="text-caption">
+                      Não foi possível carregar esta mídia.
+                    </p>
+                    <Button
+                      variant="outline"
+                      onClick={() => window.location.reload()}
+                      className="bg-white/10 text-white border-white/30 hover:bg-white/20"
+                    >
+                      Recarregar página
+                    </Button>
+                  </div>
+                ) : isVideoUrl(photos[selectedIndex].url) ? (
                   <video
                     src={photos[selectedIndex].url}
                     controls
                     autoPlay
                     playsInline
+                    onError={() =>
+                      markBroken(photos[selectedIndex], "video-full")
+                    }
                     className="max-w-full max-h-[70dvh] sm:max-h-[70vh] rounded"
                   />
                 ) : (
                   <img
                     src={photos[selectedIndex].url}
                     alt={photos[selectedIndex].caption}
+                    onError={() =>
+                      markBroken(photos[selectedIndex], "image-full")
+                    }
                     className="max-w-full max-h-[70dvh] sm:max-h-[70vh] object-contain rounded"
                   />
                 )}
@@ -311,18 +354,22 @@ const PhotoGallery = ({ photos }: PhotoGalleryProps) => {
                           : "border-transparent opacity-50",
                       )}
                     >
-                      {isVideoUrl(photo.url) ? (
+                      {brokenIds.has(photo.id) ? (
+                        <MediaUnavailable compact />
+                      ) : isVideoUrl(photo.url) ? (
                         <video
                           src={`${photo.url}#t=0.5`}
                           preload="metadata"
                           muted
                           playsInline
+                          onError={() => markBroken(photo, "video-strip")}
                           className="w-full h-full object-cover"
                         />
                       ) : (
                         <img
                           src={photo.url}
                           alt=""
+                          onError={() => markBroken(photo, "image-strip")}
                           className="w-full h-full object-cover"
                         />
                       )}

--- a/src/hooks/useLinkCustomerOnLogin.ts
+++ b/src/hooks/useLinkCustomerOnLogin.ts
@@ -139,9 +139,20 @@ export function useLinkCustomerOnLogin(user: User | null) {
     // A link operation for this user is already in flight in another component.
     if (inFlight.has(user.id)) return;
 
-    const promise = linkCustomerToProjects(user).finally(() => {
-      inFlight.delete(user.id);
-    });
+    // Register the in-flight entry SYNCHRONOUSLY, before invoking the async
+    // function. linkCustomerToProjects starts running the moment it's called,
+    // so if we set the map only after the call, two effects mounting in the
+    // same tick (StrictMode / Concurrent) would both pass the inFlight.has
+    // check above and fire duplicate requests. The lazy promise wrapper keeps
+    // the set + assignment a single synchronous step.
+    const promise: Promise<void> = Promise.resolve().then(() =>
+      linkCustomerToProjects(user).finally(() => {
+        // Only clear if it's still our promise (guards against a newer run).
+        if (inFlight.get(user.id) === promise) {
+          inFlight.delete(user.id);
+        }
+      }),
+    );
     inFlight.set(user.id, promise);
   }, [user?.id, user?.email]);
 }

--- a/src/hooks/useProjectPortal.ts
+++ b/src/hooks/useProjectPortal.ts
@@ -161,6 +161,7 @@ export function useProjectPortal() {
   } = useProjectActivities(projectId);
   const {
     reportDataByWeek,
+    availableAtByWeek,
     saveReport: saveWeeklyReport,
     isSaving: isSavingReport,
     savingWeek,
@@ -344,8 +345,9 @@ export function useProjectPortal() {
       reportData.reportDate,
       reportData.activities,
       reportData.endDate ?? undefined,
+      availableAtByWeek,
     );
-  }, [reportData]);
+  }, [reportData, availableAtByWeek]);
 
   const reportsChronological = useMemo(
     () => [...allWeeklyReports].reverse(),
@@ -547,6 +549,7 @@ export function useProjectPortal() {
     setSelectedActivityId,
     reportsChronological,
     reportDataByWeek,
+    availableAtByWeek,
     isSavingReport,
     savingWeek,
     updateActivity,

--- a/src/hooks/useReportImageUpload.ts
+++ b/src/hooks/useReportImageUpload.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { GalleryPhoto } from "@/types/weeklyReport";
+import { isHeic } from "@/lib/mediaTypes";
 import { toast } from "sonner";
 
 interface UploadResult {
@@ -72,7 +73,8 @@ export function useReportImageUpload() {
           // Validate file size against bucket limit
           if (blob.size > MAX_FILE_SIZE) {
             toast.error(
-              `Arquivo muito grande: ${(blob.size / 1024 / 1024).toFixed(1)}MB. Máximo: 200MB.`,
+              `"${photo.caption || "Arquivo"}" tem ${(blob.size / 1024 / 1024).toFixed(0)}MB (máx. 200MB) e não foi enviado. Envie um vídeo mais curto ou de menor resolução. O relatório não será salvo até resolver.`,
+              { duration: 8000 },
             );
             failedCount++;
             continue;
@@ -80,6 +82,18 @@ export function useReportImageUpload() {
 
           // Determine file extension from MIME type
           const mimeType = blob.type || "application/octet-stream";
+
+          // Reject HEIC/HEIF: iPhones capture in this format but it does not
+          // render on Android/Windows/Chrome, so the customer would see a
+          // broken image. Fail loudly here instead of silently later.
+          if (isHeic(mimeType, photo.caption)) {
+            toast.error(
+              "Formato HEIC não é suportado. Converta a foto para JPG ou PNG antes de enviar (no iPhone: Ajustes → Câmera → Formatos → Mais Compatível).",
+            );
+            failedCount++;
+            continue;
+          }
+
           const extension = getExtensionFromMimeType(mimeType);
 
           // Create unique filename with projectId as first segment (required by RLS)
@@ -118,7 +132,7 @@ export function useReportImageUpload() {
               msg.includes("invalid_mime_type")
             ) {
               toast.error(
-                `Formato não suportado: ${mimeType || "desconhecido"}. Use JPG, PNG, HEIC ou MP4.`,
+                `Formato não suportado: ${mimeType || "desconhecido"}. Use JPG, PNG ou MP4.`,
               );
             } else {
               toast.error(`Falha ao enviar foto: ${msg}`);
@@ -139,9 +153,12 @@ export function useReportImageUpload() {
             continue;
           }
 
-          // Update the gallery entry with the permanent URL
+          // Persist the storage path (source of truth) alongside a fresh
+          // signed URL for immediate display. The saved signed URL will
+          // expire — refreshGalleryUrls re-signs from `path` on every load.
           updatedGallery[index] = {
             ...updatedGallery[index],
+            path: data.path,
             url: urlData.signedUrl,
           };
 
@@ -199,8 +216,6 @@ function getExtensionFromMimeType(mimeType: string): string {
     "image/jpg": ".jpg",
     "image/png": ".png",
     "image/webp": ".webp",
-    "image/heic": ".heic",
-    "image/heif": ".heif",
     "image/gif": ".gif",
     "video/mp4": ".mp4",
     "video/quicktime": ".mov",

--- a/src/hooks/useReportImageUpload.ts
+++ b/src/hooks/useReportImageUpload.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { GalleryPhoto } from "@/types/weeklyReport";
-import { isHeic } from "@/lib/mediaTypes";
+import { isHeicMimeOrName, isHeicBlob } from "@/lib/mediaTypes";
 import { toast } from "sonner";
 
 interface UploadResult {
@@ -85,8 +85,12 @@ export function useReportImageUpload() {
 
           // Reject HEIC/HEIF: iPhones capture in this format but it does not
           // render on Android/Windows/Chrome, so the customer would see a
-          // broken image. Fail loudly here instead of silently later.
-          if (isHeic(mimeType, photo.caption)) {
+          // broken image. Fail loudly here instead of silently later. Blob
+          // uploads often lose the MIME type/filename, so also sniff the
+          // file header (ISO-BMFF brand) as a fallback.
+          if (
+            isHeicMimeOrName(mimeType) || (await isHeicBlob(blob))
+          ) {
             toast.error(
               "Formato HEIC não é suportado. Converta a foto para JPG ou PNG antes de enviar (no iPhone: Ajustes → Câmera → Formatos → Mais Compatível).",
             );

--- a/src/hooks/useWeeklyReports.ts
+++ b/src/hooks/useWeeklyReports.ts
@@ -37,6 +37,26 @@ function extractWeeklyReportPath(url: string | undefined): string | null {
 }
 
 /**
+ * Resolves the storage path for a gallery photo. Prefers the explicit `path`
+ * field (written on upload since the Bug #1 fix); falls back to parsing it out
+ * of a saved URL for legacy rows that predate the `path` field. When neither
+ * works the photo is unrecoverable — log it (with id) so we can spot legacy
+ * data that needs a backfill instead of failing silently.
+ */
+function resolveWeeklyReportPath(photo: GalleryPhoto): string | null {
+  if (photo.path) return photo.path;
+  const fromUrl = extractWeeklyReportPath(photo.url);
+  if (fromUrl) return fromUrl;
+  if (photo.url && !photo.url.startsWith("blob:")) {
+    reportLogger.warn("weekly-report photo has no resolvable storage path", {
+      photoId: photo.id,
+      url: photo.url,
+    });
+  }
+  return null;
+}
+
+/**
  * Regenerates signed URLs for every gallery photo across all reports in a
  * single batched request. Saved URLs go stale (7-day signed-URL TTL or legacy
  * public-bucket URLs that no longer resolve since the bucket went private),
@@ -54,7 +74,7 @@ async function refreshGalleryUrls(
     const gallery = data?.gallery;
     if (!gallery || gallery.length === 0) continue;
     for (const photo of gallery) {
-      const path = extractWeeklyReportPath(photo.url);
+      const path = resolveWeeklyReportPath(photo);
       if (path) allPaths.add(path);
     }
   }
@@ -81,9 +101,11 @@ async function refreshGalleryUrls(
     const gallery = data?.gallery;
     if (!gallery || gallery.length === 0) return row;
     const refreshed = gallery.map((photo) => {
-      const path = extractWeeklyReportPath(photo.url);
+      const path = resolveWeeklyReportPath(photo);
       const fresh = path ? pathToUrl.get(path) : undefined;
-      return fresh ? { ...photo, url: fresh } : photo;
+      // Keep `path` persisted so future loads don't depend on URL parsing.
+      if (fresh) return { ...photo, path: path ?? photo.path, url: fresh };
+      return path && !photo.path ? { ...photo, path } : photo;
     });
     return {
       ...row,
@@ -144,11 +166,16 @@ export function useWeeklyReports({ projectId }: UseWeeklyReportsOptions) {
 
   // Map week_number -> stored WeeklyReportData
   const reportDataByWeek = new Map<number, WeeklyReportData>();
+  // Map week_number -> server-controlled availability timestamp (or null).
+  // When set, this is the source of truth for whether a customer may view the
+  // report — the frontend date heuristic is only a fallback.
+  const availableAtByWeek = new Map<number, string | null>();
   for (const row of reports) {
     reportDataByWeek.set(
       row.week_number,
       row.data as unknown as WeeklyReportData,
     );
+    availableAtByWeek.set(row.week_number, row.available_at);
   }
 
   const upsertMutation = useMutation({
@@ -298,6 +325,7 @@ export function useWeeklyReports({ projectId }: UseWeeklyReportsOptions) {
 
   return {
     reportDataByWeek,
+    availableAtByWeek,
     isLoading,
     error,
     saveReport,

--- a/src/lib/mediaTypes.ts
+++ b/src/lib/mediaTypes.ts
@@ -1,0 +1,35 @@
+// Shared media-type helpers. The list here MUST stay in sync with the
+// extensions/MIME types accepted by useReportImageUpload — otherwise a file
+// can be uploaded as a video but rendered as <img>, which always breaks.
+
+const VIDEO_EXTENSIONS = [
+  ".mp4",
+  ".mov",
+  ".webm",
+  ".quicktime",
+  ".m4v",
+  ".3gp",
+  ".3g2",
+  ".mkv",
+] as const;
+
+export function isVideoUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  const lower = url.toLowerCase().split("?")[0];
+  return (
+    VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext)) ||
+    lower.includes("video/")
+  );
+}
+
+// HEIC/HEIF are accepted by iOS cameras but do not render natively on
+// Android/Windows/Chrome. We reject them at upload time with a clear message.
+export const HEIC_MIME_TYPES = ["image/heic", "image/heif"] as const;
+export const HEIC_EXTENSIONS = [".heic", ".heif"] as const;
+
+export function isHeic(mimeType: string | undefined, name?: string): boolean {
+  const mt = (mimeType || "").toLowerCase();
+  if ((HEIC_MIME_TYPES as readonly string[]).includes(mt)) return true;
+  const lower = (name || "").toLowerCase();
+  return HEIC_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}

--- a/src/lib/mediaTypes.ts
+++ b/src/lib/mediaTypes.ts
@@ -27,9 +27,41 @@ export function isVideoUrl(url: string | undefined | null): boolean {
 export const HEIC_MIME_TYPES = ["image/heic", "image/heif"] as const;
 export const HEIC_EXTENSIONS = [".heic", ".heif"] as const;
 
-export function isHeic(mimeType: string | undefined, name?: string): boolean {
+export function isHeicMimeOrName(
+  mimeType: string | undefined,
+  name?: string,
+): boolean {
   const mt = (mimeType || "").toLowerCase();
   if ((HEIC_MIME_TYPES as readonly string[]).includes(mt)) return true;
   const lower = (name || "").toLowerCase();
   return HEIC_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+// HEIC/HEIF are ISO-BMFF: bytes 4-8 are "ftyp", bytes 8-12 are the major
+// brand. Blob uploads frequently arrive as application/octet-stream with no
+// filename, so MIME/extension checks miss them — sniff the brand instead.
+const HEIC_BRANDS = new Set([
+  "heic",
+  "heix",
+  "hevc",
+  "hevx",
+  "heim",
+  "heis",
+  "hevm",
+  "hevs",
+  "mif1",
+  "msf1",
+]);
+
+export async function isHeicBlob(blob: Blob): Promise<boolean> {
+  try {
+    const header = new Uint8Array(await blob.slice(0, 12).arrayBuffer());
+    if (header.length < 12) return false;
+    const ascii = (start: number, end: number) =>
+      String.fromCharCode(...header.subarray(start, end));
+    if (ascii(4, 8) !== "ftyp") return false;
+    return HEIC_BRANDS.has(ascii(8, 12).toLowerCase());
+  } catch {
+    return false;
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -86,6 +86,7 @@ const Index = () => {
     setSelectedActivityId,
     reportsChronological,
     reportDataByWeek,
+    availableAtByWeek,
     isSavingReport,
     savingWeek,
     updateActivity,
@@ -547,6 +548,7 @@ const Index = () => {
                             activities={reportData.activities}
                             onReportClick={handleReportClick}
                             isStaff={isStaff}
+                            availableAtByWeek={availableAtByWeek}
                           />
                         )}
                       </TabsContent>

--- a/src/types/weeklyReport.ts
+++ b/src/types/weeklyReport.ts
@@ -106,7 +106,13 @@ export interface DeliverableItem {
 
 export interface GalleryPhoto {
   id: string;
+  // Signed URL for display only. NEVER rely on this being valid long-term:
+  // signed URLs expire. `path` is the source of truth and is used to
+  // regenerate fresh signed URLs on every load.
   url: string;
+  // Storage object path inside the weekly-reports bucket
+  // ({projectId}/{userId}/week-N/...). Persisted so we can re-sign on display.
+  path?: string;
   caption: string;
   area: string;
   date: string;

--- a/supabase/migrations/20260517120000_fix_weekly_reports_write_policies_uuid_cast.sql
+++ b/supabase/migrations/20260517120000_fix_weekly_reports_write_policies_uuid_cast.sql
@@ -1,0 +1,48 @@
+-- Bug: uploads/updates to weekly-reports fail with `invalid_text_representation`
+-- when the object path's first segment is not a valid UUID (legacy paths,
+-- manual uploads, or a transient frontend bug).
+--
+-- Root cause: the INSERT and UPDATE policies created in
+-- 20260506183356 still cast the first path segment directly to ::uuid:
+--
+--   has_project_access(auth.uid(), ((storage.foldername(name))[1])::uuid)
+--
+-- A non-UUID segment raises invalid_text_representation, which aborts the
+-- whole statement instead of evaluating to false. The SELECT policy was
+-- already fixed in 20260509184127 by routing through
+-- public.weekly_reports_path_has_access (SECURITY DEFINER, swallows the cast
+-- error and also accepts the legacy {user_id}/{project_id}/... layout).
+--
+-- Fix: apply the same helper to INSERT and UPDATE. DELETE is staff-only and
+-- performs no UUID cast, so it is left unchanged.
+
+DROP POLICY IF EXISTS "Weekly reports: project members can upload" ON storage.objects;
+
+CREATE POLICY "Weekly reports: project members can upload"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'weekly-reports'
+  AND (
+    is_staff(auth.uid())
+    OR public.weekly_reports_path_has_access(auth.uid(), name)
+  )
+);
+
+DROP POLICY IF EXISTS "Weekly reports: project members can update" ON storage.objects;
+
+CREATE POLICY "Weekly reports: project members can update"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'weekly-reports'
+  AND (
+    is_staff(auth.uid())
+    OR public.weekly_reports_path_has_access(auth.uid(), name)
+  )
+)
+WITH CHECK (
+  bucket_id = 'weekly-reports'
+  AND (
+    is_staff(auth.uid())
+    OR public.weekly_reports_path_has_access(auth.uid(), name)
+  )
+);

--- a/supabase/migrations/20260517120100_backfill_weekly_reports_gallery_path.sql
+++ b/supabase/migrations/20260517120100_backfill_weekly_reports_gallery_path.sql
@@ -1,0 +1,66 @@
+-- Bug: gallery photos saved a long-lived signed URL directly into
+-- weekly_reports.data.gallery[].url. Once the signed URL expires the customer
+-- sees a permanently broken image. The frontend now persists the storage
+-- `path` and re-signs on every load, but existing rows have no `path`.
+--
+-- Fix: backfill `path` for every gallery element by parsing it out of the
+-- saved URL (everything after `/weekly-reports/`, before the query string).
+-- Elements that already have a path, or whose URL can't be parsed (blob:,
+-- legacy CDN, etc.), are left untouched — the frontend resolver logs those.
+
+DO $$
+DECLARE
+  r RECORD;
+  new_gallery jsonb;
+  elem jsonb;
+  url text;
+  marker text := '/weekly-reports/';
+  tail text;
+  qidx int;
+  extracted text;
+BEGIN
+  FOR r IN
+    SELECT id, data
+    FROM public.weekly_reports
+    WHERE data ? 'gallery'
+      AND jsonb_typeof(data -> 'gallery') = 'array'
+      AND jsonb_array_length(data -> 'gallery') > 0
+  LOOP
+    new_gallery := '[]'::jsonb;
+
+    FOR elem IN SELECT * FROM jsonb_array_elements(r.data -> 'gallery')
+    LOOP
+      -- Keep elements that already have a usable path.
+      IF (elem ? 'path')
+         AND elem ->> 'path' IS NOT NULL
+         AND elem ->> 'path' <> '' THEN
+        new_gallery := new_gallery || elem;
+        CONTINUE;
+      END IF;
+
+      url := elem ->> 'url';
+      extracted := NULL;
+
+      IF url IS NOT NULL AND position(marker IN url) > 0 THEN
+        tail := substring(url FROM position(marker IN url) + length(marker));
+        qidx := position('?' IN tail);
+        IF qidx > 0 THEN
+          extracted := substring(tail FROM 1 FOR qidx - 1);
+        ELSE
+          extracted := tail;
+        END IF;
+      END IF;
+
+      IF extracted IS NOT NULL AND extracted <> '' THEN
+        new_gallery := new_gallery
+          || jsonb_set(elem, '{path}', to_jsonb(extracted));
+      ELSE
+        new_gallery := new_gallery || elem;
+      END IF;
+    END LOOP;
+
+    UPDATE public.weekly_reports
+    SET data = jsonb_set(data, '{gallery}', new_gallery)
+    WHERE id = r.id;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

Fixes two critical issues with weekly report gallery photos:

1. **Expired signed URLs**: Gallery photos saved long-lived signed URLs directly, which expire after 7 days, leaving customers with permanently broken images. Now the storage `path` is persisted and fresh signed URLs are regenerated on every load.

2. **Silent media load failures**: When images/videos fail to load, there was no user feedback. Now failures are caught, logged, and a clear "media unavailable" UI is shown with a reload button.

Additionally, fixes RLS policy bugs that prevented uploads when storage paths contained non-UUID segments (legacy data, manual uploads).

## Key Changes

### Frontend

- **PhotoGallery.tsx**: 
  - Extract `isVideoUrl` to shared `src/lib/mediaTypes.ts` (with expanded video format support)
  - Track broken media IDs in state; show `MediaUnavailable` component when load fails
  - Add `onError` handlers to all `<img>` and `<video>` elements (thumbnails, full-screen, strip)
  - Log failures via `logWarn` with photo ID for debugging

- **useReportImageUpload.ts**:
  - Persist storage `path` alongside signed URL in gallery entries
  - Reject HEIC/HEIF files at upload time (iPhone format, doesn't render on Android/Windows/Chrome)
  - Improved error messages with file size and format details

- **useWeeklyReports.ts**:
  - Add `resolveWeeklyReportPath()`: prefers explicit `path` field, falls back to parsing from saved URL, logs unrecoverable photos
  - Keep `path` persisted when refreshing signed URLs so future loads don't depend on URL parsing

- **VideoPlayer.tsx**: Add error overlay with reload prompt when video fails to load

- **WeeklyReportsHistory.tsx**: Accept `availableAtByWeek` map for server-controlled report release (respects explicit `available_at` timestamp over date heuristics)

- **useLinkCustomerOnLogin.ts**: Fix race condition where concurrent effects could fire duplicate link requests by registering in-flight promise synchronously

- **GalleryPhoto type**: Document that `url` is temporary (expires) and `path` is the source of truth

### Backend

- **20260517120100_backfill_weekly_reports_gallery_path.sql**: Backfill `path` for all existing gallery photos by parsing from saved URLs; skip rows that already have a path or can't be parsed (logged by frontend)

- **20260517120000_fix_weekly_reports_write_policies_uuid_cast.sql**: Fix INSERT/UPDATE RLS policies to use `weekly_reports_path_has_access()` helper (SECURITY DEFINER) instead of direct `::uuid` cast, which was failing on non-UUID path segments

### Shared

- **src/lib/mediaTypes.ts** (new): Centralized video/HEIC detection with expanded format support (`.m4v`, `.3gp`, `.3g2`, `.mkv`)

## Implementation Details

- Media unavailability is graceful: broken items show a compact icon in thumbnails, a full error card in full-screen view with a reload button
- All load failures are logged with photo ID so we can identify legacy data needing backfill
- The `path` field is optional (`path?: string`) for backward compatibility; old rows without it will be backfilled by the migration
- Server-controlled `available_at` timestamp takes precedence over date-based heuristics for report visibility

https://claude.ai/code/session_01JrQTAg6HiPueWzpM9dTW5Z