### PR TITLE
Fix mobile nav active state on project sub-routes

### DIFF
--- a/src/components/mobile/MobileBottomNav.tsx
+++ b/src/components/mobile/MobileBottomNav.tsx
@@ -106,7 +106,7 @@ export function MobileBottomNav() {
               <NavLink
                 key={slot.id}
                 to={to}
-                end={slot.id === "inicio"}
+                end={slot.end ?? false}
                 onClick={() => {
                   rememberMobileNavSlot(projectId, slot.id);
                   // Tapping "Obra" (the project hub) must take the user back

--- a/src/components/mobile/MobileBottomNav.tsx
+++ b/src/components/mobile/MobileBottomNav.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { NavLink, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useProjectNavigation } from "@/hooks/useProjectNavigation";
 import { usePendencias } from "@/hooks/usePendencias";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -86,6 +86,26 @@ export function MobileBottomNav() {
     return 0;
   };
 
+  /**
+   * Active-tab matching. Computed here (rather than via NavLink's built-in
+   * `end`) because the obra hub needs exact-match *plus* one alias: it must
+   * stay active on `/obra/:id/relatorio`, which renders the same Index page as
+   * `/obra/:id`, while NOT lighting up on the dedicated sub-route tabs.
+   */
+  const isSlotActive = (slot: MobileNavSlot, to: string): boolean => {
+    const path = location.pathname;
+    if (slot.end) {
+      if (path === to) return true;
+      if (slot.matchReportHub) {
+        const id = projectId ?? lastProjectId;
+        if (id && path === `/obra/${id}/relatorio`) return true;
+      }
+      return false;
+    }
+    // Default: active on the route and its descendants (e.g. formalizacoes/nova).
+    return path === to || path.startsWith(to + "/");
+  };
+
   return (
     <>
       <nav
@@ -102,11 +122,12 @@ export function MobileBottomNav() {
             const to = slot.to({ paths, hasProject, projectId, lastProjectId });
             const badge = resolveBadge(slot);
             const Icon = slot.icon;
+            const isActive = isSlotActive(slot, to);
             return (
-              <NavLink
+              <Link
                 key={slot.id}
                 to={to}
-                end={slot.end ?? false}
+                aria-current={isActive ? "page" : undefined}
                 onClick={() => {
                   rememberMobileNavSlot(projectId, slot.id);
                   // Tapping "Obra" (the project hub) must take the user back
@@ -119,64 +140,58 @@ export function MobileBottomNav() {
                     resetProjectHubState(projectId ?? lastProjectId);
                   }
                 }}
-                className={({ isActive }) =>
-                  cn(
-                    "relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 px-1 py-1",
-                    "min-h-[56px] transition-all active:scale-[0.94]",
-                    "focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-primary rounded-lg",
-                    isActive ? "text-primary" : "text-foreground-muted",
-                  )
-                }
+                className={cn(
+                  "relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 px-1 py-1",
+                  "min-h-[56px] transition-all active:scale-[0.94]",
+                  "focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-primary rounded-lg",
+                  isActive ? "text-primary" : "text-foreground-muted",
+                )}
                 aria-label={
                   badge > 0 ? `${slot.label} — ${badge} críticas` : slot.label
                 }
                 title={slot.label}
               >
-                {({ isActive }) => (
-                  <>
-                    {isActive && (
-                      <span
-                        className="absolute -top-px left-1/2 -translate-x-1/2 h-1 w-8 rounded-b-full bg-primary shadow-[0_0_8px_hsl(var(--primary)/0.45)]"
-                        aria-hidden="true"
-                      />
-                    )}
-                    <span
-                      className={cn(
-                        "relative flex items-center justify-center w-12 h-7 rounded-full transition-all duration-200",
-                        isActive
-                          ? "bg-primary/15 ring-1 ring-primary/25"
-                          : "bg-transparent",
-                      )}
-                    >
-                      <Icon
-                        className={cn(
-                          "h-[22px] w-[22px] transition-all",
-                          isActive
-                            ? "text-primary scale-110"
-                            : "text-foreground-muted",
-                        )}
-                        strokeWidth={isActive ? 2.5 : 2}
-                      />
-                      {badge > 0 && (
-                        <span
-                          className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card"
-                          aria-hidden="true"
-                        >
-                          {badge > 99 ? "99+" : badge}
-                        </span>
-                      )}
-                    </span>
-                    <span
-                      className={cn(
-                        "text-[clamp(8px,2.2vw,11px)] leading-[1.05] text-center whitespace-nowrap overflow-visible",
-                        isActive ? "font-semibold text-primary" : "font-medium",
-                      )}
-                    >
-                      {slot.label}
-                    </span>
-                  </>
+                {isActive && (
+                  <span
+                    className="absolute -top-px left-1/2 -translate-x-1/2 h-1 w-8 rounded-b-full bg-primary shadow-[0_0_8px_hsl(var(--primary)/0.45)]"
+                    aria-hidden="true"
+                  />
                 )}
-              </NavLink>
+                <span
+                  className={cn(
+                    "relative flex items-center justify-center w-12 h-7 rounded-full transition-all duration-200",
+                    isActive
+                      ? "bg-primary/15 ring-1 ring-primary/25"
+                      : "bg-transparent",
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      "h-[22px] w-[22px] transition-all",
+                      isActive
+                        ? "text-primary scale-110"
+                        : "text-foreground-muted",
+                    )}
+                    strokeWidth={isActive ? 2.5 : 2}
+                  />
+                  {badge > 0 && (
+                    <span
+                      className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card"
+                      aria-hidden="true"
+                    >
+                      {badge > 99 ? "99+" : badge}
+                    </span>
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    "text-[clamp(8px,2.2vw,11px)] leading-[1.05] text-center whitespace-nowrap overflow-visible",
+                    isActive ? "font-semibold text-primary" : "font-medium",
+                  )}
+                >
+                  {slot.label}
+                </span>
+              </Link>
             );
           })}
 

--- a/src/components/mobile/__tests__/MobileBottomNav.activeState.test.tsx
+++ b/src/components/mobile/__tests__/MobileBottomNav.activeState.test.tsx
@@ -85,4 +85,20 @@ describe("MobileBottomNav — active state on sub-routes", () => {
     const obra = screen.getByRole("link", { name: /^Obra$/i });
     expect(obra).toHaveAttribute("aria-current", "page");
   });
+
+  it('cliente no hub de relatório /obra/:id/relatorio: "Obra" continua ativo', () => {
+    // /obra/:id/relatorio renderiza a mesma página Index do hub da obra, então
+    // a aba "Obra" deve permanecer ativa (alias do hub), e nenhuma outra aba.
+    render(
+      <MemoryRouter initialEntries={["/obra/proj-1/relatorio"]}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+
+    const obra = screen.getByRole("link", { name: /^Obra$/i });
+    const financeiro = screen.getByRole("link", { name: /^Financeiro$/i });
+
+    expect(obra).toHaveAttribute("aria-current", "page");
+    expect(financeiro).not.toHaveAttribute("aria-current");
+  });
 });

--- a/src/components/mobile/__tests__/MobileBottomNav.activeState.test.tsx
+++ b/src/components/mobile/__tests__/MobileBottomNav.activeState.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { MobileBottomNav } from "../MobileBottomNav";
+
+const navState = {
+  projectId: "proj-1" as string | undefined,
+  isStaff: false,
+};
+
+vi.mock("@/hooks/useProjectNavigation", () => ({
+  useProjectNavigation: () => ({
+    projectId: navState.projectId,
+    // Paths aren't consulted by the obra/financeiro/pendências slots (they
+    // derive the URL from projectId directly), so an empty object is enough.
+    paths: {},
+  }),
+}));
+
+vi.mock("@/hooks/usePendencias", () => ({
+  usePendencias: () => ({ stats: { overdueCount: 0, urgentCount: 0 } }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({ unreadCount: 0 }),
+}));
+
+vi.mock("@/hooks/useUserRole", () => ({
+  useUserRole: () => ({ isStaff: navState.isStaff }),
+}));
+
+vi.mock("../MobileProfileSheet", () => ({
+  MobileProfileSheet: () => null,
+}));
+
+/**
+ * Regression: the obra hub tab (`/obra/:id`) is a prefix of every project
+ * sub-route, so without NavLink `end` it stayed active alongside the real tab,
+ * lighting up two tabs at once. The hub slots now declare `end: true`.
+ */
+describe("MobileBottomNav — active state on sub-routes", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    navState.projectId = "proj-1";
+    navState.isStaff = false;
+  });
+
+  it('cliente em /financeiro: só "Financeiro" fica ativo, não "Obra"', () => {
+    render(
+      <MemoryRouter initialEntries={["/obra/proj-1/financeiro"]}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+
+    const obra = screen.getByRole("link", { name: /^Obra$/i });
+    const financeiro = screen.getByRole("link", { name: /^Financeiro$/i });
+
+    expect(financeiro).toHaveAttribute("aria-current", "page");
+    expect(obra).not.toHaveAttribute("aria-current");
+  });
+
+  it('staff em /pendencias: só "Pendências" fica ativo, não "Obras"', () => {
+    navState.isStaff = true;
+
+    render(
+      <MemoryRouter initialEntries={["/obra/proj-1/pendencias"]}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+
+    const obras = screen.getByRole("link", { name: /^Obras$/i });
+    const pendencias = screen.getByRole("link", { name: /Pendências/i });
+
+    expect(pendencias).toHaveAttribute("aria-current", "page");
+    expect(obras).not.toHaveAttribute("aria-current");
+  });
+
+  it('cliente no hub /obra/:id: "Obra" fica ativo', () => {
+    render(
+      <MemoryRouter initialEntries={["/obra/proj-1"]}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+
+    const obra = screen.getByRole("link", { name: /^Obra$/i });
+    expect(obra).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/src/config/mobileNav.ts
+++ b/src/config/mobileNav.ts
@@ -32,12 +32,19 @@ export type MobileNavSlot = {
   }) => string;
   badge?: MobileNavBadge;
   /**
-   * Exact-match the active state (NavLink `end`). Required for slots whose
-   * destination is a prefix of other slots' routes — e.g. the obra hub
-   * (`/obra/:id`) is a prefix of `/obra/:id/financeiro`, so without `end`
-   * the hub tab stays highlighted alongside the real tab on every sub-route.
+   * Exact-match the active state. Required for slots whose destination is a
+   * prefix of other slots' routes — e.g. the obra hub (`/obra/:id`) is a
+   * prefix of `/obra/:id/financeiro`, so a plain prefix match would keep the
+   * hub tab highlighted alongside the real tab on every sub-route.
    */
   end?: boolean;
+  /**
+   * Also treat the report-hub route (`/obra/:id/relatorio`) as active. That
+   * route renders the same `Index` hub page as `/obra/:id` (see App.tsx), so
+   * the Obra tab must stay lit there even though `end` otherwise demands an
+   * exact match. Only meaningful together with `end` on the obra hub slots.
+   */
+  matchReportHub?: boolean;
 };
 
 const HOME_CLIENT = "/minhas-obras";
@@ -62,8 +69,11 @@ export const CLIENT_NAV: MobileNavSlot[] = [
       return id ? `/obra/${id}` : HOME_CLIENT;
     },
     // Project hub root — exact match so it doesn't stay active on sub-routes
-    // (financeiro, documentos…), which would double-highlight the bar.
+    // (financeiro, documentos…), which would double-highlight the bar. The
+    // report-hub alias (`/obra/:id/relatorio`) renders the same hub page, so
+    // keep the tab lit there too.
     end: true,
+    matchReportHub: true,
     badge: "none",
   },
   {
@@ -122,8 +132,11 @@ export const STAFF_NAV: MobileNavSlot[] = [
       return id ? `/obra/${id}` : STAFF_OBRAS_INDEX;
     },
     // Obra hub root — exact match so it doesn't stay active on sub-routes
-    // (pendências, etc.), which would double-highlight the bar.
+    // (pendências, etc.), which would double-highlight the bar. The report-hub
+    // alias (`/obra/:id/relatorio`) renders the same hub page, so keep the tab
+    // lit there too.
     end: true,
+    matchReportHub: true,
     badge: "none",
   },
   {

--- a/src/config/mobileNav.ts
+++ b/src/config/mobileNav.ts
@@ -31,6 +31,13 @@ export type MobileNavSlot = {
     lastProjectId?: string;
   }) => string;
   badge?: MobileNavBadge;
+  /**
+   * Exact-match the active state (NavLink `end`). Required for slots whose
+   * destination is a prefix of other slots' routes — e.g. the obra hub
+   * (`/obra/:id`) is a prefix of `/obra/:id/financeiro`, so without `end`
+   * the hub tab stays highlighted alongside the real tab on every sub-route.
+   */
+  end?: boolean;
 };
 
 const HOME_CLIENT = "/minhas-obras";
@@ -54,6 +61,9 @@ export const CLIENT_NAV: MobileNavSlot[] = [
       const id = effectiveProjectId(ctx);
       return id ? `/obra/${id}` : HOME_CLIENT;
     },
+    // Project hub root — exact match so it doesn't stay active on sub-routes
+    // (financeiro, documentos…), which would double-highlight the bar.
+    end: true,
     badge: "none",
   },
   {
@@ -97,6 +107,7 @@ export const STAFF_NAV: MobileNavSlot[] = [
     label: "Início",
     icon: Home,
     to: () => HOME_STAFF,
+    end: true,
     badge: "none",
   },
   {
@@ -110,6 +121,9 @@ export const STAFF_NAV: MobileNavSlot[] = [
       const id = effectiveProjectId(ctx);
       return id ? `/obra/${id}` : STAFF_OBRAS_INDEX;
     },
+    // Obra hub root — exact match so it doesn't stay active on sub-routes
+    // (pendências, etc.), which would double-highlight the bar.
+    end: true,
     badge: "none",
   },
   {


### PR DESCRIPTION
## Summary

Fixes a regression where the mobile bottom navigation would highlight multiple tabs simultaneously when navigating to project sub-routes (e.g., `/obra/:id/financeiro`). The obra/obras hub tabs were staying active because their routes are prefixes of all sub-routes, causing NavLink to match without the `end` prop.

## Changes

- **`src/config/mobileNav.ts`**: Added `end?: boolean` property to `MobileNavSlot` type to control exact-match behavior on NavLinks. Set `end: true` on:
  - Client nav: "Obra" hub (`/obra/:id`)
  - Staff nav: "Início" home (`/minhas-obras` equivalent) and "Obras" hub (`/obra/:id`)
  
- **`src/components/mobile/MobileBottomNav.tsx`**: Updated NavLink rendering to use `end={slot.end ?? false}` instead of hardcoded `end={slot.id === "inicio"}`, allowing per-slot configuration.

- **`src/components/mobile/__tests__/MobileBottomNav.activeState.test.tsx`** (new): Added regression test suite with three scenarios:
  - Client on `/financeiro` sub-route: only "Financeiro" tab is active
  - Staff on `/pendencias` sub-route: only "Pendências" tab is active  
  - Client on hub `/obra/:id`: only "Obra" tab is active

## Implementation Details

The fix leverages React Router's NavLink `end` prop to enforce exact-match routing. Without `end`, a NavLink to `/obra/:id` matches both `/obra/:id` and `/obra/:id/financeiro`, causing double-highlighting. By setting `end: true` on hub routes, only the exact path activates the tab, while sub-routes activate their own dedicated tabs.

https://claude.ai/code/session_016tHGaNynAonDQrmeNGDXq8