### PR TITLE
Sync blob URLs to persisted media after save

### DIFF
--- a/src/components/report/WeeklyReportEditor.tsx
+++ b/src/components/report/WeeklyReportEditor.tsx
@@ -15,8 +15,14 @@ import { AIReportGenerator } from "./AIReportGenerator";
 interface WeeklyReportEditorProps {
   data: WeeklyReportData;
   projectId?: string;
-  onAutoSave?: (updatedData: WeeklyReportData) => void | Promise<void>;
-  onSaveAndClose?: (updatedData: WeeklyReportData) => void;
+  // Handlers may return the persisted data so the editor can replace blob:
+  // URLs in its local state with the permanent signed URLs.
+  onAutoSave?: (
+    updatedData: WeeklyReportData,
+  ) => void | Promise<WeeklyReportData | null | undefined | void>;
+  onSaveAndClose?: (
+    updatedData: WeeklyReportData,
+  ) => void | Promise<WeeklyReportData | null | undefined | void>;
   onCancel?: () => void;
   isSaving?: boolean;
 }

--- a/src/components/report/WeeklyReportTemplate.tsx
+++ b/src/components/report/WeeklyReportTemplate.tsx
@@ -16,7 +16,11 @@ interface WeeklyReportTemplateProps {
   data: WeeklyReportData;
   isStaff?: boolean;
   projectId?: string;
-  onSaveReport?: (updatedData: WeeklyReportData) => void;
+  // May return the persisted data (with permanent media URLs) so the editor
+  // can sync blob: URLs to their uploaded counterparts.
+  onSaveReport?: (
+    updatedData: WeeklyReportData,
+  ) => void | Promise<WeeklyReportData | null | void>;
   isSaving?: boolean;
 }
 
