### PR TITLE
Fix weekly report notification tab and expand recipient scope

### DIFF
--- a/supabase/migrations/20260625120000_fix_weekly_report_published_notification_tab.sql
+++ b/supabase/migrations/20260625120000_fix_weekly_report_published_notification_tab.sql
@@ -1,0 +1,63 @@
+-- Bug: clientes não conseguem acessar os relatórios a partir da notificação.
+--
+-- Causa raiz: o gatilho notify_weekly_report_published (migration 20260322090903)
+-- grava a notificação "Relatório Semana N disponível" com action_url apontando
+-- para `/obra/{project_id}?tab=evolucao` — a aba de Evolução (curva S), e NÃO a
+-- aba de Relatórios. O sino de notificações (NotificationBell / MobileNotifications)
+-- navega direto para esse action_url, então o cliente que toca na notificação cai
+-- na tela errada e nunca chega ao relatório. O destino correto é `?tab=relatorios`
+-- (mesmo padrão das demais notificações: ?tab=documentos, ?tab=financeiro, etc.).
+--
+-- Correções:
+--   1) Apontar a notificação para `?tab=relatorios`.
+--   2) Notificar TODOS os clientes vinculados ao projeto — tanto os legados em
+--      project_customers quanto os vinculados via project_members (role 'viewer',
+--      criado pelo auto-link em 20260509012003). Antes, clientes que só existiam
+--      em project_members não recebiam a notificação.
+--   3) Backfill: corrigir o action_url das notificações de relatório já gravadas.
+
+CREATE OR REPLACE FUNCTION public.notify_weekly_report_published()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_project_name TEXT;
+BEGIN
+  -- Only notify on insert or when content is first populated
+  IF TG_OP = 'INSERT' OR (TG_OP = 'UPDATE' AND OLD.data IS DISTINCT FROM NEW.data AND NEW.data IS NOT NULL) THEN
+    SELECT name INTO v_project_name FROM projects WHERE id = NEW.project_id;
+
+    FOR v_user_id IN
+      -- Clientes legados vinculados por project_customers
+      SELECT customer_user_id AS uid
+      FROM project_customers
+      WHERE project_id = NEW.project_id AND customer_user_id IS NOT NULL
+      UNION
+      -- Clientes vinculados pelo sistema unificado (project_members role 'viewer')
+      SELECT user_id AS uid
+      FROM project_members
+      WHERE project_id = NEW.project_id AND role = 'viewer'
+    LOOP
+      PERFORM create_notification(
+        v_user_id,
+        'report_published',
+        'Relatório Semana ' || NEW.week_number || ' disponível',
+        'O relatório semanal de ' || COALESCE(v_project_name, 'seu projeto') || ' está pronto.',
+        NEW.project_id,
+        '/obra/' || NEW.project_id || '?tab=relatorios'
+      );
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Backfill: notificações de relatório já gravadas apontam para a aba errada.
+UPDATE public.notifications
+SET action_url = replace(action_url, '?tab=evolucao', '?tab=relatorios')
+WHERE type = 'report_published'
+  AND action_url LIKE '%?tab=evolucao';


### PR DESCRIPTION
## Summary

Fixes a critical bug where clients could not access weekly reports from the notification bell. The notification was pointing to the wrong tab (`?tab=evolucao` instead of `?tab=relatorios`), causing users to land on the Evolution (S-curve) screen instead of the Reports tab. Additionally, expands notification recipients to include all linked clients.

## Changes

- **Corrected action URL**: Updated `notify_weekly_report_published()` trigger to point notifications to `?tab=relatorios` instead of `?tab=evolucao`, matching the pattern used by other notifications (documents, financial, etc.)

- **Expanded recipient scope**: Modified the trigger to notify both:
  - Legacy clients linked via `project_customers` table
  - Clients linked via the unified system (`project_members` with role `'viewer'`)
  
  Previously, clients who only existed in `project_members` were not receiving notifications.

- **Backfill migration**: Added SQL to correct the `action_url` of all previously-published report notifications that were pointing to the wrong tab.

## Implementation Details

The updated trigger now uses a `UNION` query to fetch all eligible recipients from both tables, ensuring no client is missed regardless of how they were linked to the project. The notification message and metadata remain unchanged; only the navigation destination is corrected.

https://claude.ai/code/session_01AJgb1ZWJdc9oFnri8Hvo19