### PR TITLE
Add UUID validation to prevent route parameter capture bugs

### DIFF
--- a/src/hooks/useCsTicketActions.ts
+++ b/src/hooks/useCsTicketActions.ts
@@ -13,6 +13,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { isUuid } from "@/lib/utils";
 
 // ----- types -----
 export type CsActionStatus =
@@ -74,7 +75,10 @@ export function useCsTicketActions(ticketId: string | undefined | null) {
     queryKey: ticketId
       ? csActionKeys.byTicket(ticketId)
       : ["cs-ticket-actions", "idle"],
-    enabled: !!ticketId,
+    // Só consulta com um UUID válido: impede queries ao Supabase quando o
+    // parâmetro de rota `:ticketId` captura um segmento estático (ex.:
+    // `operacional`, `analytics`), evitando erros silenciosos de query.
+    enabled: isUuid(ticketId),
     queryFn: async (): Promise<CsTicketAction[]> => {
       const { data, error } = await supabase
         .from("cs_ticket_actions")

--- a/src/hooks/useCsTicketHistory.ts
+++ b/src/hooks/useCsTicketHistory.ts
@@ -9,6 +9,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { isUuid } from "@/lib/utils";
 
 export type CsTicketHistoryEventType =
   | "created"
@@ -40,7 +41,10 @@ export const csTicketHistoryKeys = {
 export function useCsTicketHistory(ticketId: string | undefined) {
   return useQuery({
     queryKey: csTicketHistoryKeys.list(ticketId ?? ""),
-    enabled: !!ticketId,
+    // Só consulta com um UUID válido: impede queries ao Supabase quando o
+    // parâmetro de rota `:ticketId` captura um segmento estático (ex.:
+    // `operacional`, `analytics`), evitando erros silenciosos de query.
+    enabled: isUuid(ticketId),
     queryFn: async (): Promise<CsTicketHistoryEntry[]> => {
       // NOTA: cs_ticket_history.actor_id referencia auth.users, não
       // public.users_profile — não é possível usar embed PostgREST.

--- a/src/lib/__tests__/isUuid.test.ts
+++ b/src/lib/__tests__/isUuid.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isUuid } from "@/lib/utils";
+
+describe("isUuid", () => {
+  it("aceita UUIDs válidos (qualquer caixa)", () => {
+    expect(isUuid("123e4567-e89b-12d3-a456-426614174000")).toBe(true);
+    expect(isUuid("123E4567-E89B-12D3-A456-426614174000")).toBe(true);
+    expect(isUuid("00000000-0000-0000-0000-000000000000")).toBe(true);
+  });
+
+  it("rejeita segmentos estáticos de rota capturados por :ticketId", () => {
+    // Cenário do bug: /gestao/cs/:ticketId capturando rotas estáticas.
+    expect(isUuid("operacional")).toBe(false);
+    expect(isUuid("analytics")).toBe(false);
+  });
+
+  it("rejeita strings malformadas e valores não-string", () => {
+    expect(isUuid("")).toBe(false);
+    expect(isUuid("123e4567-e89b-12d3-a456")).toBe(false); // curto demais
+    expect(isUuid("123e4567e89b12d3a456426614174000")).toBe(false); // sem hífens
+    expect(isUuid("123e4567-e89b-12d3-a456-426614174000 ")).toBe(false); // espaço extra
+    expect(isUuid(null)).toBe(false);
+    expect(isUuid(undefined)).toBe(false);
+    expect(isUuid(123)).toBe(false);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,22 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Regex de UUID v1–v5 (case-insensitive). */
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Verifica se o valor é um UUID válido.
+ *
+ * Útil como guarda antes de consultas ao Supabase por `id`: evita disparar
+ * queries com identificadores inválidos quando um parâmetro de rota dinâmica
+ * (`:ticketId`) captura, por engano, um segmento estático como
+ * `operacional` ou `analytics`.
+ */
+export function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_REGEX.test(value);
+}
+
 /**
  * Safely parse JSON with a fallback value.
  * Prevents crashes from corrupted localStorage, Supabase JSONB, or SSE data.


### PR DESCRIPTION
## Summary

Adds a `isUuid()` utility function to validate UUID format and uses it as a guard in TanStack Query hooks to prevent invalid queries when dynamic route parameters (`:ticketId`) accidentally capture static route segments.

## Changes

- **New utility**: `isUuid(value: unknown): value is string` in `src/lib/utils.ts`
  - Validates UUIDs v1–v5 (case-insensitive) via regex
  - Type guard that returns `false` for non-strings, malformed UUIDs, and edge cases (whitespace, missing hyphens, etc.)
  - Includes JSDoc explaining the use case: preventing Supabase queries with invalid identifiers

- **Updated query hooks**:
  - `useCsTicketActions`: changed `enabled: !!ticketId` → `enabled: isUuid(ticketId)`
  - `useCsTicketHistory`: changed `enabled: !!ticketId` → `enabled: isUuid(ticketId)`
  - Both now skip queries when the route parameter captures static segments like `operacional` or `analytics`

- **Test coverage**: `src/lib/__tests__/isUuid.test.ts`
  - Valid UUIDs (mixed case, all zeros)
  - Rejection of static route segments (the bug scenario)
  - Rejection of malformed strings and non-string values

## Implementation Details

The regex `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i` matches the standard UUID format across all versions. The type guard ensures callers can safely treat the value as a string after validation passes, improving type safety in downstream code.

https://claude.ai/code/session_01Q5fGMwLvjAtMEZkKxZrapG