@@ -54,16 +58,18 @@ const WeeklyReportTemplate = ({
     safeData.deliverablesCompleted.length > 0;
 
   const handleAutoSave = useCallback(
-    (updatedData: WeeklyReportData) => {
-      onSaveReport?.(updatedData);
+    async (updatedData: WeeklyReportData) => {
+      const result = await onSaveReport?.(updatedData);
+      return result ?? undefined;
     },
     [onSaveReport],
   );
 
   const handleSaveAndClose = useCallback(
-    (updatedData: WeeklyReportData) => {
+    async (updatedData: WeeklyReportData) => {
+      const result = await onSaveReport?.(updatedData);
       setIsEditing(false);
-      onSaveReport?.(updatedData);
+      return result ?? undefined;
     },
     [onSaveReport],
   );

--- a/src/components/report/editor/useEditorState.ts
+++ b/src/components/report/editor/useEditorState.ts
@@ -12,8 +12,16 @@ import { toast } from "sonner";
 
 interface UseEditorStateOptions {
   data: WeeklyReportData;
-  onAutoSave?: (updatedData: WeeklyReportData) => void | Promise<void>;
-  onSaveAndClose?: (updatedData: WeeklyReportData) => void;
+  // When a handler returns the persisted WeeklyReportData (i.e. the upload
+  // pipeline replaced blob: URLs with permanent ones), the editor patches its
+  // local formData.gallery so previews stay valid and subsequent saves don't
+  // try to re-upload the same blobs.
+  onAutoSave?: (
+    updatedData: WeeklyReportData,
+  ) => void | Promise<WeeklyReportData | null | undefined | void>;
+  onSaveAndClose?: (
+    updatedData: WeeklyReportData,
+  ) => void | Promise<WeeklyReportData | null | undefined | void>;
   externalIsSaving?: boolean;
 }
 
@@ -71,10 +79,38 @@ export function useEditorState({
     [],
   );
 
+  // Replace blob: URLs in formData.gallery with the persisted url/path that
+  // came back from the save pipeline, matching by photo id. Revoke any blob
+  // URLs we just replaced so they don't leak memory.
+  const syncGalleryFromPersisted = useCallback(
+    (persisted: WeeklyReportData | null | undefined | void) => {
+      if (!persisted || !persisted.gallery) return;
+      const persistedById = new Map<string, GalleryPhoto>();
+      for (const p of persisted.gallery) persistedById.set(p.id, p);
+      setFormData((prev) => {
+        let mutated = false;
+        const toRevoke: string[] = [];
+        const nextGallery = prev.gallery.map((photo) => {
+          if (!photo.url?.startsWith("blob:")) return photo;
+          const saved = persistedById.get(photo.id);
+          if (!saved?.url || saved.url.startsWith("blob:")) return photo;
+          mutated = true;
+          toRevoke.push(photo.url);
+          return { ...photo, url: saved.url, path: saved.path ?? photo.path };
+        });
+        if (!mutated) return prev;
+        for (const url of toRevoke) URL.revokeObjectURL(url);
+        return { ...prev, gallery: nextGallery };
+      });
+    },
+    [],
+  );
+
   const { isSaving: autoSaving, lastSaved } = useAutoSave({
     data: formData,
     onSave: async (payload) => {
-      await onAutoSave?.(payload);
+      const result = await onAutoSave?.(payload);
+      syncGalleryFromPersisted(result);
     },
     debounceMs: 3000,
     enabled: !!onAutoSave,
@@ -82,7 +118,10 @@ export function useEditorState({
 
   const isSaving = externalIsSaving || autoSaving;
 
-  const handleSave = () => onSaveAndClose?.(formData);
+  const handleSave = async () => {
+    const result = await onSaveAndClose?.(formData);
+    syncGalleryFromPersisted(result);
+  };
 
   const updateExecutiveSummary = (value: string) => {
     setFormDataWithTracking((prev) => ({ ...prev, executiveSummary: value }));

--- a/src/hooks/useReportImageUpload.ts
+++ b/src/hooks/useReportImageUpload.ts
@@ -176,18 +176,12 @@ export function useReportImageUpload() {
         }
       }
 
-      // Revoke old blob URLs to free memory (only for successfully uploaded)
-      photosToUpload.forEach((photo) => {
-        const updated = updatedGallery.find((p) => p.id === photo.id);
-        // Only revoke if URL changed (upload succeeded)
-        if (
-          updated &&
-          updated.url !== photo.url &&
-          photo.url.startsWith("blob:")
-        ) {
-          URL.revokeObjectURL(photo.url);
-        }
-      });
+      // Note: blob URLs are intentionally NOT revoked here. The editor still
+      // holds them in its local `formData` state — revoking before the editor
+      // syncs to the persisted URLs would (1) blank the preview and (2) make
+      // any subsequent re-upload attempt fail with `fetch(blob:...)` on a
+      // dead URL. The caller is responsible for revoking after replacing the
+      // blob URL in its local state with the persisted `path` + signed URL.
 
       if (failedCount > 0) {
         toast.error(

--- a/src/hooks/useWeeklyReports.ts
+++ b/src/hooks/useWeeklyReports.ts
@@ -280,10 +280,10 @@ export function useWeeklyReports({ projectId }: UseWeeklyReportsOptions) {
       weekStart: string,
       weekEnd: string,
       data: WeeklyReportData,
-    ) => {
+    ): Promise<WeeklyReportData | null> => {
       if (!projectId) {
         toast.error("Projeto não selecionado");
-        return;
+        return null;
       }
 
       setSavingWeek(weekNumber);
@@ -307,7 +307,7 @@ export function useWeeklyReports({ projectId }: UseWeeklyReportsOptions) {
 
           if (!success) {
             setSavingWeek(null);
-            return; // Upload failed, don't save with broken URLs
+            return null; // Upload failed, don't save with broken URLs
           }
           dataToSave = { ...data, gallery: photos };
         }
@@ -319,6 +319,10 @@ export function useWeeklyReports({ projectId }: UseWeeklyReportsOptions) {
         weekEnd,
         data: dataToSave,
       });
+
+      // Return the persisted shape so the editor can replace its in-memory
+      // blob URLs with the permanent signed URLs (and revoke the blobs).
+      return dataToSave;
     },
     [projectId, uploadGalleryPhotos, upsertMutation],
   );


### PR DESCRIPTION
## Summary

Implements a blob URL lifecycle management system for weekly report media uploads. When the save pipeline persists media (replacing temporary `blob:` URLs with permanent signed URLs), the editor now syncs its local state to prevent stale blob references, memory leaks, and re-upload attempts on subsequent saves.

## Key Changes

- **`useEditorState.ts`**: Added `syncGalleryFromPersisted()` callback that patches `formData.gallery` when save handlers return persisted data. Matches photos by ID, replaces blob URLs with permanent ones, and revokes the old blob URLs to free memory. Both `onAutoSave` and `onSaveAndClose` now capture and sync the result.

- **`useReportImageUpload.ts`**: Removed blob URL revocation from the upload completion handler. Added clarifying comment explaining that revocation is now the caller's responsibility — revoking before the editor syncs would blank previews and break re-upload attempts on dead URLs.

- **`WeeklyReportTemplate.tsx`** & **`WeeklyReportEditor.tsx`**: Updated handler signatures to allow returning persisted data (`Promise<WeeklyReportData | null | undefined | void>`). Added JSDoc comments explaining the optional return value contract.

- **`useWeeklyReports.ts`**: Modified `saveWeeklyReport()` to return `Promise<WeeklyReportData | null>` instead of `void`. Returns the persisted data shape (with permanent signed URLs) so the editor can sync its in-memory blob URLs, or `null` on failure.

## Implementation Details

- Blob URL revocation is now centralized in the editor's `syncGalleryFromPersisted()` — only called after the editor has replaced its local references.
- The sync is idempotent: if persisted data is missing or already has blob URLs, the editor state is unchanged.
- Handlers are optional and may return `undefined`/`null` (backward compatible); the sync gracefully handles all cases.
- Memory leak prevention: blob URLs are revoked only after being replaced in React state, ensuring no preview blanking or fetch failures.

https://claude.ai/code/session_01G4LRPTW36zPygPvV7sNJWZ