### PR TITLE
Add Cronograma PDF export with dual layout support

### DIFF
--- a/src/components/cronograma/CronogramaPdfButton.tsx
+++ b/src/components/cronograma/CronogramaPdfButton.tsx
@@ -1,0 +1,80 @@
+/**
+ * CronogramaPdfButton — botão que gera e baixa o PDF do Cronograma de Obra.
+ *
+ * Geração é direta (sem modal). Mostra toast de loading enquanto roda e
+ * desativa o botão quando não há atividades para exportar.
+ */
+
+import { useState } from "react";
+import { FileDown, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { trackAmplitude } from "@/lib/amplitude";
+import {
+  generateCronogramaPdf,
+  CronogramaPdfEmptyError,
+  type CronogramaPdfProject,
+} from "@/lib/pdf/cronogramaPdf";
+import { isProjectNotStarted } from "@/lib/scheduleState";
+import { captureError } from "@/lib/errorMonitoring";
+import type { ProjectActivity } from "@/hooks/useProjectActivities";
+
+interface Props {
+  project: CronogramaPdfProject | null | undefined;
+  activities: ProjectActivity[];
+}
+
+export function CronogramaPdfButton({ project, activities }: Props) {
+  const [exporting, setExporting] = useState(false);
+  const disabled = !project || !activities || activities.length === 0;
+
+  const handleExport = async () => {
+    if (disabled || !project) return;
+    setExporting(true);
+    const toastId = toast.loading("Gerando PDF...");
+    try {
+      const { doc, fileName } = await generateCronogramaPdf(project, activities);
+      doc.save(fileName);
+      trackAmplitude("cronograma_pdf_exported", {
+        project_id: project.id ?? null,
+        activities_count: activities.length,
+        project_started: !isProjectNotStarted(activities),
+      });
+      toast.success("Cronograma exportado", { id: toastId });
+    } catch (err) {
+      if (err instanceof CronogramaPdfEmptyError) {
+        toast.error(err.message, { id: toastId });
+      } else {
+        captureError(err, { feature: "cronograma" });
+        toast.error("Erro ao gerar PDF", { id: toastId });
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="text-xs"
+      onClick={handleExport}
+      disabled={disabled || exporting}
+      title={
+        disabled
+          ? "Adicione atividades para exportar o cronograma"
+          : "Exportar cronograma em PDF"
+      }
+      aria-label="Exportar cronograma em PDF"
+    >
+      {exporting ? (
+        <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+      ) : (
+        <FileDown className="w-4 h-4 mr-1.5" />
+      )}
+      <span className="hidden sm:inline">
+        {exporting ? "Gerando..." : "Exportar PDF"}
+      </span>
+    </Button>
+  );
+}

--- a/src/lib/__tests__/scheduleState.test.ts
+++ b/src/lib/__tests__/scheduleState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getActivityState } from "../scheduleState";
+import { getActivityState, isProjectNotStarted } from "../scheduleState";
 
 describe("getActivityState", () => {
   // Reference date: 2025-07-20
@@ -68,6 +68,33 @@ describe("getActivityState", () => {
     expect(r.state).toBe("delayed");
     expect(r.tone).toBe("danger");
     expect(r.delayDays).toBe(10);
+  });
+
+  it("isProjectNotStarted returns true for empty list", () => {
+    expect(isProjectNotStarted([])).toBe(true);
+  });
+
+  it("isProjectNotStarted returns true when no activity has actual_start", () => {
+    expect(
+      isProjectNotStarted([
+        { actual_start: null },
+        { actual_start: null },
+      ]),
+    ).toBe(true);
+  });
+
+  it("isProjectNotStarted returns false when any activity has actual_start", () => {
+    expect(
+      isProjectNotStarted([
+        { actual_start: null },
+        { actual_start: "2025-07-15" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("isProjectNotStarted accepts camelCase shape too", () => {
+    expect(isProjectNotStarted([{ actualStart: "2025-07-15" }])).toBe(false);
+    expect(isProjectNotStarted([{ actualStart: null }])).toBe(true);
   });
 
   it("reports delayDays for late completion but keeps state as completed", () => {

--- a/src/lib/amplitude.ts
+++ b/src/lib/amplitude.ts
@@ -27,7 +27,9 @@ export type AmplitudeEvent =
   | "next_action_clicked"
   // Mobile bottom-nav sync
   | "mobile_tab_synced"
-  | "mobile_tab_route_redirect";
+  | "mobile_tab_route_redirect"
+  // Cronograma export
+  | "cronograma_pdf_exported";
 
 export type AmplitudeProps = Record<
   string,

--- a/src/lib/pdf/__tests__/cronogramaPdf.test.ts
+++ b/src/lib/pdf/__tests__/cronogramaPdf.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateCronogramaPdf,
+  CronogramaPdfEmptyError,
+  slugifyForFilename,
+  type CronogramaPdfProject,
+} from "../cronogramaPdf";
+import type { ProjectActivity } from "@/hooks/useProjectActivities";
+
+const baseProject: CronogramaPdfProject = {
+  id: "p-1",
+  name: "Apto Itaim Jardim",
+  customer_name: "Carlos Pereira",
+  address: "Rua das Flores, 123",
+  bairro: "Itaim Bibi",
+  cidade: "São Paulo",
+};
+
+const fixedNow = new Date(2026, 4, 24, 10, 0, 0); // 2026-05-24 10:00 local
+
+function makeActivity(
+  overrides: Partial<ProjectActivity> = {},
+): ProjectActivity {
+  return {
+    id: overrides.id ?? "a-1",
+    project_id: "p-1",
+    description: "Mobilização e alinhamentos",
+    planned_start: "2026-06-01",
+    planned_end: "2026-06-05",
+    actual_start: null,
+    actual_end: null,
+    weight: 10,
+    sort_order: 0,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    created_by: "u-1",
+    predecessor_ids: [],
+    baseline_start: null,
+    baseline_end: null,
+    baseline_saved_at: null,
+    etapa: null,
+    detailed_description: null,
+    ...overrides,
+  };
+}
+
+describe("slugifyForFilename", () => {
+  it("normaliza acentos e espaços", () => {
+    expect(slugifyForFilename("Apto Itaim Jardim")).toBe("apto-itaim-jardim");
+    expect(slugifyForFilename("Obra São João — Centro!")).toBe(
+      "obra-sao-joao-centro",
+    );
+  });
+
+  it("retorna fallback para entrada vazia", () => {
+    expect(slugifyForFilename("")).toBe("obra");
+    expect(slugifyForFilename(null)).toBe("obra");
+    expect(slugifyForFilename(undefined)).toBe("obra");
+  });
+});
+
+describe("generateCronogramaPdf", () => {
+  it("lança CronogramaPdfEmptyError quando não há atividades", async () => {
+    await expect(generateCronogramaPdf(baseProject, [])).rejects.toBeInstanceOf(
+      CronogramaPdfEmptyError,
+    );
+  });
+
+  it("gera PDF para obra não iniciada e produz blob válido", async () => {
+    const activities = [
+      makeActivity({
+        id: "a-1",
+        description: "Demolição",
+        planned_start: "2026-06-01",
+        planned_end: "2026-06-05",
+        weight: 30,
+        etapa: "Estrutura",
+        sort_order: 0,
+      }),
+      makeActivity({
+        id: "a-2",
+        description: "Alvenaria",
+        planned_start: "2026-06-08",
+        planned_end: "2026-06-19",
+        weight: 70,
+        etapa: "Estrutura",
+        sort_order: 1,
+      }),
+    ];
+
+    const { doc, fileName } = await generateCronogramaPdf(
+      baseProject,
+      activities,
+      { now: fixedNow },
+    );
+
+    expect(fileName).toBe("cronograma_apto-itaim-jardim_2026-05-24.pdf");
+    const blob = doc.output("blob");
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(500);
+  });
+
+  it("gera PDF para obra em andamento (com actual_start) sem erros", async () => {
+    const activities = [
+      makeActivity({
+        id: "a-1",
+        description: "Fundação",
+        planned_start: "2026-04-01",
+        planned_end: "2026-04-20",
+        actual_start: "2026-04-01",
+        actual_end: "2026-04-22",
+        weight: 50,
+        sort_order: 0,
+      }),
+      makeActivity({
+        id: "a-2",
+        description: "Alvenaria",
+        planned_start: "2026-05-01",
+        planned_end: "2026-05-20",
+        actual_start: "2026-05-05",
+        weight: 50,
+        sort_order: 1,
+      }),
+    ];
+
+    const { doc, fileName } = await generateCronogramaPdf(
+      baseProject,
+      activities,
+      { now: fixedNow },
+    );
+
+    expect(fileName).toMatch(/^cronograma_apto-itaim-jardim_2026-05-24\.pdf$/);
+    const blob = doc.output("blob");
+    expect(blob.size).toBeGreaterThan(500);
+  });
+
+  it("gera PDF com atividade atrasada (linha em destaque) sem erros", async () => {
+    const activities = [
+      makeActivity({
+        id: "a-1",
+        description: "Demolição (em atraso)",
+        planned_start: "2026-04-01",
+        planned_end: "2026-04-15",
+        actual_start: "2026-04-01",
+        actual_end: null,
+        weight: 100,
+        sort_order: 0,
+      }),
+    ];
+
+    const { doc } = await generateCronogramaPdf(baseProject, activities, {
+      now: fixedNow,
+    });
+
+    const blob = doc.output("blob");
+    expect(blob.size).toBeGreaterThan(500);
+  });
+
+  it("respeita o nome de arquivo customizado", async () => {
+    const activities = [makeActivity()];
+    const { fileName } = await generateCronogramaPdf(baseProject, activities, {
+      now: fixedNow,
+      fileName: "cronograma_custom.pdf",
+    });
+    expect(fileName).toBe("cronograma_custom.pdf");
+  });
+});

--- a/src/lib/pdf/cronogramaPdf.ts
+++ b/src/lib/pdf/cronogramaPdf.ts
@@ -1,0 +1,511 @@
+/**
+ * cronogramaPdf — exporta o Cronograma de Obra em PDF (A4 paisagem).
+ *
+ * Dois layouts:
+ *   1. Obra NÃO iniciada (nenhuma atividade com `actual_start`):
+ *      tabela enxuta sem colunas de execução real.
+ *   2. Obra EM andamento: tabela completa com colunas de execução,
+ *      progresso e status calculado.
+ *
+ * Carrega `jspdf` + `jspdf-autotable` dinamicamente (lazy import) para
+ * manter o bundle inicial leve.
+ */
+
+import { formatInTimeZone } from "date-fns-tz";
+import { ptBR } from "date-fns/locale";
+import type { ProjectActivity } from "@/hooks/useProjectActivities";
+import { getActivityState, isProjectNotStarted } from "@/lib/scheduleState";
+import { countBusinessDaysInclusive } from "@/lib/businessDays";
+import { parseLocalDate, computeEffectiveStatus } from "@/lib/activityStatus";
+
+const SP_TZ = "America/Sao_Paulo";
+
+const HEADER_FILL: [number, number, number] = [15, 23, 42]; // slate-900
+const HEADER_TEXT: [number, number, number] = [255, 255, 255];
+const ZEBRA_FILL: [number, number, number] = [245, 245, 247];
+const DELAYED_FILL: [number, number, number] = [254, 226, 226]; // bg-destructive/10
+const ETAPA_FILL: [number, number, number] = [226, 232, 240]; // slate-200
+
+export interface CronogramaPdfProject {
+  id?: string;
+  name: string;
+  customer_name?: string | null;
+  address?: string | null;
+  endereco_completo?: string | null;
+  bairro?: string | null;
+  cidade?: string | null;
+}
+
+export interface CronogramaPdfOptions {
+  /** Date used to compute statuses (default: now). Useful for tests. */
+  now?: Date;
+  /** When provided, overrides the auto-generated filename. */
+  fileName?: string;
+}
+
+export class CronogramaPdfEmptyError extends Error {
+  constructor() {
+    super("Não há atividades cadastradas para exportar.");
+    this.name = "CronogramaPdfEmptyError";
+  }
+}
+
+/** Slug compatível com nomes de arquivo: minúsculo, sem acento, hífens. */
+export function slugifyForFilename(input: string | null | undefined): string {
+  const value = (input ?? "").toString();
+  const normalized = value
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim();
+  const slug = normalized.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug || "obra";
+}
+
+function formatAddress(project: CronogramaPdfProject): string | null {
+  const direct = project.endereco_completo?.trim() || project.address?.trim();
+  if (direct) {
+    const extras = [project.bairro, project.cidade].filter(Boolean).join(" — ");
+    return extras ? `${direct} · ${extras}` : direct;
+  }
+  const fallback = [project.bairro, project.cidade].filter(Boolean).join(" — ");
+  return fallback || null;
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  return formatInTimeZone(parseLocalDate(value), SP_TZ, "dd/MM/yyyy", {
+    locale: ptBR,
+  });
+}
+
+function durationBusinessDays(activity: ProjectActivity): number {
+  if (!activity.planned_start || !activity.planned_end) return 0;
+  return countBusinessDaysInclusive(
+    parseLocalDate(activity.planned_start),
+    parseLocalDate(activity.planned_end),
+  );
+}
+
+function sortActivities(activities: ProjectActivity[]): ProjectActivity[] {
+  return [...activities].sort((a, b) => {
+    const sa = a.planned_start ?? "";
+    const sb = b.planned_start ?? "";
+    if (sa === sb) return a.sort_order - b.sort_order;
+    return sa < sb ? -1 : 1;
+  });
+}
+
+interface GroupedByEtapa {
+  etapa: string | null;
+  activities: ProjectActivity[];
+}
+
+function groupByEtapa(activities: ProjectActivity[]): GroupedByEtapa[] {
+  const groups: GroupedByEtapa[] = [];
+  let currentEtapa: string | null | undefined;
+  for (const act of activities) {
+    const etapa = act.etapa?.trim() || null;
+    if (etapa !== currentEtapa) {
+      groups.push({ etapa, activities: [act] });
+      currentEtapa = etapa;
+    } else {
+      groups[groups.length - 1].activities.push(act);
+    }
+  }
+  return groups;
+}
+
+interface BuildResult {
+  doc: import("jspdf").jsPDF;
+  fileName: string;
+}
+
+/**
+ * Gera o PDF do cronograma e retorna o doc + filename.
+ * Lança `CronogramaPdfEmptyError` quando não há atividades.
+ */
+export async function generateCronogramaPdf(
+  project: CronogramaPdfProject,
+  activities: ProjectActivity[],
+  options: CronogramaPdfOptions = {},
+): Promise<BuildResult> {
+  if (!activities || activities.length === 0) {
+    throw new CronogramaPdfEmptyError();
+  }
+
+  const [{ default: jsPDF }, autoTableMod] = await Promise.all([
+    import("jspdf"),
+    import("jspdf-autotable"),
+  ]);
+  const autoTable = (
+    autoTableMod as { default: typeof import("jspdf-autotable").default }
+  ).default;
+
+  const doc = new jsPDF({ orientation: "landscape", unit: "mm", format: "a4" });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const marginX = 12;
+
+  const sorted = sortActivities(activities);
+  const notStarted = isProjectNotStarted(activities);
+  const now = options.now ?? new Date();
+
+  const plannedStarts = sorted
+    .map((a) => a.planned_start)
+    .filter((d): d is string => !!d);
+  const plannedEnds = sorted
+    .map((a) => a.planned_end)
+    .filter((d): d is string => !!d);
+  const minStart = plannedStarts.length
+    ? plannedStarts.reduce((min, d) => (d < min ? d : min))
+    : null;
+  const maxEnd = plannedEnds.length
+    ? plannedEnds.reduce((max, d) => (d > max ? d : max))
+    : null;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(14);
+  doc.setTextColor(15, 23, 42);
+  doc.text("Cronograma de Obra", marginX, 16);
+
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(11);
+  doc.setTextColor(30, 41, 59);
+  doc.text(project.name || "—", marginX, 22);
+
+  doc.setFontSize(9);
+  doc.setTextColor(90, 90, 90);
+
+  const infoLines: string[] = [];
+  if (project.customer_name) {
+    infoLines.push(`Cliente: ${project.customer_name}`);
+  }
+  const address = formatAddress(project);
+  if (address) {
+    infoLines.push(`Endereço: ${address}`);
+  }
+  const emittedAt = formatInTimeZone(now, SP_TZ, "dd/MM/yyyy HH:mm", {
+    locale: ptBR,
+  });
+  infoLines.push(`Emitido em: ${emittedAt}`);
+  infoLines.push(`Status geral: ${notStarted ? "Não iniciada" : "Em andamento"}`);
+  if (minStart) infoLines.push(`Início previsto: ${formatDate(minStart)}`);
+  if (maxEnd) infoLines.push(`Término previsto: ${formatDate(maxEnd)}`);
+
+  let infoY = 28;
+  for (const line of infoLines) {
+    doc.text(line, marginX, infoY);
+    infoY += 4.5;
+  }
+
+  let startY = infoY + 4;
+
+  if (!notStarted) {
+    const stats = computeProjectStats(sorted, now);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(15, 23, 42);
+    doc.text(
+      `Progresso geral: ${stats.weightedProgress.toFixed(1)}%`,
+      marginX,
+      startY,
+    );
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(90, 90, 90);
+    doc.text(
+      `Concluídas: ${stats.completed}  ·  Em andamento: ${stats.inProgress}  ·  Atrasadas: ${stats.delayed}  ·  Não iniciadas: ${stats.notStarted}`,
+      marginX,
+      startY + 5,
+    );
+    startY += 12;
+  }
+
+  const groups = groupByEtapa(sorted);
+
+  if (notStarted) {
+    buildNotStartedTable(doc, autoTable, groups, startY, marginX);
+  } else {
+    buildInProgressTable(doc, autoTable, groups, startY, marginX, now);
+  }
+
+  const totalPages = doc.getNumberOfPages();
+  const footerNote = notStarted
+    ? "Cronograma preliminar — obra ainda não iniciada."
+    : "";
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+    doc.setFontSize(8);
+    doc.setTextColor(120, 120, 120);
+    doc.setFont("helvetica", "normal");
+    const footerLeft = `Portal BWild · ${project.name || "Obra"}`;
+    const footerRight = `Página ${i} de ${totalPages}`;
+    doc.text(footerLeft, marginX, pageHeight - 6);
+    doc.text(footerRight, pageWidth - marginX, pageHeight - 6, {
+      align: "right",
+    });
+    if (footerNote && i === totalPages) {
+      doc.setFont("helvetica", "italic");
+      doc.text(footerNote, pageWidth / 2, pageHeight - 6, { align: "center" });
+    }
+  }
+
+  const dateStamp = formatInTimeZone(now, SP_TZ, "yyyy-MM-dd");
+  const fileName =
+    options.fileName ??
+    `cronograma_${slugifyForFilename(project.name)}_${dateStamp}.pdf`;
+
+  return { doc, fileName };
+}
+
+function computeProjectStats(activities: ProjectActivity[], now: Date) {
+  let completed = 0;
+  let inProgress = 0;
+  let delayed = 0;
+  let notStartedCount = 0;
+  let totalWeight = 0;
+  let weightedProgress = 0;
+
+  for (const act of activities) {
+    const status = computeEffectiveStatus(
+      {
+        plannedStart: act.planned_start,
+        plannedEnd: act.planned_end,
+        actualStart: act.actual_start,
+        actualEnd: act.actual_end,
+      },
+      now,
+    );
+    const weight = Number.isFinite(act.weight) ? act.weight : 0;
+    totalWeight += weight;
+    weightedProgress += (weight * status.progress) / 100;
+
+    switch (status.status) {
+      case "completed":
+        completed++;
+        break;
+      case "in-progress":
+        inProgress++;
+        break;
+      case "delayed":
+        delayed++;
+        break;
+      default:
+        notStartedCount++;
+    }
+  }
+
+  const finalProgress =
+    totalWeight > 0 ? (weightedProgress / totalWeight) * 100 : 0;
+
+  return {
+    completed,
+    inProgress,
+    delayed,
+    notStarted: notStartedCount,
+    weightedProgress: finalProgress,
+  };
+}
+
+type AutoTableFn = typeof import("jspdf-autotable").default;
+
+function buildEtapaRow(label: string, columns: number) {
+  return [
+    {
+      content: label,
+      colSpan: columns,
+      styles: {
+        fontStyle: "bold" as const,
+        fillColor: ETAPA_FILL,
+        textColor: [15, 23, 42] as [number, number, number],
+        halign: "left" as const,
+      },
+    },
+  ];
+}
+
+function buildNotStartedTable(
+  doc: import("jspdf").jsPDF,
+  autoTable: AutoTableFn,
+  groups: GroupedByEtapa[],
+  startY: number,
+  marginX: number,
+) {
+  const head = [
+    [
+      "#",
+      "Etapa",
+      "Atividade",
+      "Início Previsto",
+      "Término Previsto",
+      "Duração (dias úteis)",
+      "Peso (%)",
+    ],
+  ];
+  const body: import("jspdf-autotable").RowInput[] = [];
+
+  let counter = 0;
+  for (const group of groups) {
+    if (group.etapa) {
+      body.push(buildEtapaRow(`Etapa: ${group.etapa}`, head[0].length));
+    }
+    for (const act of group.activities) {
+      counter++;
+      body.push([
+        counter,
+        group.etapa ?? "—",
+        act.description,
+        formatDate(act.planned_start),
+        formatDate(act.planned_end),
+        durationBusinessDays(act).toString(),
+        Number.isFinite(act.weight) ? act.weight.toFixed(1) : "0.0",
+      ]);
+    }
+  }
+
+  autoTable(doc, {
+    head,
+    body,
+    startY,
+    margin: { left: marginX, right: marginX, bottom: 12 },
+    styles: {
+      fontSize: 9,
+      cellPadding: 2.2,
+      overflow: "linebreak",
+      lineColor: [226, 232, 240],
+      lineWidth: 0.1,
+    },
+    headStyles: {
+      fillColor: HEADER_FILL,
+      textColor: HEADER_TEXT,
+      fontStyle: "bold",
+      halign: "center",
+    },
+    alternateRowStyles: { fillColor: ZEBRA_FILL },
+    columnStyles: {
+      0: { halign: "center", cellWidth: 10 },
+      1: { cellWidth: 45 },
+      2: { cellWidth: "auto" },
+      3: { halign: "center", cellWidth: 32 },
+      4: { halign: "center", cellWidth: 32 },
+      5: { halign: "center", cellWidth: 32 },
+      6: { halign: "right", cellWidth: 20 },
+    },
+    rowPageBreak: "avoid",
+    pageBreak: "auto",
+  });
+}
+
+function buildInProgressTable(
+  doc: import("jspdf").jsPDF,
+  autoTable: AutoTableFn,
+  groups: GroupedByEtapa[],
+  startY: number,
+  marginX: number,
+  now: Date,
+) {
+  const head = [
+    [
+      "#",
+      "Etapa",
+      "Atividade",
+      "Início Prev.",
+      "Término Prev.",
+      "Início Real",
+      "Término Real",
+      "Progresso",
+      "Status",
+    ],
+  ];
+  const body: import("jspdf-autotable").RowInput[] = [];
+  const delayedRowIndexes = new Set<number>();
+
+  let counter = 0;
+  let rowIdx = 0;
+  for (const group of groups) {
+    if (group.etapa) {
+      body.push(buildEtapaRow(`Etapa: ${group.etapa}`, head[0].length));
+      rowIdx++;
+    }
+    for (const act of group.activities) {
+      counter++;
+      const state = getActivityState(
+        {
+          plannedStart: act.planned_start,
+          plannedEnd: act.planned_end,
+          actualStart: act.actual_start,
+          actualEnd: act.actual_end,
+        },
+        now,
+      );
+      const status = computeEffectiveStatus(
+        {
+          plannedStart: act.planned_start,
+          plannedEnd: act.planned_end,
+          actualStart: act.actual_start,
+          actualEnd: act.actual_end,
+        },
+        now,
+      );
+
+      if (state.state === "delayed") {
+        delayedRowIndexes.add(rowIdx);
+      }
+
+      body.push([
+        counter,
+        group.etapa ?? "—",
+        act.description,
+        formatDate(act.planned_start),
+        formatDate(act.planned_end),
+        formatDate(act.actual_start),
+        formatDate(act.actual_end),
+        `${status.progress}%`,
+        state.label,
+      ]);
+      rowIdx++;
+    }
+  }
+
+  autoTable(doc, {
+    head,
+    body,
+    startY,
+    margin: { left: marginX, right: marginX, bottom: 12 },
+    styles: {
+      fontSize: 9,
+      cellPadding: 2,
+      overflow: "linebreak",
+      lineColor: [226, 232, 240],
+      lineWidth: 0.1,
+    },
+    headStyles: {
+      fillColor: HEADER_FILL,
+      textColor: HEADER_TEXT,
+      fontStyle: "bold",
+      halign: "center",
+    },
+    alternateRowStyles: { fillColor: ZEBRA_FILL },
+    columnStyles: {
+      0: { halign: "center", cellWidth: 10 },
+      1: { cellWidth: 32 },
+      2: { cellWidth: "auto" },
+      3: { halign: "center", cellWidth: 26 },
+      4: { halign: "center", cellWidth: 26 },
+      5: { halign: "center", cellWidth: 26 },
+      6: { halign: "center", cellWidth: 26 },
+      7: { halign: "right", cellWidth: 22 },
+      8: { halign: "center", cellWidth: 26 },
+    },
+    didParseCell: (data) => {
+      if (data.section !== "body") return;
+      if (delayedRowIndexes.has(data.row.index)) {
+        data.cell.styles.fillColor = DELAYED_FILL;
+        data.cell.styles.textColor = [127, 29, 29];
+      }
+    },
+    rowPageBreak: "avoid",
+    pageBreak: "auto",
+  });
+}

--- a/src/lib/scheduleState.ts
+++ b/src/lib/scheduleState.ts
@@ -83,3 +83,17 @@ export function getActivityState(
 
 export const ACTIVITY_STATE_LABEL = LABEL;
 export const ACTIVITY_STATE_TONE = TONE;
+
+/**
+ * Considera a obra como "não iniciada" quando NENHUMA atividade tem
+ * `actual_start` preenchido. Aceita tanto o shape do banco (`actual_start`)
+ * quanto a forma camelCase (`actualStart`) usada em algumas camadas.
+ */
+export function isProjectNotStarted(
+  activities: Array<{ actual_start?: string | null; actualStart?: string | null }>,
+): boolean {
+  if (!activities || activities.length === 0) return true;
+  return activities.every(
+    (a) => !(a.actual_start ?? a.actualStart),
+  );
+}

--- a/src/pages/Cronograma.tsx
+++ b/src/pages/Cronograma.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { Progress } from "@/components/ui/progress";
 import { ImportScheduleModal } from "@/components/ImportScheduleModal";
 import { CronogramaMobileView } from "@/components/cronograma/CronogramaMobileView";
+import { CronogramaPdfButton } from "@/components/cronograma/CronogramaPdfButton";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { AssessorSheet } from "@/components/agent";
 import { cn } from "@/lib/utils";
@@ -615,7 +616,12 @@ const Cronograma = () => {
             { label: project?.name || "Obra", href: `/obra/${projectId}` },
             { label: "Cronograma" },
           ]}
-        />
+        >
+          <CronogramaPdfButton
+            project={project}
+            activities={existingActivities}
+          />
+        </PageHeader>
         <div className="max-w-lg mx-auto p-4">
           <CronogramaMobileView
             activities={existingActivities}
@@ -742,6 +748,10 @@ const Cronograma = () => {
             <Upload className="w-4 h-4 mr-1.5" />
             <span className="hidden sm:inline">Importar</span>
           </Button>
+          <CronogramaPdfButton
+            project={project}
+            activities={existingActivities}
+          />
           <AssessorSheet
             defaultEventType="schedule_request"
             placeholder="Ex: A demolição encontrou parede de tijolo maciço — qual o impacto no caminho crítico?"


### PR DESCRIPTION
## Summary

Adds PDF export functionality for the project schedule (Cronograma de Obra) with intelligent layout switching based on project status. The feature generates A4 landscape PDFs with two distinct table layouts: a simplified view for projects not yet started, and a detailed view with execution tracking for active projects.

## Key Changes

- **New PDF generation module** (`src/lib/pdf/cronogramaPdf.ts`):
  - `generateCronogramaPdf()` function that produces jsPDF documents with lazy-loaded dependencies (jspdf + jspdf-autotable) to keep bundle size minimal
  - Dual layout system: simplified table for non-started projects vs. comprehensive table with progress/status for active projects
  - Activity grouping by "etapa" (phase) with visual hierarchy
  - Delayed activities highlighted in red with custom styling
  - Project statistics (weighted progress, completion counts) displayed for active projects
  - Proper date formatting in São Paulo timezone with PT-BR locale
  - Business day duration calculation for planned activities
  - Automatic filename generation with project name slug and date stamp

- **Export button component** (`src/components/cronograma/CronogramaPdfButton.tsx`):
  - Integrated button for direct PDF generation and download
  - Loading state with spinner feedback
  - Toast notifications for success/error states
  - Amplitude event tracking for export analytics
  - Disabled state when no activities exist

- **Helper function** (`src/lib/scheduleState.ts`):
  - `isProjectNotStarted()` utility to determine if any activity has begun (checks `actual_start` field)
  - Accepts both snake_case (database) and camelCase (internal) field names

- **Comprehensive test coverage** (`src/lib/pdf/__tests__/cronogramaPdf.test.ts`):
  - Tests for empty activity list error handling
  - Tests for both non-started and in-progress project layouts
  - Tests for delayed activity highlighting
  - Tests for custom filename override
  - Tests for filename slug normalization

- **Integration into Cronograma page** (`src/pages/Cronograma.tsx`):
  - Added `CronogramaPdfButton` to the page header for easy access
  - Button positioned alongside other schedule actions

- **Analytics** (`src/lib/amplitude.ts`):
  - New event type `cronograma_pdf_exported` with project context

## Implementation Details

- **Lazy loading**: jsPDF and jspdf-autotable are dynamically imported only when export is triggered, avoiding bundle bloat
- **Styling**: Uses semantic color tokens (slate-900 headers, slate-200 phase rows, red-100 delayed activities) consistent with the design system
- **Error handling**: Custom `CronogramaPdfEmptyError` for user-friendly messaging when no activities exist
- **Date handling**: Leverages existing `parseLocalDate()` and `computeEffectiveStatus()` utilities for consistency
- **Responsive**: Automatically handles page breaks and multi-page documents with proper footers and page numbering
- **Accessibility**: Proper ARIA labels and title attributes on the export button

https://claude.ai/code/session_01PJkhnGuZhubTcifEyPE442