### PR TITLE
fix(#82): acesso do cliente — RLS de storage, signed URLs e galerias

### DIFF
--- a/src/components/MediaUnavailable.tsx
+++ b/src/components/MediaUnavailable.tsx
@@ -1,0 +1,18 @@
+import { ImageOff } from "lucide-react";
+
+/**
+ * Placeholder mostrado quando uma imagem/vídeo falha ao carregar (signed URL
+ * expirada, RLS bloqueando, path inválido). Substitui o ícone de imagem
+ * quebrada do navegador por um feedback claro. Usar dentro de um container
+ * `relative` (cobre via inset-0).
+ */
+export function MediaUnavailable({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-muted text-muted-foreground p-2 text-center">
+      <ImageOff className={compact ? "w-4 h-4" : "w-6 h-6"} />
+      {!compact && (
+        <span className="text-tiny">Mídia indisponível — recarregue</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/journey/StagePhotoGallery.tsx
+++ b/src/components/journey/StagePhotoGallery.tsx
@@ -1,10 +1,12 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { Camera, Plus, Trash2, X, Loader2, ImageIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useStagePhotos, StagePhoto } from "@/hooks/useStagePhotos";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { MediaUnavailable } from "@/components/MediaUnavailable";
+import { logWarn } from "@/lib/errorLogger";
 
 interface StagePhotoGalleryProps {
   stageId: string;
@@ -30,6 +32,27 @@ export function StagePhotoGallery({
   const [lightbox, setLightbox] = useState<StagePhoto | null>(null);
   const [editingCaption, setEditingCaption] = useState<string | null>(null);
   const [captionValue, setCaptionValue] = useState("");
+
+  // Track media that failed to load so we can show a clear placeholder instead
+  // of the browser's broken-image icon (signed URL expired / RLS / bad path).
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+  const photosKey = photos.map((p) => `${p.id}::${p.url}`).join("|");
+  useEffect(() => {
+    setBrokenIds(new Set());
+  }, [photosKey]);
+  const markBroken = useCallback((photo: StagePhoto) => {
+    logWarn("Stage gallery media failed to load", {
+      component: "StagePhotoGallery",
+      photoId: photo.id,
+      url: photo.url,
+    });
+    setBrokenIds((prev) => {
+      if (prev.has(photo.id)) return prev;
+      const next = new Set(prev);
+      next.add(photo.id);
+      return next;
+    });
+  }, []);
 
   const handleFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -96,12 +119,17 @@ export function StagePhotoGallery({
               className="group relative aspect-square rounded-lg overflow-hidden border border-border bg-muted cursor-pointer"
               onClick={() => setLightbox(photo)}
             >
-              <img
-                src={photo.url}
-                alt={photo.caption || "Foto da etapa"}
-                className="h-full w-full object-cover transition-transform group-hover:scale-105"
-                loading="lazy"
-              />
+              {brokenIds.has(photo.id) ? (
+                <MediaUnavailable compact />
+              ) : (
+                <img
+                  src={photo.url}
+                  alt={photo.caption || "Foto da etapa"}
+                  className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                  loading="lazy"
+                  onError={() => markBroken(photo)}
+                />
+              )}
               {isAdmin && (
                 <button
                   className="absolute top-1 right-1 bg-background/80 backdrop-blur-sm rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
@@ -134,11 +162,18 @@ export function StagePhotoGallery({
           <DialogTitle className="sr-only">Visualizar foto</DialogTitle>
           {lightbox && (
             <div className="flex flex-col">
-              <img
-                src={lightbox.url}
-                alt={lightbox.caption || "Foto"}
-                className="w-full max-h-[70vh] object-contain bg-black"
-              />
+              <div className="relative w-full min-h-[200px] bg-black">
+                {brokenIds.has(lightbox.id) ? (
+                  <MediaUnavailable />
+                ) : (
+                  <img
+                    src={lightbox.url}
+                    alt={lightbox.caption || "Foto"}
+                    className="w-full max-h-[70vh] object-contain bg-black"
+                    onError={() => markBroken(lightbox)}
+                  />
+                )}
+              </div>
               <div className="p-4 space-y-2">
                 {editingCaption === lightbox.id ? (
                   <div className="flex gap-2">

--- a/src/components/tabs/PendenciasContent.tsx
+++ b/src/components/tabs/PendenciasContent.tsx
@@ -144,6 +144,14 @@ const PendenciasContent = () => {
         return paths.projeto3D;
       case "approval_exec":
         return paths.executivo;
+      case "decision":
+        // Decisões do cliente são exibidas e tomadas na aba de Relatórios
+        // (ClientDecisionsSection). Quando o item não tem actionUrl específico
+        // (tratado acima), abrimos diretamente a aba de relatórios — o ?tab
+        // garante que a aba correta abra em qualquer entrada (inclusive mobile).
+        return projectId
+          ? `/obra/${projectId}?tab=relatorios`
+          : paths.relatorio;
       default:
         return paths.relatorio;
     }

--- a/src/hooks/use3DVersions.ts
+++ b/src/hooks/use3DVersions.ts
@@ -239,6 +239,8 @@ export function use3DImages(versionId: string | undefined) {
     },
     enabled: !!versionId,
     staleTime: 5 * 60 * 1000,
+    // Re-assina as signed URLs (TTL 1h) antes de expirarem com a aba aberta.
+    refetchInterval: 45 * 60 * 1000, // 45 min
   });
 }
 

--- a/src/hooks/useDocuments.ts
+++ b/src/hooks/useDocuments.ts
@@ -65,48 +65,34 @@ async function fetchDocuments(projectId: string): Promise<ProjectDocument[]> {
   const results = await Promise.allSettled(
     (data || []).map(async (doc) => {
       try {
-        // Try signed URL first
+        // project-documents é um bucket PRIVADO — só a signed URL funciona.
+        // getPublicUrl devolve uma URL 400/403 para bucket privado, então não
+        // há fallback útil: em caso de falha, registra o erro e devolve o doc
+        // sem URL (a UI já trata `!url` com "pré-visualização indisponível").
         const { data: urlData, error: urlError } = await supabase.storage
           .from(doc.storage_bucket)
           .createSignedUrl(doc.storage_path, 3600); // 1 hour
 
-        let url = urlData?.signedUrl;
-
-        // Fallback to public URL if signed URL fails (bucket is public)
-        if (!url || urlError) {
-          console.warn(
-            `[Documents] Signed URL failed for ${doc.name}, trying public URL:`,
+        if (urlError || !urlData?.signedUrl) {
+          console.error(
+            `[Documents] Failed to sign ${doc.name} (bucket: ${doc.storage_bucket}, path: ${doc.storage_path}):`,
             urlError?.message,
           );
-          const { data: publicData } = supabase.storage
-            .from(doc.storage_bucket)
-            .getPublicUrl(doc.storage_path);
-          url = publicData?.publicUrl || undefined;
-        }
-
-        if (!url) {
-          console.error(
-            `[Documents] No URL generated for ${doc.name} (bucket: ${doc.storage_bucket}, path: ${doc.storage_path})`,
-          );
         }
 
         return {
           ...doc,
           document_type: doc.document_type as DocumentCategory,
           status: doc.status as DocumentStatus,
-          url,
+          url: urlData?.signedUrl,
         } as ProjectDocument;
       } catch (err) {
-        console.warn(`[Documents] Error fetching URL for ${doc.name}:`, err);
-        // Final fallback to public URL
-        const { data: publicData } = supabase.storage
-          .from(doc.storage_bucket)
-          .getPublicUrl(doc.storage_path);
+        console.error(`[Documents] Error signing URL for ${doc.name}:`, err);
         return {
           ...doc,
           document_type: doc.document_type as DocumentCategory,
           status: doc.status as DocumentStatus,
-          url: publicData?.publicUrl || undefined,
+          url: undefined,
         } as ProjectDocument;
       }
     }),
@@ -148,6 +134,9 @@ export function useDocuments(projectId: string | undefined) {
     staleTime: 2 * 60 * 1000, // 2 minutes — keep fresh so new uploads appear quickly
     gcTime: 30 * 60 * 1000, // 30 minutes (signed URLs valid for 1 hour)
     refetchOnWindowFocus: true, // Ensure documents refresh when user switches tabs
+    // Re-sign URLs before the 1h TTL expires even if the tab stays open (focused)
+    // on a long document — without this the viewer's URL would 403 after 1h.
+    refetchInterval: 45 * 60 * 1000, // 45 minutes
     placeholderData: (previousData) => previousData, // Keep previous data while refetching
     // Signed URLs expire in 1h. Persisting them to localStorage would restore
     // expired URLs after a reload, breaking previews. Always refetch fresh.
@@ -314,28 +303,29 @@ export function useDocument(documentId: string | undefined) {
       if (error) throw error;
       if (!data) return null;
 
-      // Get signed URL, fallback to public URL
+      // project-documents é privado — só a signed URL funciona (sem fallback público).
       const { data: urlData, error: urlError } = await supabase.storage
         .from(data.storage_bucket)
         .createSignedUrl(data.storage_path, 3600);
 
-      let url = urlData?.signedUrl;
-      if (!url || urlError) {
-        const { data: publicData } = supabase.storage
-          .from(data.storage_bucket)
-          .getPublicUrl(data.storage_path);
-        url = publicData?.publicUrl || undefined;
+      if (urlError || !urlData?.signedUrl) {
+        console.error(
+          `[Documents] Failed to sign ${data.name} (bucket: ${data.storage_bucket}):`,
+          urlError?.message,
+        );
       }
 
       return {
         ...data,
         document_type: data.document_type as DocumentCategory,
         status: data.status as DocumentStatus,
-        url,
+        url: urlData?.signedUrl,
       } as ProjectDocument;
     },
     enabled: !!documentId,
     staleTime: 2 * 60 * 1000, // 2 minutes (match list query)
+    // Re-sign before the 1h TTL expires while the viewer stays open.
+    refetchInterval: 45 * 60 * 1000, // 45 minutes
     // Signed URL expires in 1h — never restore from localStorage.
     meta: { persist: false },
   });

--- a/src/hooks/useExecutivoVersions.ts
+++ b/src/hooks/useExecutivoVersions.ts
@@ -191,6 +191,8 @@ export function useExecutivoFile(versionId: string | undefined) {
     },
     enabled: !!versionId,
     staleTime: 50 * 60 * 1000,
+    // Re-assina a signed URL (TTL 1h) antes de expirar com a aba aberta.
+    refetchInterval: 45 * 60 * 1000, // 45 min
   });
 }
 

--- a/src/hooks/useFormalizacoes.ts
+++ b/src/hooks/useFormalizacoes.ts
@@ -354,6 +354,11 @@ export function useAcknowledge() {
       partyId: string;
       signatureText?: string;
     }) => {
+      // Inicia a busca do IP em paralelo às leituras abaixo para que o roundtrip
+      // da edge function não adicione latência sequencial no momento crítico da
+      // assinatura. O IP continua entrando no hash exatamente como antes.
+      const clientIpPromise = getClientIp();
+
       const user = (await supabase.auth.getUser()).data.user;
 
       // Get formalization data for domain event
@@ -370,7 +375,7 @@ export function useAcknowledge() {
         .eq("id", partyId)
         .single();
 
-      const clientIp = await getClientIp();
+      const clientIp = await clientIpPromise;
       const timestamp = new Date().toISOString();
 
       // Create signature hash

--- a/src/hooks/useJourneyTeamMembers.ts
+++ b/src/hooks/useJourneyTeamMembers.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import {
+  resolveProjectDocumentPath,
+  signProjectDocumentUrls,
+} from "@/lib/projectDocumentUrl";
 
 export interface JourneyTeamMember {
   id: string;
@@ -45,7 +49,15 @@ export function useJourneyTeamMembers(
         .eq("stage_context", stageContext)
         .order("sort_order", { ascending: true });
       if (error) throw error;
-      return (data || []) as JourneyTeamMember[];
+      const members = (data || []) as JourneyTeamMember[];
+      // photo_url guarda o PATH no bucket privado — assina sob demanda p/ exibir.
+      const signed = await signProjectDocumentUrls(
+        members.map((m) => m.photo_url),
+      );
+      return members.map((m) => ({
+        ...m,
+        photo_url: m.photo_url ? (signed.get(m.photo_url) ?? m.photo_url) : null,
+      }));
     },
     enabled: !!projectId,
   });
@@ -67,6 +79,10 @@ export function useJourneyTeamMembers(
         .from("journey_team_members")
         .insert({
           ...input,
+          // Persiste o PATH de storage, nunca uma URL (assinada/pública).
+          photo_url: input.photo_url
+            ? (resolveProjectDocumentPath(input.photo_url) ?? input.photo_url)
+            : input.photo_url,
           sort_order: sortOrder,
           stage_context: input.stage_context || stageContext,
         })
@@ -87,6 +103,12 @@ export function useJourneyTeamMembers(
       id,
       ...updates
     }: Partial<JourneyTeamMember> & { id: string }) => {
+      // Nunca persiste uma URL em photo_url — normaliza para o PATH de storage.
+      if ("photo_url" in updates) {
+        updates.photo_url = updates.photo_url
+          ? (resolveProjectDocumentPath(updates.photo_url) ?? updates.photo_url)
+          : updates.photo_url;
+      }
       const { data, error } = await supabase
         .from("journey_team_members")
         .update(updates)
@@ -135,11 +157,13 @@ export function useJourneyTeamMembers(
         .upload(filePath, file, { upsert: true });
       if (uploadError) throw uploadError;
 
-      const {
-        data: { publicUrl },
-      } = supabase.storage.from("project-documents").getPublicUrl(filePath);
+      // Bucket privado: devolve uma signed URL para preview imediato. O path é
+      // persistido (normalizado no insert/update) e re-assinado na leitura.
+      const { data: signed } = await supabase.storage
+        .from("project-documents")
+        .createSignedUrl(filePath, 60 * 60);
 
-      return publicUrl;
+      return signed?.signedUrl ?? filePath;
     },
     onError: () => toast.error("Erro ao enviar foto"),
   });

--- a/src/hooks/useProject3DPhotos.ts
+++ b/src/hooks/useProject3DPhotos.ts
@@ -50,6 +50,9 @@ export function useProject3DPhotos(projectId: string | undefined) {
     },
     enabled: !!projectId,
     staleTime: 60_000,
+    // Re-assina as signed URLs (TTL 1h) antes de expirarem, mesmo com a aba
+    // aberta e ociosa por mais de uma hora.
+    refetchInterval: 45 * 60 * 1000, // 45 min
   });
 
   const uploadMutation = useMutation({

--- a/src/hooks/useProjectJourney.ts
+++ b/src/hooks/useProjectJourney.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import type { JourneyCSM } from "@/components/journey/JourneyCSMSection";
+import { signProjectDocumentUrl } from "@/lib/projectDocumentUrl";
 
 export type JourneyStageStatus =
   | "pending"
@@ -114,10 +115,16 @@ async function fetchProjectJourney(
     todos: todosByStage.get(stage.id) || [],
   }));
 
+  const csm = csmResult.data as JourneyCSM | null;
+  if (csm?.photo_url) {
+    // photo_url guarda o PATH no bucket privado — assina sob demanda p/ exibir.
+    csm.photo_url = (await signProjectDocumentUrl(csm.photo_url)) ?? csm.photo_url;
+  }
+
   return {
     hero: heroResult.data as JourneyHero | null,
     footer: footerResult.data as JourneyFooter | null,
-    csm: csmResult.data as JourneyCSM | null,
+    csm,
     stages,
   };
 }

--- a/src/hooks/useStagePhotos.ts
+++ b/src/hooks/useStagePhotos.ts
@@ -50,6 +50,9 @@ export function useStagePhotos(stageId: string, projectId: string) {
     },
     enabled: !!stageId,
     staleTime: 60_000,
+    // Re-assina as signed URLs (TTL 1h) antes de expirarem, mesmo com a aba
+    // aberta e ociosa por mais de uma hora.
+    refetchInterval: 45 * 60 * 1000, // 45 min
   });
 
   const uploadMutation = useMutation({

--- a/src/hooks/useTeamContacts.ts
+++ b/src/hooks/useTeamContacts.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import {
+  resolveProjectDocumentPath,
+  signProjectDocumentUrls,
+} from "@/lib/projectDocumentUrl";
 
 export interface TeamContact {
   id: string;
@@ -74,7 +78,13 @@ export function useTeamContacts(projectId: string | undefined) {
         .order("role_type");
 
       if (error) throw error;
-      return (data || []) as TeamContact[];
+      const rows = (data || []) as TeamContact[];
+      // photo_url guarda o PATH no bucket privado — assina sob demanda p/ exibir.
+      const signed = await signProjectDocumentUrls(rows.map((c) => c.photo_url));
+      return rows.map((c) => ({
+        ...c,
+        photo_url: c.photo_url ? (signed.get(c.photo_url) ?? c.photo_url) : null,
+      }));
     },
     enabled: !!projectId,
   });
@@ -109,7 +119,11 @@ export function useTeamContacts(projectId: string | undefined) {
             phone: contact.phone,
             email: contact.email,
             crea: contact.crea,
-            photo_url: contact.photo_url,
+            // Persiste o PATH de storage, nunca uma URL (assinada/pública).
+            photo_url: contact.photo_url
+              ? (resolveProjectDocumentPath(contact.photo_url) ??
+                contact.photo_url)
+              : contact.photo_url,
           },
           { onConflict: "project_id,role_type" },
         )
@@ -148,11 +162,13 @@ export function useTeamContacts(projectId: string | undefined) {
 
       if (uploadError) throw uploadError;
 
-      const {
-        data: { publicUrl },
-      } = supabase.storage.from("project-documents").getPublicUrl(filePath);
+      // Bucket privado: signed URL para preview imediato. O path é persistido
+      // (normalizado no upsert) e re-assinado na leitura.
+      const { data: signed } = await supabase.storage
+        .from("project-documents")
+        .createSignedUrl(filePath, 60 * 60);
 
-      return publicUrl;
+      return signed?.signedUrl ?? filePath;
     },
     onError: (error) => {
       console.error("Error uploading photo:", error);

--- a/src/infra/repositories/journey.repository.ts
+++ b/src/infra/repositories/journey.repository.ts
@@ -11,6 +11,7 @@ import {
   type RepositoryResult,
   type RepositoryListResult,
 } from "./base.repository";
+import { resolveProjectDocumentPath } from "@/lib/projectDocumentUrl";
 
 // ============================================================================
 // Types
@@ -150,9 +151,11 @@ export async function updateCSMPhoto(
   photoUrl: string,
 ): Promise<RepositoryResult<null>> {
   return executeQuery(async () => {
+    // Persiste o PATH de storage, nunca uma URL (assinada/pública).
+    const stored = resolveProjectDocumentPath(photoUrl) ?? photoUrl;
     const { error } = await supabase
       .from("journey_csm")
-      .update({ photo_url: photoUrl })
+      .update({ photo_url: stored })
       .eq("id", csmId);
     return { data: null, error };
   });
@@ -177,11 +180,13 @@ export async function uploadCSMPhoto(
     return null;
   }
 
-  const { data } = supabase.storage
+  // Bucket privado: devolve uma signed URL para preview imediato. updateCSMPhoto
+  // normaliza para o PATH ao persistir, e a leitura re-assina sob demanda.
+  const { data } = await supabase.storage
     .from("project-documents")
-    .getPublicUrl(path);
+    .createSignedUrl(path, 60 * 60);
 
-  return data.publicUrl;
+  return data?.signedUrl ?? path;
 }
 
 /**

--- a/src/lib/projectDocumentUrl.ts
+++ b/src/lib/projectDocumentUrl.ts
@@ -1,0 +1,83 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Helpers para fotos guardadas no bucket PRIVADO `project-documents`
+ * (fotos de membros de equipe, contatos e CSM).
+ *
+ * Regra: persistimos o PATH de storage em `photo_url`, nunca uma URL. URLs
+ * assinadas expiram (issue #80 Bug 1) e URLs públicas não funcionam em bucket
+ * privado (issue #82 Bug 1). A URL para exibição é assinada sob demanda na
+ * leitura. Dados legados podem ter uma URL pública/assinada antiga apontando
+ * para o bucket — extraímos o path dela.
+ */
+const BUCKET = "project-documents";
+const SIGNED_TTL_SECONDS = 60 * 60; // 1h
+
+/** Normaliza um valor guardado (path puro ou URL legada) para o PATH de storage. */
+export function resolveProjectDocumentPath(
+  stored: string | null | undefined,
+): string | null {
+  if (!stored) return null;
+  if (stored.startsWith("blob:") || stored.startsWith("data:")) return null;
+
+  const marker = `/${BUCKET}/`;
+  const idx = stored.indexOf(marker);
+  if (idx !== -1) {
+    const tail = stored.slice(idx + marker.length);
+    const q = tail.indexOf("?");
+    return q === -1 ? tail : tail.slice(0, q);
+  }
+
+  // Sem marcador do bucket e não é http(s) → assume que já é um path de storage.
+  return stored.startsWith("http") ? null : stored;
+}
+
+/** Assina um único valor (path ou URL legada) em uma signed URL fresca. */
+export async function signProjectDocumentUrl(
+  stored: string | null | undefined,
+): Promise<string | null> {
+  const path = resolveProjectDocumentPath(stored);
+  if (!path) return null;
+  const { data } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(path, SIGNED_TTL_SECONDS);
+  return data?.signedUrl ?? null;
+}
+
+/**
+ * Assina vários valores de uma vez (batch). Devolve um Map keyed pelo valor
+ * ORIGINAL passado, para o chamador remapear cada registro à sua signed URL.
+ */
+export async function signProjectDocumentUrls(
+  values: (string | null | undefined)[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+
+  // Mapeia path -> valores originais que resolvem para esse path.
+  const pathToOriginals = new Map<string, string[]>();
+  for (const v of values) {
+    if (!v) continue;
+    const path = resolveProjectDocumentPath(v);
+    if (!path) continue;
+    const arr = pathToOriginals.get(path) ?? [];
+    arr.push(v);
+    pathToOriginals.set(path, arr);
+  }
+
+  const paths = Array.from(pathToOriginals.keys());
+  if (paths.length === 0) return out;
+
+  const { data } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrls(paths, SIGNED_TTL_SECONDS);
+  if (!data) return out;
+
+  for (const item of data) {
+    if (item.signedUrl && item.path) {
+      for (const original of pathToOriginals.get(item.path) ?? []) {
+        out.set(original, item.signedUrl);
+      }
+    }
+  }
+  return out;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -131,6 +131,10 @@ const Index = () => {
     // Only restore when the user landed on the project root — not on a
     // deep-linked schedule/relatório/etc. or already on a bottom-nav route.
     if (location.pathname !== `/obra/${projectId}`) return;
+    // A deep-link carrying an explicit ?tab= (e.g. the report-published
+    // notification → ?tab=relatorios) must win over the persisted bottom-nav
+    // slot — otherwise the restore would immediately navigate away from it.
+    if (searchParams.get("tab")) return;
     const slot = readMobileNavSlot(projectId);
     if (!slot) return;
     const target = pathForMobileNavSlot(projectId, slot);
@@ -141,7 +145,7 @@ const Index = () => {
       reason: "persisted_slot_restore",
     });
     navigate(target, { replace: true });
-  }, [isMobile, projectId, location.pathname, navigate]);
+  }, [isMobile, projectId, location.pathname, navigate, searchParams]);
 
   // Mobile sync: route-only tabs (financeiro/documentos/formalizacoes/pendencias)
   // live in the bottom nav as standalone pages. If a stale activeTab still

--- a/src/pages/Projeto3D.tsx
+++ b/src/pages/Projeto3D.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Camera, Plus, Trash2, X, Loader2, ImageIcon, Box } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,8 @@ import { useUserRole } from "@/hooks/useUserRole";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useProject3DPhotos, Project3DPhoto } from "@/hooks/useProject3DPhotos";
 import { cn } from "@/lib/utils";
+import { MediaUnavailable } from "@/components/MediaUnavailable";
+import { logWarn } from "@/lib/errorLogger";
 
 const Projeto3D = () => {
   const { projectId } = useParams();
@@ -27,6 +29,27 @@ const Projeto3D = () => {
   const [lightbox, setLightbox] = useState<Project3DPhoto | null>(null);
   const [editingCaption, setEditingCaption] = useState<string | null>(null);
   const [captionValue, setCaptionValue] = useState("");
+
+  // Broken-media tracking: show a clear placeholder instead of the browser's
+  // broken-image icon when a signed URL expires / RLS blocks / path is bad.
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+  const photosKey = photos.map((p) => `${p.id}::${p.url}`).join("|");
+  useEffect(() => {
+    setBrokenIds(new Set());
+  }, [photosKey]);
+  const markBroken = useCallback((photo: Project3DPhoto) => {
+    logWarn("3D gallery media failed to load", {
+      component: "Projeto3D",
+      photoId: photo.id,
+      url: photo.url,
+    });
+    setBrokenIds((prev) => {
+      if (prev.has(photo.id)) return prev;
+      const next = new Set(prev);
+      next.add(photo.id);
+      return next;
+    });
+  }, []);
 
   const handleFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -168,12 +191,17 @@ const Projeto3D = () => {
                       className="group relative aspect-square rounded-lg overflow-hidden border border-border bg-muted cursor-pointer"
                       onClick={() => setLightbox(photo)}
                     >
-                      <img
-                        src={photo.url}
-                        alt={photo.caption || "Foto do Projeto 3D"}
-                        className="h-full w-full object-cover transition-transform group-hover:scale-105"
-                        loading="lazy"
-                      />
+                      {brokenIds.has(photo.id) ? (
+                        <MediaUnavailable compact />
+                      ) : (
+                        <img
+                          src={photo.url}
+                          alt={photo.caption || "Foto do Projeto 3D"}
+                          className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                          loading="lazy"
+                          onError={() => markBroken(photo)}
+                        />
+                      )}
                       {isStaff && (
                         <button
                           className="absolute top-1.5 right-1.5 bg-background/80 backdrop-blur-sm rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
@@ -213,11 +241,18 @@ const Projeto3D = () => {
           </DialogTitle>
           {lightbox && (
             <div className="flex flex-col">
-              <img
-                src={lightbox.url}
-                alt={lightbox.caption || "Foto"}
-                className="w-full max-h-[75vh] object-contain bg-black"
-              />
+              <div className="relative w-full min-h-[200px] bg-black">
+                {brokenIds.has(lightbox.id) ? (
+                  <MediaUnavailable />
+                ) : (
+                  <img
+                    src={lightbox.url}
+                    alt={lightbox.caption || "Foto"}
+                    className="w-full max-h-[75vh] object-contain bg-black"
+                    onError={() => markBroken(lightbox)}
+                  />
+                )}
+              </div>
               <div className="p-4 space-y-2">
                 {isStaff && editingCaption === lightbox.id ? (
                   <div className="flex gap-2">

--- a/supabase/migrations/20260625130000_fix_storage_rls_uuid_cast_and_missing_policies.sql
+++ b/supabase/migrations/20260625130000_fix_storage_rls_uuid_cast_and_missing_policies.sql
@@ -11,8 +11,10 @@
 --
 -- Correção:
 --   1) Helper genérico `storage_path_has_project_access` (modelo project_*),
---      que engole o cast inválido e ainda aceita project_id no segmento 1 ou 2
---      (layouts legados), espelhando `weekly_reports_path_has_access`.
+--      que engole o cast inválido. Checa o project_id APENAS no 1º segmento —
+--      buckets compartilhados (ex.: project-documents, que também hospeda
+--      purchases/{project_id}/... staff-only) usam helper DEDICADO para não
+--      super-expor prefixos. Ver project_documents_path_has_access abaixo.
 --   2) Helpers `anexos_path_has_access` / `anexos_path_can_write` (modelo
 --      has_obra_access + get_effective_role) para o bucket `anexos`.
 --   3) Reescrever as policies bugadas dos buckets stage-photos,
@@ -23,7 +25,7 @@
 --      o próprio boleto quando vinculado só por project_customers).
 
 -- =========================================================================
--- 1. Helper genérico (modelo project_*): swallow invalid uuid + 2 layouts
+-- 1. Helper genérico (modelo project_*): swallow invalid uuid, project_id no 1º segmento
 -- =========================================================================
 CREATE OR REPLACE FUNCTION public.storage_path_has_project_access(_user_id uuid, _name text)
 RETURNS boolean
@@ -42,7 +44,56 @@ BEGIN
 
   segs := storage.foldername(_name);
 
-  -- Layout atual: {project_id}/...
+  -- project_id no PRIMEIRO segmento: {project_id}/...
+  -- (stage-photos, project-3d-photos, payment-boletos). NÃO checamos o 2º
+  -- segmento de propósito: em buckets compartilhados isso exporia prefixos
+  -- staff-only (ex.: project-documents → purchases/{project_id}/...).
+  IF array_length(segs, 1) >= 1 AND segs[1] IS NOT NULL THEN
+    BEGIN
+      pid := segs[1]::uuid;
+      RETURN public.has_project_access(_user_id, pid);
+    EXCEPTION WHEN invalid_text_representation THEN
+      RETURN false; -- segmento 1 não é uuid
+    END;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.storage_path_has_project_access(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.storage_path_has_project_access(uuid, text) TO authenticated;
+
+-- Helper dedicado do bucket COMPARTILHADO `project-documents`. Esse bucket
+-- hospeda conteúdo do cliente E conteúdo staff-only no MESMO bucket, separados
+-- por prefixo:
+--   * {project_id}/...                 -> documentos/contratos/plantas/orçamento
+--                                          e fotos de contato ({pid}/team/...)  [cliente]
+--   * team-photos/{project_id}/...     -> fotos de membros de equipe            [cliente]
+--   * csm-photos/{project_id}/...      -> foto do CSM                           [cliente]
+--   * purchases/{project_id}/...       -> compras/NF/boletos                    [STAFF]
+-- O helper genérico (1º segmento) cobre o layout {project_id}/..., mas as fotos
+-- de equipe/CSM têm o project_id no 2º segmento. Liberamos o 2º segmento APENAS
+-- para esses prefixos voltados ao cliente (allowlist) — purchases continua
+-- negado para clientes (staff acessa pelo is_staff na policy).
+CREATE OR REPLACE FUNCTION public.project_documents_path_has_access(_user_id uuid, _name text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  segs text[];
+  pid uuid;
+BEGIN
+  IF _name IS NULL THEN
+    RETURN false;
+  END IF;
+
+  segs := storage.foldername(_name);
+
+  -- Root: {project_id}/... (documentos, contratos, fotos de contato)
   IF array_length(segs, 1) >= 1 AND segs[1] IS NOT NULL THEN
     BEGIN
       pid := segs[1]::uuid;
@@ -50,12 +101,14 @@ BEGIN
         RETURN true;
       END IF;
     EXCEPTION WHEN invalid_text_representation THEN
-      NULL; -- segmento 1 não é uuid: cai pro próximo
+      NULL; -- não é uuid (ex.: 'purchases', 'team-photos'): avalia abaixo
     END;
   END IF;
 
-  -- Layout legado: {algo}/{project_id}/...
-  IF array_length(segs, 1) >= 2 AND segs[2] IS NOT NULL THEN
+  -- Prefixos de FOTO voltados ao cliente: team-photos/{pid}/..., csm-photos/{pid}/...
+  IF array_length(segs, 1) >= 2
+     AND segs[1] IN ('team-photos', 'csm-photos')
+     AND segs[2] IS NOT NULL THEN
     BEGIN
       pid := segs[2]::uuid;
       IF public.has_project_access(_user_id, pid) THEN
@@ -70,8 +123,8 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.storage_path_has_project_access(uuid, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.storage_path_has_project_access(uuid, text) TO authenticated;
+REVOKE ALL ON FUNCTION public.project_documents_path_has_access(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.project_documents_path_has_access(uuid, text) TO authenticated;
 
 -- =========================================================================
 -- 2. Helpers do bucket `anexos` (modelo has_obra_access / get_effective_role)
@@ -180,14 +233,16 @@ USING (
 );
 
 -- =========================================================================
--- 4. project-documents — SELECT (staff bypass mantido)
+-- 4. project-documents — SELECT (staff bypass + helper dedicado por prefixo)
+--    Cliente vê documentos/contratos do projeto e fotos de equipe/CSM, mas NÃO
+--    os arquivos staff-only de purchases/{project_id}/...
 -- =========================================================================
 DROP POLICY IF EXISTS "Project members can view project documents" ON storage.objects;
 CREATE POLICY "Project members can view project documents"
 ON storage.objects FOR SELECT
 USING (
   bucket_id = 'project-documents'
-  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+  AND (is_staff(auth.uid()) OR public.project_documents_path_has_access(auth.uid(), name))
 );
 
 -- =========================================================================

--- a/supabase/migrations/20260625130000_fix_storage_rls_uuid_cast_and_missing_policies.sql
+++ b/supabase/migrations/20260625130000_fix_storage_rls_uuid_cast_and_missing_policies.sql
@@ -1,0 +1,276 @@
+-- Issue #82 — P0 #2, P0 #3, P2 #7
+--
+-- Bug: várias policies de storage.objects fazem cast direto
+--   ((storage.foldername(name))[N])::uuid
+-- dentro do USING/WITH CHECK. Quando o primeiro segmento do path não é um UUID
+-- (paths legados, uploads manuais, ou bug transitório do frontend), o cast
+-- levanta `invalid_text_representation` e ABORTA a query inteira em vez de
+-- avaliar para `false` — o cliente vê galeria vazia / download quebrado, e o
+-- upload falha. Mesma família já corrigida para `weekly-reports` em
+-- 20260509184127 / 20260517120000 via helper SECURITY DEFINER.
+--
+-- Correção:
+--   1) Helper genérico `storage_path_has_project_access` (modelo project_*),
+--      que engole o cast inválido e ainda aceita project_id no segmento 1 ou 2
+--      (layouts legados), espelhando `weekly_reports_path_has_access`.
+--   2) Helpers `anexos_path_has_access` / `anexos_path_can_write` (modelo
+--      has_obra_access + get_effective_role) para o bucket `anexos`.
+--   3) Reescrever as policies bugadas dos buckets stage-photos,
+--      project-documents, project-3d-photos, anexos e payment-boletos para usar
+--      os helpers, e adicionar os UPDATE faltantes (stage-photos, 3d-photos).
+--   4) payment-boletos SELECT passa a usar has_project_access (cobre clientes
+--      legados de project_customers), corrigindo o P0 #3 (cliente não baixava
+--      o próprio boleto quando vinculado só por project_customers).
+
+-- =========================================================================
+-- 1. Helper genérico (modelo project_*): swallow invalid uuid + 2 layouts
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.storage_path_has_project_access(_user_id uuid, _name text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  segs text[];
+  pid uuid;
+BEGIN
+  IF _name IS NULL THEN
+    RETURN false;
+  END IF;
+
+  segs := storage.foldername(_name);
+
+  -- Layout atual: {project_id}/...
+  IF array_length(segs, 1) >= 1 AND segs[1] IS NOT NULL THEN
+    BEGIN
+      pid := segs[1]::uuid;
+      IF public.has_project_access(_user_id, pid) THEN
+        RETURN true;
+      END IF;
+    EXCEPTION WHEN invalid_text_representation THEN
+      NULL; -- segmento 1 não é uuid: cai pro próximo
+    END;
+  END IF;
+
+  -- Layout legado: {algo}/{project_id}/...
+  IF array_length(segs, 1) >= 2 AND segs[2] IS NOT NULL THEN
+    BEGIN
+      pid := segs[2]::uuid;
+      IF public.has_project_access(_user_id, pid) THEN
+        RETURN true;
+      END IF;
+    EXCEPTION WHEN invalid_text_representation THEN
+      NULL;
+    END;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.storage_path_has_project_access(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.storage_path_has_project_access(uuid, text) TO authenticated;
+
+-- =========================================================================
+-- 2. Helpers do bucket `anexos` (modelo has_obra_access / get_effective_role)
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.anexos_path_has_access(_name text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  segs text[];
+  oid uuid;
+BEGIN
+  IF _name IS NULL THEN
+    RETURN false;
+  END IF;
+  segs := storage.foldername(_name);
+  IF array_length(segs, 1) >= 1 AND segs[1] IS NOT NULL THEN
+    BEGIN
+      oid := segs[1]::uuid;
+      RETURN public.is_admin_v2() OR public.has_obra_access(oid);
+    EXCEPTION WHEN invalid_text_representation THEN
+      RETURN false;
+    END;
+  END IF;
+  RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.anexos_path_has_access(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.anexos_path_has_access(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.anexos_path_can_write(_name text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  segs text[];
+  oid uuid;
+BEGIN
+  IF _name IS NULL THEN
+    RETURN false;
+  END IF;
+  segs := storage.foldername(_name);
+  IF array_length(segs, 1) >= 1 AND segs[1] IS NOT NULL THEN
+    BEGIN
+      oid := segs[1]::uuid;
+      RETURN public.is_admin_v2()
+        OR (
+          public.has_obra_access(oid)
+          AND public.get_effective_role(oid) NOT IN ('customer', 'cliente')
+        );
+    EXCEPTION WHEN invalid_text_representation THEN
+      RETURN false;
+    END;
+  END IF;
+  RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.anexos_path_can_write(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.anexos_path_can_write(text) TO authenticated;
+
+-- =========================================================================
+-- 3. stage-photos — SELECT / INSERT / DELETE + UPDATE (faltava)
+-- =========================================================================
+DROP POLICY IF EXISTS "Project members can view stage photos" ON storage.objects;
+CREATE POLICY "Project members can view stage photos"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'stage-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can upload stage photos" ON storage.objects;
+CREATE POLICY "Project members can upload stage photos"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'stage-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can update stage photos" ON storage.objects;
+CREATE POLICY "Project members can update stage photos"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'stage-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+)
+WITH CHECK (
+  bucket_id = 'stage-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can delete stage photos" ON storage.objects;
+CREATE POLICY "Project members can delete stage photos"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'stage-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+-- =========================================================================
+-- 4. project-documents — SELECT (staff bypass mantido)
+-- =========================================================================
+DROP POLICY IF EXISTS "Project members can view project documents" ON storage.objects;
+CREATE POLICY "Project members can view project documents"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'project-documents'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+-- =========================================================================
+-- 5. project-3d-photos — SELECT / INSERT / DELETE + UPDATE (faltava)
+-- =========================================================================
+DROP POLICY IF EXISTS "Project members can view 3D photo files" ON storage.objects;
+CREATE POLICY "Project members can view 3D photo files"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'project-3d-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can upload 3D photo files" ON storage.objects;
+CREATE POLICY "Project members can upload 3D photo files"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'project-3d-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can update 3D photo files" ON storage.objects;
+CREATE POLICY "Project members can update 3D photo files"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'project-3d-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+)
+WITH CHECK (
+  bucket_id = 'project-3d-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+DROP POLICY IF EXISTS "Project members can delete 3D photo files" ON storage.objects;
+CREATE POLICY "Project members can delete 3D photo files"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'project-3d-photos'
+  AND (is_staff(auth.uid()) OR public.storage_path_has_project_access(auth.uid(), name))
+);
+
+-- =========================================================================
+-- 6. anexos — SELECT / INSERT / UPDATE (DELETE é admin-only, fica)
+--    Remove as duas INSERT existentes (upload_anexos_bucket e a duplicata
+--    "Staff can upload anexos") e recria uma única.
+-- =========================================================================
+DROP POLICY IF EXISTS "read_anexos_bucket" ON storage.objects;
+CREATE POLICY "read_anexos_bucket"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'anexos'
+  AND public.anexos_path_has_access(name)
+);
+
+DROP POLICY IF EXISTS "upload_anexos_bucket" ON storage.objects;
+DROP POLICY IF EXISTS "Staff can upload anexos" ON storage.objects;
+CREATE POLICY "upload_anexos_bucket"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'anexos'
+  AND public.anexos_path_can_write(name)
+);
+
+DROP POLICY IF EXISTS "update_anexos_bucket" ON storage.objects;
+CREATE POLICY "update_anexos_bucket"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'anexos'
+  AND public.anexos_path_can_write(name)
+)
+WITH CHECK (
+  bucket_id = 'anexos'
+  AND public.anexos_path_can_write(name)
+);
+
+-- =========================================================================
+-- 7. payment-boletos — SELECT passa a usar has_project_access
+--    (cobre clientes legados vinculados só por project_customers).
+-- =========================================================================
+DROP POLICY IF EXISTS "Users can view boletos for their projects" ON storage.objects;
+CREATE POLICY "Users can view boletos for their projects"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'payment-boletos'
+  AND public.storage_path_has_project_access(auth.uid(), name)
+);

--- a/supabase/migrations/20260625140000_notify_weekly_report_include_customer_role.sql
+++ b/supabase/migrations/20260625140000_notify_weekly_report_include_customer_role.sql
@@ -1,0 +1,47 @@
+-- Follow-up de 20260625120000 (PR #90): a query de destinatários da notificação
+-- de relatório só incluía project_members com role 'viewer'. Mas o enum
+-- project_role também tem 'customer' (exposto como "Cliente" no editor de
+-- equipe). Um cliente vinculado apenas via project_members com role 'customer'
+-- (sem linha legada em project_customers) não recebia a notificação.
+--
+-- Correção: incluir role IN ('viewer', 'customer') na query de destinatários.
+
+CREATE OR REPLACE FUNCTION public.notify_weekly_report_published()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_project_name TEXT;
+BEGIN
+  IF TG_OP = 'INSERT' OR (TG_OP = 'UPDATE' AND OLD.data IS DISTINCT FROM NEW.data AND NEW.data IS NOT NULL) THEN
+    SELECT name INTO v_project_name FROM projects WHERE id = NEW.project_id;
+
+    FOR v_user_id IN
+      -- Clientes legados vinculados por project_customers
+      SELECT customer_user_id AS uid
+      FROM project_customers
+      WHERE project_id = NEW.project_id AND customer_user_id IS NOT NULL
+      UNION
+      -- Clientes vinculados pelo sistema unificado (project_members nas roles
+      -- de cliente: 'viewer' e 'customer')
+      SELECT user_id AS uid
+      FROM project_members
+      WHERE project_id = NEW.project_id AND role IN ('viewer', 'customer')
+    LOOP
+      PERFORM create_notification(
+        v_user_id,
+        'report_published',
+        'Relatório Semana ' || NEW.week_number || ' disponível',
+        'O relatório semanal de ' || COALESCE(v_project_name, 'seu projeto') || ' está pronto.',
+        NEW.project_id,
+        '/obra/' || NEW.project_id || '?tab=relatorios'
+      );
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
Corrige os 9 bugs da issue #82 (acesso do cliente ao portal/obra). As issues #80 e #81 já estavam resolvidas/mergeadas (verificado); este PR cobre a #82.

## Bugs corrigidos (#82)

| # | Prio | Bug | Correção |
|---|---|---|---|
| 1 | P0 | `getPublicUrl` em bucket privado (documentos, fotos de equipe/CSM) | Remove o fallback; só signed URL. Fotos passam a guardar o **path** e são assinadas sob demanda na leitura (sem o anti-padrão de URL assinada gravada — issue #80 Bug 1) |
| 2 | P0 | Cast `::uuid` cru na RLS de `storage.objects` (estoura `invalid_text_representation` e aborta a query) | Helpers `SECURITY DEFINER` (`storage_path_has_project_access`, `anexos_path_has_access/can_write`) + reescrita das policies de `stage-photos`, `project-documents`, `project-3d-photos` e `anexos` |
| 3 | P0 | `payment-boletos` SELECT só checava `project_members` | Passa a usar `has_project_access` — cobre clientes legados de `project_customers` (antes não baixavam o próprio boleto) |
| 4 | P1 | Galerias 3D/etapa sem `onError` | Novo componente `MediaUnavailable` + `onError` em `StagePhotoGallery` e `Projeto3D` |
| 5 | P1 | Signed URLs (TTL 1h) sem re-sign | `refetchInterval` de 45min em `useStagePhotos`, `useProject3DPhotos`, `use3DVersions`, `useExecutivoVersions` |
| 6 | P1 | Documentos sem re-sign após 1h | `refetchInterval` de 45min em `useDocuments` |
| 7 | P2 | Faltavam policies de UPDATE/INSERT em storage | UPDATE (stage/3d) e INSERT/UPDATE (anexos) recriados via helper |
| 8 | P2 | Pendência `decision` caía no default sem destino | Destino explícito → aba Relatórios (`?tab=relatorios`, onde fica o `ClientDecisionsSection`) |
| 9 | P3 | `getClientIp` bloqueia a assinatura | Roda **em paralelo** às leituras (não bloqueia o momento crítico); o IP continua entrando no hash exatamente como antes |

**Nota (#9):** mover a captura de IP totalmente para o servidor exigiria rearquitetar o hash de assinatura (hoje computado no cliente). Optou-se pela melhoria segura (paralelizar) sem alterar a composição do hash.

## Bônus — review do Codex na PR #90 (mergeada)
- `notify_weekly_report_published` passa a notificar `project_members` com role `IN ('viewer','customer')` — antes clientes com role `customer` ficavam de fora.
- O restore do slot do bottom-nav no mobile não sobrescreve mais um deep-link com `?tab=` (ex.: notificação de relatório), garantindo que a aba correta abra.

## Validação
`npm run typecheck` ✓ · `npm run lint` (0 erros) ✓ · `npm run build` ✓ · `npm run test` — **764 testes** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJgb1ZWJdc9oFnri8Hvo19

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJgb1ZWJdc9oFnri8Hvo19)_